### PR TITLE
fix: use local emoji with the same name for reaction fallback

### DIFF
--- a/lib/view/widget/emoji_sheet.dart
+++ b/lib/view/widget/emoji_sheet.dart
@@ -86,6 +86,7 @@ class EmojiSheet extends ConsumerWidget {
             title: Text(t.misskey.doReaction),
             onTap: () async {
               if (targetNote?.myReaction == null) {
+                final localEmoji = isCustomEmoji ? ':$name@.:' : emoji;
                 if (ref
                         .read(generalSettingsNotifierProvider)
                         .confirmBeforeReact ||
@@ -93,7 +94,7 @@ class EmojiSheet extends ConsumerWidget {
                   final confirmed = await confirmReaction(
                     context,
                     account: account,
-                    emoji: ':$name@.:',
+                    emoji: localEmoji,
                     note: targetNote!,
                   );
                   if (!confirmed) return;
@@ -103,9 +104,10 @@ class EmojiSheet extends ConsumerWidget {
                   context,
                   ref
                       .read(notesNotifierProvider(account).notifier)
-                      .react(targetNote!.id, emoji),
+                      .react(targetNote!.id, localEmoji),
                 );
               } else {
+                final localEmoji = isCustomEmoji ? ':$name@.:' : emoji;
                 final confirmed = await confirm(
                   context,
                   content: Column(
@@ -114,7 +116,7 @@ class EmojiSheet extends ConsumerWidget {
                       Text(t.misskey.changeReactionConfirm),
                       EmojiWidget(
                         account: account,
-                        emoji: ':$name@.:',
+                        emoji: localEmoji,
                         style: DefaultTextStyle.of(context)
                             .style
                             .apply(fontSizeFactor: 2.0),
@@ -126,13 +128,13 @@ class EmojiSheet extends ConsumerWidget {
                 if (!context.mounted) return;
                 await ref
                     .read(notesNotifierProvider(account).notifier)
-                    .changeReaction(targetNote!.id, emoji);
+                    .changeReaction(targetNote!.id, localEmoji);
               }
               if (!context.mounted) return;
               context.pop();
             },
           ),
-        if (!account.isGuest) ...[
+        if (!account.isGuest && host == null) ...[
           if (!isPinnedForReaction)
             ListTile(
               leading: const Icon(Icons.push_pin),

--- a/lib/view/widget/reaction_button.dart
+++ b/lib/view/widget/reaction_button.dart
@@ -66,6 +66,7 @@ class ReactionButton extends ConsumerWidget {
           ? () async {
               if (note.id.isEmpty) return;
               if (note.myReaction == null) {
+                final localEmoji = isCustomEmoji ? ':$name@.:' : emoji;
                 if (ref
                         .read(generalSettingsNotifierProvider)
                         .confirmBeforeReact ||
@@ -73,7 +74,7 @@ class ReactionButton extends ConsumerWidget {
                   final confirmed = await confirmReaction(
                     context,
                     account: account,
-                    emoji: isCustomEmoji ? ':$name:' : emoji,
+                    emoji: localEmoji,
                     note: note,
                   );
                   if (!confirmed) return;
@@ -83,7 +84,7 @@ class ReactionButton extends ConsumerWidget {
                   context,
                   ref
                       .read(notesNotifierProvider(account).notifier)
-                      .react(note.id, emoji),
+                      .react(note.id, localEmoji),
                 );
               } else if (isMyReaction) {
                 final confirmed = await confirm(
@@ -99,6 +100,7 @@ class ReactionButton extends ConsumerWidget {
                       .unreact(note.id),
                 );
               } else {
+                final localEmoji = isCustomEmoji ? ':$name@.:' : emoji;
                 final confirmed = await confirm(
                   context,
                   content: Column(
@@ -107,7 +109,7 @@ class ReactionButton extends ConsumerWidget {
                       Text(t.misskey.changeReactionConfirm),
                       EmojiWidget(
                         account: account,
-                        emoji: emoji,
+                        emoji: localEmoji,
                         style: DefaultTextStyle.of(context)
                             .style
                             .apply(fontSizeFactor: 2.0),
@@ -121,7 +123,7 @@ class ReactionButton extends ConsumerWidget {
                   context,
                   ref
                       .read(notesNotifierProvider(account).notifier)
-                      .changeReaction(note.id, emoji),
+                      .changeReaction(note.id, localEmoji),
                 );
               }
             }


### PR DESCRIPTION
When reacting from remote emoji, extract name from emoji and use local emoji with the same name instead of remote emoji itself.