### PR TITLE
fix: allow selecting self for tab and antenna user

### DIFF
--- a/lib/view/dialog/antenna_settings_dialog.dart
+++ b/lib/view/dialog/antenna_settings_dialog.dart
@@ -133,6 +133,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
                       final result = await selectUser(
                         context,
                         account,
+                        includeSelf: true,
                         localOnly: settings.value.localOnly ?? false,
                       );
                       if (result != null) {

--- a/lib/view/page/settings/tab_settings_page.dart
+++ b/lib/view/page/settings/tab_settings_page.dart
@@ -361,7 +361,11 @@ class TabSettingsPage extends HookConsumerWidget {
                           );
                         }
                       case TabType.user:
-                        final result = await selectUser(context, account);
+                        final result = await selectUser(
+                          context,
+                          account,
+                          includeSelf: true,
+                        );
                         if (result != null) {
                           tabSettings.value = tabSettings.value.copyWith(
                             userId: result.id,


### PR DESCRIPTION
For tab and antenna, users can select a target user to track notes. Change these to also allow the user themselves to be a target user.