### PR TITLE
fix: automatically dispose `incomingMessage`

### DIFF
--- a/lib/provider/streaming/incoming_message_provider.dart
+++ b/lib/provider/streaming/incoming_message_provider.dart
@@ -9,7 +9,7 @@ import 'web_socket_channel_provider.dart';
 
 part 'incoming_message_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 Stream<IncomingMessage> incomingMessage(
   IncomingMessageRef ref,
   Account account,

--- a/lib/provider/streaming/incoming_message_provider.g.dart
+++ b/lib/provider/streaming/incoming_message_provider.g.dart
@@ -6,7 +6,7 @@ part of 'incoming_message_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$incomingMessageHash() => r'9187a73139f172381927f6ce452661d7ade1cd43';
+String _$incomingMessageHash() => r'd9325542a866d93f281640eee17294aaf4c1771b';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -72,7 +72,8 @@ class IncomingMessageFamily extends Family<AsyncValue<IncomingMessage>> {
 }
 
 /// See also [incomingMessage].
-class IncomingMessageProvider extends StreamProvider<IncomingMessage> {
+class IncomingMessageProvider
+    extends AutoDisposeStreamProvider<IncomingMessage> {
   /// See also [incomingMessage].
   IncomingMessageProvider(
     Account account,
@@ -124,7 +125,7 @@ class IncomingMessageProvider extends StreamProvider<IncomingMessage> {
   }
 
   @override
-  StreamProviderElement<IncomingMessage> createElement() {
+  AutoDisposeStreamProviderElement<IncomingMessage> createElement() {
     return _IncomingMessageProviderElement(this);
   }
 
@@ -142,13 +143,14 @@ class IncomingMessageProvider extends StreamProvider<IncomingMessage> {
   }
 }
 
-mixin IncomingMessageRef on StreamProviderRef<IncomingMessage> {
+mixin IncomingMessageRef on AutoDisposeStreamProviderRef<IncomingMessage> {
   /// The parameter `account` of this provider.
   Account get account;
 }
 
 class _IncomingMessageProviderElement
-    extends StreamProviderElement<IncomingMessage> with IncomingMessageRef {
+    extends AutoDisposeStreamProviderElement<IncomingMessage>
+    with IncomingMessageRef {
   _IncomingMessageProviderElement(super.provider);
 
   @override

--- a/lib/provider/streaming/web_socket_channel_provider.dart
+++ b/lib/provider/streaming/web_socket_channel_provider.dart
@@ -8,7 +8,7 @@ import '../token_provider.dart';
 
 part 'web_socket_channel_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 WebSocketChannel webSocketChannel(
   WebSocketChannelRef ref,
   Account account,

--- a/lib/provider/streaming/web_socket_channel_provider.g.dart
+++ b/lib/provider/streaming/web_socket_channel_provider.g.dart
@@ -6,7 +6,7 @@ part of 'web_socket_channel_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$webSocketChannelHash() => r'f11dec9037e8296e318877d7f9e8ea9397f0340d';
+String _$webSocketChannelHash() => r'40506ba9cb1958506a80e9afbae5bad505e2bcae';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -72,7 +72,7 @@ class WebSocketChannelFamily extends Family<WebSocketChannel> {
 }
 
 /// See also [webSocketChannel].
-class WebSocketChannelProvider extends Provider<WebSocketChannel> {
+class WebSocketChannelProvider extends AutoDisposeProvider<WebSocketChannel> {
   /// See also [webSocketChannel].
   WebSocketChannelProvider(
     Account account,
@@ -124,7 +124,7 @@ class WebSocketChannelProvider extends Provider<WebSocketChannel> {
   }
 
   @override
-  ProviderElement<WebSocketChannel> createElement() {
+  AutoDisposeProviderElement<WebSocketChannel> createElement() {
     return _WebSocketChannelProviderElement(this);
   }
 
@@ -142,12 +142,13 @@ class WebSocketChannelProvider extends Provider<WebSocketChannel> {
   }
 }
 
-mixin WebSocketChannelRef on ProviderRef<WebSocketChannel> {
+mixin WebSocketChannelRef on AutoDisposeProviderRef<WebSocketChannel> {
   /// The parameter `account` of this provider.
   Account get account;
 }
 
-class _WebSocketChannelProviderElement extends ProviderElement<WebSocketChannel>
+class _WebSocketChannelProviderElement
+    extends AutoDisposeProviderElement<WebSocketChannel>
     with WebSocketChannelRef {
   _WebSocketChannelProviderElement(super.provider);
 


### PR DESCRIPTION
Removed `keepAlive` from `incomingMessage` to avoid duplicate message
on rebuild of `TimelineStreamNotifier`.