### PR TITLE
feat: scroll to last viewed date if already built

### DIFF
--- a/lib/view/widget/notifications_list_view.dart
+++ b/lib/view/widget/notifications_list_view.dart
@@ -216,7 +216,7 @@ class _NewNotificationsDivider extends ConsumerWidget {
       color: colors.panel,
       child: Row(
         children: [
-          Expanded(child: Divider(color: colors.accent)),
+          Expanded(child: Divider(color: colors.accent, thickness: 2.0)),
           Padding(
             padding: const EdgeInsets.symmetric(
               horizontal: 8.0,
@@ -226,7 +226,7 @@ class _NewNotificationsDivider extends ConsumerWidget {
               style: TextStyle(color: colors.accent),
             ),
           ),
-          Expanded(child: Divider(color: colors.accent)),
+          Expanded(child: Divider(color: colors.accent, thickness: 2.0)),
         ],
       ),
     );

--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -27,10 +27,12 @@ class TimelineListView extends HookConsumerWidget {
     super.key,
     required this.tabSettings,
     this.postFormFocusNode,
+    this.lastViewedAtKey,
   });
 
   final TabSettings tabSettings;
   final FocusNode? postFormFocusNode;
+  final Key? lastViewedAtKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -239,7 +241,7 @@ class TimelineListView extends HookConsumerWidget {
                                       ?.createdAt,
                                 ) ??
                                 false
-                            ? const _NewNotesDivider()
+                            ? _NewNotesDivider(key: lastViewedAtKey)
                             : const Divider(height: 1.0),
                     itemCount: nextNotes.valueOrNull?.items.length ?? 0,
                   ),
@@ -253,7 +255,7 @@ class TimelineListView extends HookConsumerWidget {
                                     .valueOrNull?.items.lastOrNull?.createdAt,
                               ) ??
                               false
-                          ? const _NewNotesDivider()
+                          ? _NewNotesDivider(key: lastViewedAtKey)
                           : const Divider(height: 1.0),
                     ),
                   SliverList.separated(
@@ -276,7 +278,7 @@ class TimelineListView extends HookConsumerWidget {
                                       ?.createdAt,
                                 ) ??
                                 false
-                            ? const _NewNotesDivider()
+                            ? _NewNotesDivider(key: lastViewedAtKey)
                             : const Divider(height: 0.0),
                     itemCount: previousNotes.valueOrNull?.items.length ?? 0,
                   ),
@@ -348,7 +350,7 @@ class TimelineListView extends HookConsumerWidget {
 }
 
 class _NewNotesDivider extends ConsumerWidget {
-  const _NewNotesDivider();
+  const _NewNotesDivider({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -359,7 +361,7 @@ class _NewNotesDivider extends ConsumerWidget {
       color: colors.panel,
       child: Row(
         children: [
-          Expanded(child: Divider(color: colors.accent)),
+          Expanded(child: Divider(color: colors.accent, thickness: 2.0)),
           Padding(
             padding: const EdgeInsets.symmetric(
               horizontal: 8.0,
@@ -369,7 +371,7 @@ class _NewNotesDivider extends ConsumerWidget {
               style: TextStyle(color: colors.accent),
             ),
           ),
-          Expanded(child: Divider(color: colors.accent)),
+          Expanded(child: Divider(color: colors.accent, thickness: 2.0)),
         ],
       ),
     );

--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -66,6 +66,7 @@ class TimelineWidget extends HookConsumerWidget {
     final previousNotes = tabSettings.tabType != TabType.notifications
         ? ref.watch(timelineNotesNotifierProvider(tabSettings)).valueOrNull
         : null;
+    final lastViewedAtKey = useMemoized(() => GlobalKey(), []);
     useEffect(
       () {
         ref
@@ -272,12 +273,20 @@ class TimelineWidget extends HookConsumerWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: InkWell(
                     onTap: () {
-                      ref
-                          .read(
-                            timelineCenterNotifierProvider(tabSettings)
-                                .notifier,
-                          )
-                          .setCenterFromDate(lastViewedAt);
+                      final currentContext = lastViewedAtKey.currentContext;
+                      if (currentContext != null) {
+                        Scrollable.ensureVisible(
+                          currentContext,
+                          duration: const Duration(milliseconds: 125),
+                        );
+                      } else {
+                        ref
+                            .read(
+                              timelineCenterNotifierProvider(tabSettings)
+                                  .notifier,
+                            )
+                            .setCenterFromDate(lastViewedAt);
+                      }
                       showLastViewedAt.value = false;
                     },
                     child: Row(
@@ -303,6 +312,7 @@ class TimelineWidget extends HookConsumerWidget {
                 child: TimelineListView(
                   tabSettings: tabSettings,
                   postFormFocusNode: postFormFocusNode,
+                  lastViewedAtKey: lastViewedAtKey,
                 ),
               ),
               if (!account.isGuest)


### PR DESCRIPTION
When the last viewed date divider is on the widget tree, scroll to that widget with `Scrollable.ensureVisible()` instead of changing `centerId`.