### PR TITLE
fix: ignore trailing segment of remote renote url

### DIFF
--- a/lib/view/page/note_page.dart
+++ b/lib/view/page/note_page.dart
@@ -49,7 +49,9 @@ class NotePage extends HookConsumerWidget {
       );
     }
     final remoteUrl = note.uri ?? note.url;
-    final remoteNoteId = remoteUrl?.pathSegments.lastOrNull;
+    final remoteNoteId = remoteUrl?.pathSegments
+        .where((segment) => segment != 'activity')
+        .lastOrNull;
     final isChannelNote = note.channelId != null;
     final showUserNextNotes = useState(false);
     final showTimelineNextNotes = useState(false);


### PR DESCRIPTION
Fix `remoteNoteId` of renote.