### PR TITLE
fix: add space to the bottom of `TabsPage`

### DIFF
--- a/lib/view/page/settings/tabs_page.dart
+++ b/lib/view/page/settings/tabs_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -21,25 +23,34 @@ class TabsPage extends HookConsumerWidget {
           ? Center(child: Text(t.aria.noTabs))
           : ReorderableListView.builder(
               itemBuilder: (context, index) {
-                final tabSettings = tabs[index];
-                return ReorderableDragStartListenerWrapper(
-                  key: ValueKey(index),
-                  index: index,
-                  child: ListTile(
-                    leading: TabIconWidget(tabSettings: tabSettings),
-                    title: tabSettings.name != null
-                        ? Text(tabSettings.name ?? '')
-                        : TabTypeWidget(tabType: tabSettings.tabType),
-                    subtitle: Text(tabSettings.account.toString()),
-                    trailing: const Icon(Icons.drag_handle),
-                    onTap: () => context.push('/settings/tab/$index'),
-                  ),
-                );
+                if (index < tabs.length) {
+                  final tabSettings = tabs[index];
+                  return ReorderableDragStartListenerWrapper(
+                    key: ValueKey(index),
+                    index: index,
+                    child: ListTile(
+                      leading: TabIconWidget(tabSettings: tabSettings),
+                      title: tabSettings.name != null
+                          ? Text(tabSettings.name ?? '')
+                          : TabTypeWidget(tabType: tabSettings.tabType),
+                      subtitle: Text(tabSettings.account.toString()),
+                      trailing: const Icon(Icons.drag_handle),
+                      onTap: () => context.push('/settings/tab/$index'),
+                    ),
+                  );
+                } else {
+                  return ReorderableDragStartListener(
+                    key: ValueKey(index),
+                    index: index,
+                    enabled: false,
+                    child: const SizedBox(height: 80.0),
+                  );
+                }
               },
-              itemCount: tabs.length,
+              itemCount: tabs.length + 1,
               onReorder: (oldIndex, newIndex) => ref
                   .read(timelineTabsNotifierProvider.notifier)
-                  .reorder(oldIndex, newIndex),
+                  .reorder(oldIndex, min(newIndex, tabs.length)),
               buildDefaultDragHandles: false,
             ),
       floatingActionButton: FloatingActionButton.extended(


### PR DESCRIPTION
Add space to the end of tab list to avoid the last item from being
overlapped by the floating action button.

Fix #56