### PR TITLE
fix: use `untilId` for announcements pagination

### DIFF
--- a/lib/provider/api/announcements_notifier_provider.dart
+++ b/lib/provider/api/announcements_notifier_provider.dart
@@ -21,10 +21,15 @@ class AnnouncementsNotifier extends _$AnnouncementsNotifier {
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
   Future<Iterable<AnnouncementsResponse>> _fetchAnnouncements({
+    String? untilId,
     int? offset,
   }) async {
     return _misskey.announcements(
-      AnnouncementsRequest(isActive: isActive, offset: offset),
+      AnnouncementsRequest(
+        isActive: isActive,
+        untilId: untilId,
+        offset: offset,
+      ),
     );
   }
 
@@ -38,7 +43,10 @@ class AnnouncementsNotifier extends _$AnnouncementsNotifier {
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchAnnouncements(offset: value.items.length);
+      final response = await _fetchAnnouncements(
+        untilId: value.items.lastOrNull?.id,
+        offset: value.items.length,
+      );
       return PaginationState(
         items: [...value.items, ...response],
         isLastLoaded: response.isEmpty,

--- a/lib/provider/api/announcements_notifier_provider.g.dart
+++ b/lib/provider/api/announcements_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'announcements_notifier_provider.dart';
 // **************************************************************************
 
 String _$announcementsNotifierHash() =>
-    r'13329f4479df4fd0e900299ebe848a45cb807193';
+    r'07ddee100aecf18ab7fd234400bf8cd5601d836b';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
In Misskey, `announcements` has a parameter `untilId`, but io fork doesn't have `untilId` and instead has `offset`.
To make pagination work for both software, use both parameters.

https://github.com/misskey-dev/misskey/blob/6bd78770de06bd3694127da17ccd051f05057329/packages/backend/src/server/api/endpoints/announcements.ts#L35
https://github.com/MisskeyIO/misskey/blob/432833747d09f393b9c7451a73659600b081aab6/packages/backend/src/server/api/endpoints/announcements.ts#L30