### PR TITLE
fix: explicitly call unfocus

### DIFF
--- a/lib/view/page/search/search_notes.dart
+++ b/lib/view/page/search/search_notes.dart
@@ -79,6 +79,7 @@ class SearchNotes extends HookConsumerWidget {
                 autofocus: true,
                 onSubmitted: (value) => query.value = value.trim(),
                 textInputAction: TextInputAction.search,
+                onTapOutside: (_) => focusNode?.unfocus(),
               ),
             ),
           ),

--- a/lib/view/page/search/search_users.dart
+++ b/lib/view/page/search/search_users.dart
@@ -50,6 +50,7 @@ class SearchUsers extends HookConsumerWidget {
                 autofocus: true,
                 onSubmitted: (value) => query.value = value.trim(),
                 textInputAction: TextInputAction.search,
+                onTapOutside: (_) => focusNode?.unfocus(),
               ),
             ),
           ),

--- a/lib/view/widget/misskey_server_autocomplete.dart
+++ b/lib/view/widget/misskey_server_autocomplete.dart
@@ -25,102 +25,112 @@ class MisskeyServerAutocomplete extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Shortcuts(
-      shortcuts: disablingTextShortcuts,
-      child: RawAutocomplete(
-        textEditingController: controller,
-        focusNode: focusNode,
-        optionsBuilder: (textEditingValue) async {
-          final servers = await ref.watch(
-            searchMisskeyServersProvider(textEditingValue.text.trim()).future,
-          );
-          return servers.map((server) => server.url).toList();
-        },
-        fieldViewBuilder: (context, textEditingController, focusNode, _) =>
-            TextField(
-          controller: textEditingController,
+    return TextFieldTapRegion(
+      onTapOutside: (_) => focusNode.unfocus(),
+      child: Shortcuts(
+        shortcuts: disablingTextShortcuts,
+        child: RawAutocomplete(
+          textEditingController: controller,
           focusNode: focusNode,
-          decoration: InputDecoration(
-            prefixIcon: const Icon(Icons.dns),
-            labelText: t.aria.serverUrl,
-            hintText: 'misskey.io',
-            prefixText: 'https://',
-            suffixIcon: IconButton(
-              onPressed: () => controller.clear(),
-              icon: const Icon(Icons.close),
+          optionsBuilder: (textEditingValue) async {
+            final servers = await ref.watch(
+              searchMisskeyServersProvider(textEditingValue.text.trim()).future,
+            );
+            return servers.map((server) => server.url).toList();
+          },
+          fieldViewBuilder: (context, textEditingController, focusNode, _) =>
+              TextField(
+            controller: textEditingController,
+            focusNode: focusNode,
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.dns),
+              labelText: t.aria.serverUrl,
+              hintText: 'misskey.io',
+              prefixText: 'https://',
+              suffixIcon: IconButton(
+                onPressed: () => controller.clear(),
+                icon: const Icon(Icons.close),
+              ),
+            ),
+            autofocus: autofocus,
+            onSubmitted: onSubmitted,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.done,
+            contextMenuBuilder: (context, editableTextState) =>
+                AdaptiveTextSelectionToolbar.editable(
+              clipboardStatus: ClipboardStatus.pasteable,
+              onCopy: editableTextState.copyEnabled
+                  ? () => editableTextState
+                      .copySelection(SelectionChangedCause.toolbar)
+                  : null,
+              onCut: editableTextState.cutEnabled
+                  ? () => editableTextState
+                      .cutSelection(SelectionChangedCause.toolbar)
+                  : null,
+              onPaste: editableTextState.pasteEnabled
+                  ? () async {
+                      final data =
+                          await Clipboard.getData(Clipboard.kTextPlain);
+                      if (data case ClipboardData(:final text?)) {
+                        await Clipboard.setData(
+                          ClipboardData(
+                            text: toAscii(
+                              text
+                                  .trim()
+                                  .replaceFirst('https://', '')
+                                  .split('/')
+                                  .first,
+                            ).toLowerCase(),
+                          ),
+                        );
+                        await editableTextState
+                            .pasteText(SelectionChangedCause.toolbar);
+                      }
+                    }
+                  : null,
+              onSelectAll: editableTextState.selectAllEnabled
+                  ? () =>
+                      editableTextState.selectAll(SelectionChangedCause.toolbar)
+                  : null,
+              onLookUp: editableTextState.lookUpEnabled
+                  ? () => editableTextState
+                      .lookUpSelection(SelectionChangedCause.toolbar)
+                  : null,
+              onSearchWeb: editableTextState.searchWebEnabled
+                  ? () => editableTextState
+                      .searchWebForSelection(SelectionChangedCause.toolbar)
+                  : null,
+              onShare: editableTextState.shareEnabled
+                  ? () => editableTextState
+                      .shareSelection(SelectionChangedCause.toolbar)
+                  : null,
+              onLiveTextInput: null,
+              anchors: editableTextState.contextMenuAnchors,
             ),
           ),
-          autofocus: autofocus,
-          onSubmitted: onSubmitted,
-          keyboardType: TextInputType.url,
-          textInputAction: TextInputAction.done,
-          contextMenuBuilder: (context, editableTextState) =>
-              AdaptiveTextSelectionToolbar.editable(
-            clipboardStatus: ClipboardStatus.pasteable,
-            onCopy: editableTextState.copyEnabled
-                ? () => editableTextState
-                    .copySelection(SelectionChangedCause.toolbar)
-                : null,
-            onCut: editableTextState.cutEnabled
-                ? () => editableTextState
-                    .cutSelection(SelectionChangedCause.toolbar)
-                : null,
-            onPaste: editableTextState.pasteEnabled
-                ? () async {
-                    final data = await Clipboard.getData(Clipboard.kTextPlain);
-                    if (data case ClipboardData(:final text?)) {
-                      await Clipboard.setData(
-                        ClipboardData(
-                          text: toAscii(
-                            text
-                                .trim()
-                                .replaceFirst('https://', '')
-                                .split('/')
-                                .first,
-                          ).toLowerCase(),
-                        ),
-                      );
-                      await editableTextState
-                          .pasteText(SelectionChangedCause.toolbar);
-                    }
-                  }
-                : null,
-            onSelectAll: editableTextState.selectAllEnabled
-                ? () =>
-                    editableTextState.selectAll(SelectionChangedCause.toolbar)
-                : null,
-            onLookUp: editableTextState.lookUpEnabled
-                ? () => editableTextState
-                    .lookUpSelection(SelectionChangedCause.toolbar)
-                : null,
-            onSearchWeb: editableTextState.searchWebEnabled
-                ? () => editableTextState
-                    .searchWebForSelection(SelectionChangedCause.toolbar)
-                : null,
-            onShare: editableTextState.shareEnabled
-                ? () => editableTextState
-                    .shareSelection(SelectionChangedCause.toolbar)
-                : null,
-            onLiveTextInput: null,
-            anchors: editableTextState.contextMenuAnchors,
-          ),
-        ),
-        optionsViewBuilder: (context, onSelected, options) => Align(
-          alignment: Alignment.topLeft,
-          child: Material(
-            elevation: 4.0,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: 200.0,
-                maxWidth: min(MediaQuery.sizeOf(context).width, 800.0) - 64.0,
-              ),
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemBuilder: (context, index) => ListTile(
-                  title: Text(options.elementAt(index)),
-                  onTap: () => onSelected(options.elementAt(index)),
+          optionsViewBuilder: (context, onSelected, options) => Align(
+            alignment: Alignment.topLeft,
+            child: Material(
+              elevation: 4.0,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: 200.0,
+                  maxWidth: min(MediaQuery.sizeOf(context).width, 800.0) - 64.0,
                 ),
-                itemCount: options.length,
+                // Use `CustomScrollView` instead of `ListView` because
+                // `ListView` shows white space on top of the options
+                // for mobile devices.
+                child: CustomScrollView(
+                  slivers: [
+                    SliverList.builder(
+                      itemBuilder: (context, index) => ListTile(
+                        title: Text(options.elementAt(index)),
+                        onTap: () => onSelected(options.elementAt(index)),
+                      ),
+                      itemCount: options.length,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
If a `focusNode` is provided, `TextField` will not give up focus if tapped outside.
This can Interrupt users, especially if they are using a software keyboard without a "close keyboard" button.