### PR TITLE
feat: show user avatars on confirm

### DIFF
--- a/lib/view/dialog/reaction_confirmation_dialog.dart
+++ b/lib/view/dialog/reaction_confirmation_dialog.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+import '../../i18n/strings.g.dart';
+import '../../model/account.dart';
+import '../../provider/api/i_notifier_provider.dart';
+import '../widget/emoji_widget.dart';
+import '../widget/user_avatar.dart';
+
+Future<bool> confirmReaction(
+  BuildContext context, {
+  required Account account,
+  required String emoji,
+  required Note note,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => ReactionConfirmationDialog(
+      account: account,
+      emoji: emoji,
+      note: note,
+    ),
+  );
+  return result ?? false;
+}
+
+class ReactionConfirmationDialog extends ConsumerWidget {
+  const ReactionConfirmationDialog({
+    super.key,
+    required this.account,
+    required this.emoji,
+    required this.note,
+  });
+
+  final Account account;
+  final String emoji;
+  final Note note;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+
+    return AlertDialog(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (i != null)
+            UserAvatar(
+              user: i,
+              size: 48.0,
+              onTap: () => context.push('/$account/users/${i.id}'),
+            ),
+          const Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Icon(Icons.arrow_forward, size: 36.0),
+          ),
+          UserAvatar(
+            user: note.user,
+            size: 48.0,
+            onTap: () => context.push('/$account/users/${note.userId}'),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          EmojiWidget(
+            account: account,
+            emoji: emoji,
+            style:
+                DefaultTextStyle.of(context).style.apply(fontSizeFactor: 2.0),
+          ),
+          Text(t.aria.reactionConfirm),
+        ],
+      ),
+      actions: [
+        ElevatedButton(
+          onPressed: () => context.pop(true),
+          child: Text(t.misskey.ok),
+        ),
+        OutlinedButton(
+          onPressed: () => context.pop(false),
+          child: Text(t.misskey.cancel),
+        ),
+      ],
+      scrollable: true,
+    );
+  }
+}

--- a/lib/view/widget/emoji_sheet.dart
+++ b/lib/view/widget/emoji_sheet.dart
@@ -14,6 +14,7 @@ import '../../util/copy_text.dart';
 import '../../util/decode_custom_emoji.dart';
 import '../../util/future_with_dialog.dart';
 import '../dialog/confirmation_dialog.dart';
+import '../dialog/reaction_confirmation_dialog.dart';
 import 'custom_emoji.dart';
 import 'emoji_widget.dart';
 
@@ -80,21 +81,11 @@ class EmojiSheet extends ConsumerWidget {
                         .read(generalSettingsNotifierProvider)
                         .confirmBeforeReact ||
                     (isCustomEmoji && host != null)) {
-                  final confirmed = await confirm(
+                  final confirmed = await confirmReaction(
                     context,
-                    content: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(t.aria.reactionConfirm),
-                        EmojiWidget(
-                          account: account,
-                          emoji: ':$name@.:',
-                          style: DefaultTextStyle.of(context)
-                              .style
-                              .apply(fontSizeFactor: 2.0),
-                        ),
-                      ],
-                    ),
+                    account: account,
+                    emoji: ':$name@.:',
+                    note: targetNote!,
                   );
                   if (!confirmed) return;
                 }

--- a/lib/view/widget/follow_button.dart
+++ b/lib/view/widget/follow_button.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
+import '../../provider/api/i_notifier_provider.dart';
 import '../../provider/api/user_notifier_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../util/future_with_dialog.dart';
 import '../dialog/confirmation_dialog.dart';
+import 'user_avatar.dart';
 import 'username_widget.dart';
 
 class FollowButton extends HookConsumerWidget {
@@ -71,6 +74,8 @@ class FollowButton extends HookConsumerWidget {
         child: Text(t.misskey.unfollow),
       );
     } else {
+      final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+
       return ElevatedButton(
         style: ElevatedButton.styleFrom(
           foregroundColor: Theme.of(context).colorScheme.primary,
@@ -80,6 +85,26 @@ class FollowButton extends HookConsumerWidget {
           if (ref.read(generalSettingsNotifierProvider).confirmBeforeFollow) {
             final confirmed = await confirm(
               context,
+              title: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  if (i != null)
+                    UserAvatar(
+                      user: i,
+                      size: 48.0,
+                      onTap: () => context.push('/$account/users/${i.id}'),
+                    ),
+                  const Padding(
+                    padding: EdgeInsets.all(8.0),
+                    child: Icon(Icons.arrow_forward, size: 36.0),
+                  ),
+                  UserAvatar(
+                    user: user,
+                    size: 48.0,
+                    onTap: () => context.push('/$account/users/$userId'),
+                  ),
+                ],
+              ),
               content: Text.rich(
                 t.aria.followConfirm(
                   name: TextSpan(
@@ -91,6 +116,8 @@ class FollowButton extends HookConsumerWidget {
                   ),
                 ),
               ),
+              okText:
+                  user.isLocked ? t.misskey.followRequest : t.misskey.follow,
             );
             if (!confirmed) return;
           }

--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -19,8 +19,8 @@ import '../../provider/notes_notifier_provider.dart';
 import '../../util/future_with_dialog.dart';
 import '../dialog/clip_dialog.dart';
 import '../dialog/confirmation_dialog.dart';
+import '../dialog/reaction_confirmation_dialog.dart';
 import 'emoji_picker.dart';
-import 'emoji_widget.dart';
 import 'note_sheet.dart';
 import 'reaction_users_sheet.dart';
 import 'renote_users_sheet.dart';
@@ -209,21 +209,11 @@ class NoteFooter extends ConsumerWidget {
                           if (ref
                               .read(generalSettingsNotifierProvider)
                               .confirmBeforeReact) {
-                            final confirmed = await confirm(
+                            final confirmed = await confirmReaction(
                               context,
-                              content: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Text(t.aria.reactionConfirm),
-                                  EmojiWidget(
-                                    account: account,
-                                    emoji: emoji,
-                                    style: DefaultTextStyle.of(context)
-                                        .style
-                                        .apply(fontSizeFactor: 2.0),
-                                  ),
-                                ],
-                              ),
+                              account: account,
+                              emoji: emoji,
+                              note: appearNote,
                             );
                             if (!confirmed) return;
                           }

--- a/lib/view/widget/reaction_button.dart
+++ b/lib/view/widget/reaction_button.dart
@@ -14,6 +14,7 @@ import '../../util/check_reaction_permissions.dart';
 import '../../util/decode_custom_emoji.dart';
 import '../../util/future_with_dialog.dart';
 import '../dialog/confirmation_dialog.dart';
+import '../dialog/reaction_confirmation_dialog.dart';
 import 'emoji_widget.dart';
 import 'reaction_users_sheet.dart';
 
@@ -69,21 +70,11 @@ class ReactionButton extends ConsumerWidget {
                         .read(generalSettingsNotifierProvider)
                         .confirmBeforeReact ||
                     (isCustomEmoji && host != null)) {
-                  final confirmed = await confirm(
+                  final confirmed = await confirmReaction(
                     context,
-                    content: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(t.aria.reactionConfirm),
-                        EmojiWidget(
-                          account: account,
-                          emoji: emoji,
-                          style: DefaultTextStyle.of(context)
-                              .style
-                              .apply(fontSizeFactor: 2.0),
-                        ),
-                      ],
-                    ),
+                    account: account,
+                    emoji: emoji,
+                    note: note!,
                   );
                   if (!confirmed) return;
                 }


### PR DESCRIPTION
Show avatars of users as on top of the confirmation dialog to clearify from which account the user is acting.

| Follow | React |
| ---- | ---- |
| ![](https://github.com/poppingmoon/aria/assets/63451158/70575f3b-1ad1-4912-b9bb-1c77d721d5e8) | ![](https://github.com/poppingmoon/aria/assets/63451158/59f7f4d6-d0f7-4b63-aaeb-2bcaf65207d0) |


