### PR TITLE
fix: add fallback for invalid url to `UrlWidget`

### DIFF
--- a/lib/view/widget/url_preview.dart
+++ b/lib/view/widget/url_preview.dart
@@ -26,7 +26,10 @@ class UrlPreview extends HookConsumerWidget {
   final String link;
 
   String? _extractTweetId(String link) {
-    final url = Uri.parse(link);
+    final url = Uri.tryParse(link);
+    if (url == null) {
+      return null;
+    }
     if (url.host
         case 'twitter.com' ||
             'mobile.twitter.com' ||

--- a/lib/view/widget/url_widget.dart
+++ b/lib/view/widget/url_widget.dart
@@ -44,14 +44,35 @@ class UrlWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final url = Uri.parse(this.url);
+    final url = Uri.tryParse(this.url);
+    final style = DefaultTextStyle.of(context).style.merge(this.style);
+    if (url == null) {
+      return InkWell(
+        onTap: onTap,
+        onLongPress: () => showModalBottomSheet<void>(
+          context: context,
+          builder: (context) => UrlSheet(url: this.url),
+        ),
+        child: Text(
+          this.url,
+          style: style.apply(
+            fontSizeFactor: scale,
+            color: style.color?.withOpacity(opacity),
+          ),
+          textAlign: align,
+          overflow: overflow,
+          maxLines: maxLines,
+          semanticsLabel: this.url,
+        ),
+      );
+    }
+
     final scheme = url.scheme;
     final host = toUnicode(url.host);
     final port = url.port;
     final path = _decodeComponent(url.path);
     final query = _decodeQueryComponent(url.query);
     final fragment = _decodeComponent(url.fragment);
-    final style = DefaultTextStyle.of(context).style.merge(this.style);
 
     return InkWell(
       onTap: onTap,


### PR DESCRIPTION
If failed to parse url, display the input as it is.