### PR TITLE
feat: add border to remote reaction if the emoji exists locally

### DIFF
--- a/lib/view/widget/reaction_button.dart
+++ b/lib/view/widget/reaction_button.dart
@@ -73,7 +73,7 @@ class ReactionButton extends ConsumerWidget {
                   final confirmed = await confirmReaction(
                     context,
                     account: account,
-                    emoji: emoji,
+                    emoji: isCustomEmoji ? ':$name:' : emoji,
                     note: note,
                   );
                   if (!confirmed) return;
@@ -142,8 +142,11 @@ class ReactionButton extends ConsumerWidget {
         minimumSize: Size.zero,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         shape: RoundedRectangleBorder(
-          side:
-              isMyReaction ? BorderSide(color: colors.accent) : BorderSide.none,
+          side: isMyReaction
+              ? BorderSide(color: colors.accent)
+              : canReact && host != null
+                  ? BorderSide(color: colors.divider)
+                  : BorderSide.none,
           borderRadius: BorderRadius.circular(4.0 * scale),
         ),
         foregroundColor: isMyReaction ? colors.accent : colors.fg,


### PR DESCRIPTION
Add border to `ReactionButton` if reactioned emoji is custom emoji, emoji with the same name exists locally and the user can react the local emoji.

![](https://github.com/poppingmoon/aria/assets/63451158/9988204d-b3ad-43f8-b77e-ad437fb28569)

ref: https://github.com/hideki0403/kakurega.app/commit/11d1e6354e5c56a77cbc5c86ff80397e1e2fcc8e
