### PR TITLE
fix: avoid sharing MfmKeyboard among multiple TextEditControllers

### DIFF
--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -901,13 +901,24 @@ class PostPage extends HookConsumerWidget {
               ),
             ),
             Visibility(
-              visible: isCwFocused.value || isFocused.value,
+              visible: isCwFocused.value,
               maintainState: true,
               child: TextFieldTapRegion(
                 onTapOutside: (_) => primaryFocus?.unfocus(),
                 child: MfmKeyboard(
                   account: account.value,
-                  controller: isCwFocused.value ? cwController : controller,
+                  controller: cwController,
+                ),
+              ),
+            ),
+            Visibility(
+              visible: isFocused.value,
+              maintainState: true,
+              child: TextFieldTapRegion(
+                onTapOutside: (_) => primaryFocus?.unfocus(),
+                child: MfmKeyboard(
+                  account: account.value,
+                  controller: controller,
                 ),
               ),
             ),


### PR DESCRIPTION
Switching TextEditControllers of a MfmKeyboard leads to RangeError.
When building buttons, TagType from previous controller is keep preserved, so it tries to substring text to get query and accesses invalid range.

Fix this by simply using two MfmKeyboards, one for cw and the other for main text.