### PR TITLE
perf: lazily initialize `AudioService`

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:audio_service/audio_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,7 +10,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'constant/shortcuts.dart';
 import 'gen/assets.gen.dart';
 import 'i18n/strings.g.dart';
-import 'provider/audio_handler_provider.dart';
 import 'provider/general_settings_notifier_provider.dart';
 import 'provider/shared_preferences_provider.dart';
 import 'provider/theme_data_provider.dart';
@@ -70,27 +68,9 @@ void main() async {
     );
   });
   final prefs = await SharedPreferences.getInstance();
-  final audioHandler = switch (defaultTargetPlatform) {
-    TargetPlatform.android ||
-    TargetPlatform.iOS ||
-    TargetPlatform.macOS =>
-      await AudioService.init(
-        builder: () => AudioPlayerHandler(),
-        config: const AudioServiceConfig(
-          androidNotificationChannelId: 'com.poppingmoon.aria.channel.audio',
-          androidNotificationChannelName: 'Audio playback',
-          androidNotificationOngoing: true,
-        ),
-      ),
-    _ => null,
-  };
   runApp(
     ProviderScope(
-      overrides: [
-        sharedPreferencesProvider.overrideWithValue(prefs),
-        if (audioHandler != null)
-          audioHandlerProvider.overrideWithValue(audioHandler),
-      ],
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
       child: TranslationProvider(child: const Aria()),
     ),
   );

--- a/lib/provider/audio_handler_provider.g.dart
+++ b/lib/provider/audio_handler_provider.g.dart
@@ -6,11 +6,11 @@ part of 'audio_handler_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$audioHandlerHash() => r'5328f87d476b522218a646bb16a298358278c695';
+String _$audioHandlerHash() => r'094da1b238c0ae0b0342e3c0454e165ed1fdec73';
 
 /// See also [audioHandler].
 @ProviderFor(audioHandler)
-final audioHandlerProvider = Provider<AudioHandler>.internal(
+final audioHandlerProvider = FutureProvider<AudioHandler>.internal(
   audioHandler,
   name: r'audioHandlerProvider',
   debugGetCreateSourceHash:
@@ -19,8 +19,8 @@ final audioHandlerProvider = Provider<AudioHandler>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef AudioHandlerRef = ProviderRef<AudioHandler>;
-String _$mediaItemHash() => r'0088fc81e2aed5bbac8caa728a852cf8b45c0c13';
+typedef AudioHandlerRef = FutureProviderRef<AudioHandler>;
+String _$mediaItemHash() => r'1c17a5fbde67766fb9727bf628c013b1caf189a4';
 
 /// See also [mediaItem].
 @ProviderFor(mediaItem)
@@ -34,7 +34,7 @@ final mediaItemProvider = AutoDisposeStreamProvider<MediaItem?>.internal(
 );
 
 typedef MediaItemRef = AutoDisposeStreamProviderRef<MediaItem?>;
-String _$playbackStateHash() => r'ad9879cad39de56a754ed692e090ed1d29edcc1f';
+String _$playbackStateHash() => r'd5f6138c11c77919fb8a44d6d1e9d9825c4ccf43';
 
 /// See also [playbackState].
 @ProviderFor(playbackState)
@@ -49,7 +49,7 @@ final playbackStateProvider = AutoDisposeStreamProvider<PlaybackState>.internal(
 );
 
 typedef PlaybackStateRef = AutoDisposeStreamProviderRef<PlaybackState>;
-String _$positionHash() => r'f4e864f2fafa455ca0c7c67c45360189af139902';
+String _$positionHash() => r'0825ac909ee5c910d2dc9784b640b3fd67e56ec3';
 
 /// See also [position].
 @ProviderFor(position)

--- a/lib/view/dialog/audio_dialog.dart
+++ b/lib/view/dialog/audio_dialog.dart
@@ -32,6 +32,7 @@ class AudioDialog extends HookConsumerWidget {
     useEffect(
       () {
         Future(() async {
+          final audioHandler = await ref.read(audioHandlerProvider.future);
           await audioHandler.updateMediaItem(
             MediaItem(
               id: file.url,
@@ -42,7 +43,7 @@ class AudioDialog extends HookConsumerWidget {
           );
           await audioHandler.play();
         });
-        return audioHandler.stop;
+        return audioHandler.valueOrNull?.stop;
       },
       [],
     );
@@ -73,21 +74,21 @@ class AudioDialog extends HookConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 IconButton(
-                  onPressed: audioHandler.rewind,
+                  onPressed: audioHandler.valueOrNull?.rewind,
                   icon: const Icon(Icons.fast_rewind),
                 ),
                 if (playbackState.valueOrNull?.playing ?? false)
                   IconButton(
-                    onPressed: audioHandler.pause,
+                    onPressed: audioHandler.valueOrNull?.pause,
                     icon: const Icon(Icons.pause),
                   )
                 else
                   IconButton(
-                    onPressed: audioHandler.play,
+                    onPressed: audioHandler.valueOrNull?.play,
                     icon: const Icon(Icons.play_arrow),
                   ),
                 IconButton(
-                  onPressed: audioHandler.fastForward,
+                  onPressed: audioHandler.valueOrNull?.fastForward,
                   icon: const Icon(Icons.fast_forward),
                 ),
               ],
@@ -95,7 +96,7 @@ class AudioDialog extends HookConsumerWidget {
             ProgressBar(
               progress: position.valueOrNull ?? Duration.zero,
               total: mediaItem.valueOrNull?.duration ?? Duration.zero,
-              onSeek: audioHandler.seek,
+              onSeek: audioHandler.valueOrNull?.seek,
             ),
           ],
         ),


### PR DESCRIPTION
Initialize `AudioService` when `AudioDialog` is first loaded. This change shortens app's initialization duration.