### PR TITLE
refactor: use cache manager to cache emojis

### DIFF
--- a/lib/provider/accounts_notifier_provider.dart
+++ b/lib/provider/accounts_notifier_provider.dart
@@ -45,7 +45,7 @@ class AccountsNotifier extends _$AccountsNotifier {
     ]);
     await ref
         .read(emojisNotifierProvider(account.host).notifier)
-        .fetchAndSaveIfNeeded();
+        .reloadEmojis();
   }
 
   Future<bool> loginWithToken(String host, String token) async {

--- a/lib/provider/accounts_notifier_provider.g.dart
+++ b/lib/provider/accounts_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'accounts_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$accountsNotifierHash() => r'd10e2aa82ed4f2271bb8f4d300de005cd4aa9365';
+String _$accountsNotifierHash() => r'27a1e06e2ca9c77ab0fe2ac190550688d25bae79';
 
 /// See also [AccountsNotifier].
 @ProviderFor(AccountsNotifier)

--- a/lib/provider/categorized_emojis_provider.dart
+++ b/lib/provider/categorized_emojis_provider.dart
@@ -12,5 +12,6 @@ Map<String?, List<Emoji>> categorizedEmojis(
   String host,
 ) {
   final emojis = ref.watch(emojisNotifierProvider(host));
-  return emojis.values.groupListsBy((emoji) => emoji.category);
+  return emojis.valueOrNull?.values.groupListsBy((emoji) => emoji.category) ??
+      {};
 }

--- a/lib/provider/categorized_emojis_provider.g.dart
+++ b/lib/provider/categorized_emojis_provider.g.dart
@@ -6,7 +6,7 @@ part of 'categorized_emojis_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$categorizedEmojisHash() => r'f84d18361fa3097651f118b629aa1e1e3f70ac30';
+String _$categorizedEmojisHash() => r'970f03f49d3b6f9e0789f672ecbed0b295216fe1';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/custom_emoji_index_provider.dart
+++ b/lib/provider/custom_emoji_index_provider.dart
@@ -31,7 +31,7 @@ Future<Map<String, Set<Emoji>>> customEmojiIndex(
   CustomEmojiIndexRef ref,
   String host,
 ) async {
-  final emojis = ref.watch(emojisNotifierProvider(host));
+  final emojis = await ref.watch(emojisNotifierProvider(host).future);
   final index = await compute(_buildCustomEmojiIndex, emojis.values);
   return index;
 }

--- a/lib/provider/custom_emoji_index_provider.g.dart
+++ b/lib/provider/custom_emoji_index_provider.g.dart
@@ -6,7 +6,7 @@ part of 'custom_emoji_index_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$customEmojiIndexHash() => r'6f508fafa0832fef539fed6e38243bf7a75d1d55';
+String _$customEmojiIndexHash() => r'e16fd665bbbc3cb564aaa440c2345d18ee61482f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/emoji_provider.dart
+++ b/lib/provider/emoji_provider.dart
@@ -11,7 +11,7 @@ Emoji? emoji(EmojiRef ref, String host, String code) {
   final name = code.substring(1, code.length - 1).replaceAll('@.', '');
   return ref.watch(
     emojisNotifierProvider(host).select(
-      (emojis) => emojis[name],
+      (emojis) => emojis.valueOrNull?[name],
     ),
   );
 }

--- a/lib/provider/emoji_provider.g.dart
+++ b/lib/provider/emoji_provider.g.dart
@@ -6,7 +6,7 @@ part of 'emoji_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$emojiHash() => r'79b2e562406beeec7ad50c059b139baea2ab5ff5';
+String _$emojiHash() => r'967c4327030d5465e7cbf929167f76bfec9ca81a';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/emojis_notifier_provider.g.dart
+++ b/lib/provider/emojis_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'emojis_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$emojisNotifierHash() => r'48cc24da1651cac682dab822bf816f38bc2bbc6f';
+String _$emojisNotifierHash() => r'a1d2a05a63f138d4aadf35ff6ee3ce5ea13ef1c4';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -29,10 +29,11 @@ class _SystemHash {
   }
 }
 
-abstract class _$EmojisNotifier extends BuildlessNotifier<Map<String, Emoji>> {
+abstract class _$EmojisNotifier
+    extends BuildlessAsyncNotifier<Map<String, Emoji>> {
   late final String host;
 
-  Map<String, Emoji> build(
+  FutureOr<Map<String, Emoji>> build(
     String host,
   );
 }
@@ -42,7 +43,7 @@ abstract class _$EmojisNotifier extends BuildlessNotifier<Map<String, Emoji>> {
 const emojisNotifierProvider = EmojisNotifierFamily();
 
 /// See also [EmojisNotifier].
-class EmojisNotifierFamily extends Family<Map<String, Emoji>> {
+class EmojisNotifierFamily extends Family<AsyncValue<Map<String, Emoji>>> {
   /// See also [EmojisNotifier].
   const EmojisNotifierFamily();
 
@@ -81,7 +82,7 @@ class EmojisNotifierFamily extends Family<Map<String, Emoji>> {
 
 /// See also [EmojisNotifier].
 class EmojisNotifierProvider
-    extends NotifierProviderImpl<EmojisNotifier, Map<String, Emoji>> {
+    extends AsyncNotifierProviderImpl<EmojisNotifier, Map<String, Emoji>> {
   /// See also [EmojisNotifier].
   EmojisNotifierProvider(
     String host,
@@ -112,7 +113,7 @@ class EmojisNotifierProvider
   final String host;
 
   @override
-  Map<String, Emoji> runNotifierBuild(
+  FutureOr<Map<String, Emoji>> runNotifierBuild(
     covariant EmojisNotifier notifier,
   ) {
     return notifier.build(
@@ -137,7 +138,8 @@ class EmojisNotifierProvider
   }
 
   @override
-  NotifierProviderElement<EmojisNotifier, Map<String, Emoji>> createElement() {
+  AsyncNotifierProviderElement<EmojisNotifier, Map<String, Emoji>>
+      createElement() {
     return _EmojisNotifierProviderElement(this);
   }
 
@@ -155,13 +157,13 @@ class EmojisNotifierProvider
   }
 }
 
-mixin EmojisNotifierRef on NotifierProviderRef<Map<String, Emoji>> {
+mixin EmojisNotifierRef on AsyncNotifierProviderRef<Map<String, Emoji>> {
   /// The parameter `host` of this provider.
   String get host;
 }
 
 class _EmojisNotifierProviderElement
-    extends NotifierProviderElement<EmojisNotifier, Map<String, Emoji>>
+    extends AsyncNotifierProviderElement<EmojisNotifier, Map<String, Emoji>>
     with EmojisNotifierRef {
   _EmojisNotifierProviderElement(super.provider);
 

--- a/lib/util/navigate.dart
+++ b/lib/util/navigate.dart
@@ -20,7 +20,7 @@ Future<void> navigate(WidgetRef ref, Account account, String link) async {
       try {
         await ref
             .read(emojisNotifierProvider(url.host).notifier)
-            .fetchAndSaveIfNeeded();
+            .reloadEmojis();
         if (!ref.context.mounted) return;
         await ref.context.push('/${url.host}${url.path}');
       } catch (_) {
@@ -35,7 +35,7 @@ Future<void> navigate(WidgetRef ref, Account account, String link) async {
         try {
           await ref
               .read(emojisNotifierProvider(url.host).notifier)
-              .fetchAndSaveIfNeeded();
+              .reloadEmojis();
           if (!ref.context.mounted) return;
           await ref.context.push('/${url.host}${url.path}');
         } catch (_) {

--- a/lib/util/open_as_guest.dart
+++ b/lib/util/open_as_guest.dart
@@ -6,20 +6,10 @@ import 'package:misskey_dart/misskey_dart.dart';
 
 import '../model/account.dart';
 import '../provider/api/user_notifier_provider.dart';
-import '../provider/emojis_notifier_provider.dart';
 
 Future<void> openUserAsGuest(WidgetRef ref, UserDetailed user) async {
   final remoteUrl = user.uri ?? user.url;
-  if (remoteUrl == null) {
-    return;
-  }
-  unawaited(
-    ref
-        .read(
-          emojisNotifierProvider(remoteUrl.host).notifier,
-        )
-        .fetchIfNeeded(),
-  );
+  if (remoteUrl == null) return;
   final guest = Account(host: remoteUrl.host);
   final userAsLocal = await ref.read(
     userNotifierProvider(guest, username: user.username).future,

--- a/lib/view/dialog/icon_select_dialog.dart
+++ b/lib/view/dialog/icon_select_dialog.dart
@@ -8,7 +8,6 @@ import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../model/tab_icon.dart';
 import '../../provider/emoji_url_provider.dart';
-import '../../provider/emojis_notifier_provider.dart';
 import '../widget/emoji_picker.dart';
 
 class IconSelectDialog extends HookConsumerWidget {
@@ -33,12 +32,7 @@ class IconSelectDialog extends HookConsumerWidget {
             IconButton(
               onPressed: showEmojiPicker.value
                   ? null
-                  : () {
-                      showEmojiPicker.value = true;
-                      ref
-                          .read(emojisNotifierProvider(account!.host).notifier)
-                          .fetchAndSaveIfNeeded();
-                    },
+                  : () => showEmojiPicker.value = true,
               icon: const Icon(Icons.navigate_next),
             ),
           ],

--- a/lib/view/page/note_page.dart
+++ b/lib/view/page/note_page.dart
@@ -14,7 +14,6 @@ import '../../provider/api/meta_provider.dart';
 import '../../provider/api/misskey_provider.dart';
 import '../../provider/api/timeline_notes_after_note_notifier_provider.dart';
 import '../../provider/api/timeline_notes_notifier_provider.dart';
-import '../../provider/emojis_notifier_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
 import '../../provider/note_provider.dart';
@@ -299,18 +298,9 @@ class NotePage extends HookConsumerWidget {
                                   ),
                                   if (remoteNoteId != null)
                                     TextButton(
-                                      onPressed: () {
-                                        ref
-                                            .read(
-                                              emojisNotifierProvider(
-                                                remoteUrl.host,
-                                              ).notifier,
-                                            )
-                                            .fetchIfNeeded();
-                                        context.push(
-                                          '/${remoteUrl.host}/notes/$remoteNoteId',
-                                        );
-                                      },
+                                      onPressed: () => context.push(
+                                        '/${remoteUrl.host}/notes/$remoteNoteId',
+                                      ),
                                       child: Text(t.aria.openAsGuest),
                                     ),
                                 ],

--- a/lib/view/page/server/server_emojis.dart
+++ b/lib/view/page/server/server_emojis.dart
@@ -25,7 +25,6 @@ class ServerEmojis extends HookConsumerWidget {
     final query = useState('');
     useEffect(
       () {
-        ref.read(emojisNotifierProvider(host).notifier).fetchAndSave();
         controller.addListener(() => query.value = controller.text);
         return;
       },
@@ -36,8 +35,7 @@ class ServerEmojis extends HookConsumerWidget {
     final style = DefaultTextStyle.of(context).style;
 
     return RefreshIndicator(
-      onRefresh: () =>
-          ref.read(emojisNotifierProvider(host).notifier).fetchAndSave(),
+      onRefresh: () => ref.refresh(emojisNotifierProvider(host).future),
       child: groups.isNotEmpty
           ? ListView.builder(
               itemBuilder: (context, index) {

--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -70,7 +70,7 @@ class TimelinesPage extends HookConsumerWidget {
                   .read(
                     emojisNotifierProvider(nextAccount.host).notifier,
                   )
-                  .fetchAndSaveIfNeeded();
+                  .reloadEmojis();
             }
             if (!previousAccount.isGuest) {
               ref

--- a/lib/view/widget/emoji_sheet.dart
+++ b/lib/view/widget/emoji_sheet.dart
@@ -6,7 +6,7 @@ import 'package:misskey_dart/misskey_dart.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/api/i_notifier_provider.dart';
-import '../../provider/emojis_notifier_provider.dart';
+import '../../provider/emoji_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/notes_notifier_provider.dart';
 import '../../provider/pinned_emojis_notifier_provider.dart';
@@ -37,10 +37,7 @@ class EmojiSheet extends ConsumerWidget {
     final isCustomEmoji = emoji.startsWith(':');
     final (name, host) = decodeCustomEmoji(emoji);
     final data = isCustomEmoji
-        ? ref.watch(
-            emojisNotifierProvider(account.host)
-                .select((emojis) => emojis[name]),
-          )
+        ? ref.watch(emojiProvider(account.host, ':$name:'))
         : null;
     final canReact = !account.isGuest &&
         targetNote != null &&

--- a/lib/view/widget/note_sheet.dart
+++ b/lib/view/widget/note_sheet.dart
@@ -18,7 +18,6 @@ import '../../provider/api/misskey_provider.dart';
 import '../../provider/api/note_state_provider.dart';
 import '../../provider/api/post_notifier_provider.dart';
 import '../../provider/appear_note_provider.dart';
-import '../../provider/emojis_notifier_provider.dart';
 import '../../provider/note_provider.dart';
 import '../../provider/notes_notifier_provider.dart';
 import '../../util/copy_text.dart';
@@ -126,9 +125,6 @@ class NoteSheet extends ConsumerWidget {
                 title: Text(t.aria.openAsGuest),
                 onTap: () {
                   context.pop();
-                  ref
-                      .read(emojisNotifierProvider(remoteUrl.host).notifier)
-                      .fetchIfNeeded();
                   context.push('/${remoteUrl.host}/notes/$remoteNoteId');
                 },
               ),

--- a/lib/view/widget/reaction_button.dart
+++ b/lib/view/widget/reaction_button.dart
@@ -6,7 +6,7 @@ import '../../extension/text_style_extension.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/api/i_notifier_provider.dart';
-import '../../provider/emojis_notifier_provider.dart';
+import '../../provider/emoji_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
 import '../../provider/notes_notifier_provider.dart';
@@ -40,10 +40,7 @@ class ReactionButton extends ConsumerWidget {
     final isCustomEmoji = emoji.startsWith(':');
     final (name, host) = decodeCustomEmoji(emoji);
     final data = isCustomEmoji
-        ? ref.watch(
-            emojisNotifierProvider(account.host)
-                .select((emojis) => emojis[name]),
-          )
+        ? ref.watch(emojiProvider(account.host, ':$name:'))
         : null;
     final canReact = !account.isGuest &&
         (!isCustomEmoji ||

--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -71,9 +71,6 @@ class TimelineWidget extends HookConsumerWidget {
     useEffect(
       () {
         ref
-            .read(emojisNotifierProvider(account.host).notifier)
-            .fetchAndSaveIfNeeded();
-        ref
             .read(timelineLastViewedAtNotifierProvider(tabSettings).notifier)
             .save(DateTime.now());
         if (!tabSettings.disableSubscribing) {


### PR DESCRIPTION
Moved the storage of emojis from shared preferences to files managed by the cache manager.
This reduces the size of shared preferences and will shorten the initialization duration of the app.