### PR TITLE
fix: remove font family fallback if font is not set

### DIFF
--- a/lib/provider/theme_data_provider.dart
+++ b/lib/provider/theme_data_provider.dart
@@ -41,7 +41,15 @@ ThemeData themeData(ThemeDataRef ref, Brightness brightness) {
         )
         .apply(
           fontFamily: fontFamily,
-          fontFamilyFallback: [FontFamily.bIZUDGothic],
+          fontFamilyFallback: fontFamily != null
+              ? [
+                  FontFamily.bIZUDGothic,
+                  FontFamily.notoSansJP,
+                  FontFamily.notoSansKR,
+                  FontFamily.notoSansSC,
+                  FontFamily.notoSansTC,
+                ]
+              : null,
           displayColor: colors.fg,
           bodyColor: colors.fg,
         ),

--- a/lib/provider/theme_data_provider.g.dart
+++ b/lib/provider/theme_data_provider.g.dart
@@ -6,7 +6,7 @@ part of 'theme_data_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$themeDataHash() => r'1c9e89a7142ac7be6644dcafd8b17d477454f2a1';
+String _$themeDataHash() => r'93c96a0f576ef1ad0cb61fb895a513fae5cfbe3f';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
If `fontFamilyFallback` is set, Flutter will use the fallback fonts instead of the default device fonts.

https://api.flutter.dev/flutter/painting/TextStyle/fontFamilyFallback.html