### PR TITLE
feat: scroll to last viewed date if older notes have been fetched

### DIFF
--- a/lib/provider/api/timeline_notes_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_notifier_provider.dart
@@ -18,7 +18,7 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
     TabSettings tabSettings, {
     String? untilId,
   }) async {
-    final response = await _fetchNotes(untilId: untilId);
+    final response = await _fetchNotes(untilId: untilId, limit: 30);
     return PaginationState.fromIterable(response);
   }
 
@@ -26,6 +26,7 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
 
   Future<Iterable<Note>> _fetchNotesFromCustomTimeline({
     String? untilId,
+    int? limit,
   }) async {
     final endpoint = tabSettings.endpoint;
     if (endpoint == null) {
@@ -34,7 +35,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
     final response = await _misskey.apiService.post<List<dynamic>>(
       endpoint,
       {
-        'untilId': untilId,
+        if (untilId != null) 'untilId': untilId,
+        if (limit != null) 'limit': limit,
         'withRenotes': tabSettings.withRenotes,
         'withReplies': tabSettings.withReplies,
         'withFiles': tabSettings.withFiles,
@@ -43,11 +45,12 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
     return response.map((e) => Note.fromJson(e as Map<String, dynamic>));
   }
 
-  Future<Iterable<Note>> _fetchNotes({String? untilId}) async {
+  Future<Iterable<Note>> _fetchNotes({String? untilId, int? limit}) async {
     final notes = await switch (tabSettings.tabType) {
       TabType.homeTimeline => _misskey.notes.homeTimeline(
           NotesTimelineRequest(
             untilId: untilId,
+            limit: limit,
             withRenotes: tabSettings.withRenotes,
             withFiles: tabSettings.withFiles,
             allowPartial: true,
@@ -56,6 +59,7 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.localTimeline => _misskey.notes.localTimeline(
           NotesLocalTimelineRequest(
             untilId: untilId,
+            limit: limit,
             withRenotes: tabSettings.withRenotes,
             withReplies: tabSettings.withReplies,
             withFiles: tabSettings.withFiles,
@@ -65,6 +69,7 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.hybridTimeline => _misskey.notes.hybridTimeline(
           NotesHybridTimelineRequest(
             untilId: untilId,
+            limit: limit,
             withRenotes: tabSettings.withRenotes,
             withReplies: tabSettings.withReplies,
             withFiles: tabSettings.withFiles,
@@ -74,6 +79,7 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.globalTimeline => _misskey.notes.globalTimeline(
           NotesGlobalTimelineRequest(
             untilId: untilId,
+            limit: limit,
             withRenotes: tabSettings.withRenotes,
             withFiles: tabSettings.withFiles,
           ),
@@ -82,12 +88,14 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
           RolesNotesRequest(
             roleId: tabSettings.roleId!,
             untilId: untilId,
+            limit: limit,
           ),
         ),
       TabType.userList => _misskey.notes.userListTimeline(
           UserListTimelineRequest(
             listId: tabSettings.listId!,
             untilId: untilId,
+            limit: limit,
             withRenotes: tabSettings.withRenotes,
             withFiles: tabSettings.withFiles,
             allowPartial: true,
@@ -97,21 +105,27 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
           AntennasNotesRequest(
             antennaId: tabSettings.antennaId!,
             untilId: untilId,
+            limit: limit,
           ),
         ),
       TabType.channel => _misskey.channels.timeline(
           ChannelsTimelineRequest(
             channelId: tabSettings.channelId!,
             untilId: untilId,
+            limit: limit,
             allowPartial: true,
           ),
         ),
       TabType.mention => _misskey.notes.mentions(
-          NotesMentionsRequest(untilId: untilId),
+          NotesMentionsRequest(
+            untilId: untilId,
+            limit: limit,
+          ),
         ),
       TabType.direct => _misskey.notes.mentions(
           NotesMentionsRequest(
             untilId: untilId,
+            limit: limit,
             visibility: NoteVisibility.specified,
           ),
         ),
@@ -119,6 +133,7 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
           UsersNotesRequest(
             userId: tabSettings.userId!,
             untilId: untilId,
+            limit: limit,
             withRenotes: tabSettings.withRenotes,
             withReplies: tabSettings.withReplies,
             withFiles: tabSettings.withFiles,

--- a/lib/provider/api/timeline_notes_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$timelineNotesNotifierHash() =>
-    r'0eae4b1a3d38687c6b71f61210973ffb0e65df80';
+    r'd97369bdb4c6207f4c6d5d86254c2881a0a44c29';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -98,17 +98,22 @@ class TimelineListView extends HookConsumerWidget {
             HapticFeedback.lightImpact();
           }
           if (keepAnimation.value) {
-            if (tabSettings.id != null) {
-              ref
-                  .read(
-                    timelineLastViewedAtNotifierProvider(tabSettings).notifier,
-                  )
-                  .save(note.createdAt);
+            if (controller.offset < 400.0) {
+              if (tabSettings.id != null) {
+                ref
+                    .read(
+                      timelineLastViewedAtNotifierProvider(tabSettings)
+                          .notifier,
+                    )
+                    .save(note.createdAt);
+              }
+              Future<void>.delayed(
+                const Duration(milliseconds: 100),
+                controller.scrollToTop,
+              );
+            } else {
+              keepAnimation.value = false;
             }
-            Future<void>.delayed(
-              const Duration(milliseconds: 100),
-              controller.scrollToTop,
-            );
           } else {
             hasUnread.value = true;
           }


### PR DESCRIPTION
Changed scroll behavior of when the "last viewed at" banner is tapped.

- If the divider is already built (or inside the screen), jump to it.
  - Change from #113: removed animations because `Scrollable.ensureVisible()` also scrolls in a horizontal direction and makes unintended movements.
- If the oldest note in `TimelineNotesNotifier` is older than the last viewed date, repeatedly scroll for small offsets to find the divider.
- Otherwise, change the `centerId` and jump to the date.

We want to avoid the third case because fetching notes created after a date sometimes requires multiple requests.
So increased the number of notes fetched on build to make it more likely to be caught in the second case.