### PR TITLE
feat: make it possible to filter files by type

### DIFF
--- a/lib/view/page/image_page.dart
+++ b/lib/view/page/image_page.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -409,7 +410,10 @@ class ImagePage extends HookConsumerWidget {
               case _Modes.image:
                 final file = await showModalBottomSheet<PostFile>(
                   context: context,
-                  builder: (context) => FilePickerSheet(account: account),
+                  builder: (context) => FilePickerSheet(
+                    account: account,
+                    type: FileType.image,
+                  ),
                   clipBehavior: Clip.hardEdge,
                 );
                 if (file == null) return;

--- a/lib/view/page/settings/profile_page.dart
+++ b/lib/view/page/settings/profile_page.dart
@@ -1,3 +1,4 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -45,7 +46,10 @@ class ProfilePage extends HookConsumerWidget {
   }) async {
     final result = await showModalBottomSheet<PostFile>(
       context: ref.context,
-      builder: (context) => FilePickerSheet(account: account),
+      builder: (context) => FilePickerSheet(
+        account: account,
+        type: FileType.image,
+      ),
       clipBehavior: Clip.hardEdge,
     );
     if (result == null) return null;

--- a/lib/view/widget/drive_create_sheet.dart
+++ b/lib/view/widget/drive_create_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -28,6 +29,9 @@ class DriveCreateSheet extends HookConsumerWidget {
 
   Future<void> _upload(WidgetRef ref, bool keepOriginal) async {
     final result = await FilePicker.platform.pickFiles(
+      type: defaultTargetPlatform == TargetPlatform.iOS
+          ? FileType.media
+          : FileType.any,
       allowMultiple: true,
     );
     if (result == null || result.files.isEmpty) return;

--- a/lib/view/widget/file_picker_sheet.dart
+++ b/lib/view/widget/file_picker_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -14,10 +15,12 @@ class FilePickerSheet extends ConsumerWidget {
   const FilePickerSheet({
     super.key,
     required this.account,
+    this.type,
     this.allowMultiple = false,
   });
 
   final Account account;
+  final FileType? type;
   final bool allowMultiple;
 
   @override
@@ -29,8 +32,12 @@ class FilePickerSheet extends ConsumerWidget {
           leading: const Icon(Icons.upload),
           title: Text(t.aria.fromDevice),
           onTap: () async {
-            final result = await FilePicker.platform
-                .pickFiles(allowMultiple: allowMultiple);
+            final result = await FilePicker.platform.pickFiles(
+              type: defaultTargetPlatform == TargetPlatform.iOS && type == null
+                  ? FileType.media
+                  : type ?? FileType.any,
+              allowMultiple: allowMultiple,
+            );
             if (!context.mounted) return;
             if (result case FilePickerResult(:final files)) {
               if (allowMultiple) {
@@ -63,6 +70,7 @@ class FilePickerSheet extends ConsumerWidget {
                 builder: (context) => DrivePage(
                   account: account,
                   selectFiles: true,
+                  type: type ?? FileType.any,
                 ),
               );
               if (!context.mounted) return;
@@ -79,6 +87,7 @@ class FilePickerSheet extends ConsumerWidget {
                 builder: (context) => DrivePage(
                   account: account,
                   selectFile: true,
+                  type: type ?? FileType.any,
                 ),
               );
               if (!context.mounted) return;


### PR DESCRIPTION
Add `type` property to `FilePickerSheet`, which controlls pickable file type.

For iOS, pass `FileType.media` to `FilePicker.platform.pickFiles()` by default.
This is because if `type` is `FileType.any`, iOS opens "Files" app, which is inconvenient for basic usage.
With `FileType.media`, it opens "Photos" app, where users can find their images and videos.

Close #54