### PR TITLE
fix: reorder pinned emojis

### DIFF
--- a/lib/provider/api/attaches_notifier_provider.dart
+++ b/lib/provider/api/attaches_notifier_provider.dart
@@ -63,7 +63,7 @@ class AttachesNotifier extends _$AttachesNotifier {
   void reorder(int oldIndex, int newIndex) {
     final items = state.toList();
     final item = items.removeAt(oldIndex);
-    items.insert(oldIndex < newIndex ? newIndex - 1 : newIndex, item);
+    items.insert(newIndex, item);
     state = items;
   }
 

--- a/lib/provider/api/attaches_notifier_provider.g.dart
+++ b/lib/provider/api/attaches_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'attaches_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$attachesNotifierHash() => r'7ed92c4110d964e1a59f0821c0c452dbdbea098d';
+String _$attachesNotifierHash() => r'3c654fc3915d1abca2a9b11199ac0664acdfb862';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -69,7 +69,9 @@ class NotesNotifier extends _$NotesNotifier {
     reactions[reacted.reaction] = (reactions[reacted.reaction] ?? 0) + 1;
     final emoji = reacted.emoji;
     final reactionEmojis = Map.of(note.reactionEmojis);
-    if (emoji != null && !reacted.reaction.endsWith('@.:')) {
+    if (emoji != null &&
+        reacted.reaction.startsWith(':') &&
+        !reacted.reaction.endsWith('@.:')) {
       reactionEmojis[emoji.name] = emoji.url;
     }
     state = {
@@ -156,14 +158,17 @@ class NotesNotifier extends _$NotesNotifier {
     );
     final note = await _misskey.notes.show(NotesShowRequest(noteId: noteId));
     if (note.myReaction == null) {
+      final emoji = reaction.startsWith(':') && !reaction.endsWith('@.:')
+          ? '${reaction.substring(0, reaction.length - 1)}@.:'
+          : reaction;
       add(
         note.copyWith(
           reactionCount: (note.reactionCount ?? 0) + 1,
           reactions: {
             ...note.reactions,
-            reaction: (note.reactions[reaction] ?? 0) + 1,
+            reaction: (note.reactions[emoji] ?? 0) + 1,
           },
-          myReaction: reaction,
+          myReaction: emoji,
         ),
       );
     } else {

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'cdb0332d358ae9a03edd16336293f5763f89c305';
+String _$notesNotifierHash() => r'bde83693e280d4ff0087760981c7da280697c908';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/pinned_emojis_notifier_provider.dart
+++ b/lib/provider/pinned_emojis_notifier_provider.dart
@@ -44,7 +44,7 @@ class PinnedEmojisNotifier extends _$PinnedEmojisNotifier {
   Future<void> reorder(int oldIndex, int newIndex) async {
     final items = state.toList();
     final item = items.removeAt(oldIndex);
-    items.insert(oldIndex < newIndex ? newIndex - 1 : newIndex, item);
+    items.insert(newIndex, item);
     await _save(items);
   }
 

--- a/lib/provider/pinned_emojis_notifier_provider.g.dart
+++ b/lib/provider/pinned_emojis_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'pinned_emojis_notifier_provider.dart';
 // **************************************************************************
 
 String _$pinnedEmojisNotifierHash() =>
-    r'5a3b81a43c5af6dc2cd0ac087e3f94563600e251';
+    r'23a174ac8e1421ed1ae4511e437853546bc1f3f5';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/widget/pinned_emojis_editor.dart
+++ b/lib/view/widget/pinned_emojis_editor.dart
@@ -73,6 +73,7 @@ class PinnedEmojisEditor extends HookConsumerWidget {
                         style: DefaultTextStyle.of(context)
                             .style
                             .apply(fontSizeFactor: 2.0),
+                        disableTooltip: true,
                       ),
                     )
                     .toList(),


### PR DESCRIPTION
Disabled tooltips of emojis in `PinnedEmojiEditor`, which prevent long press events from being caught by `ReorderableWrapper`.
Also fixed reorder logic to match with the difference of arguments between `ReorderableListView` and `ReorderableWrapper` or `ReorderableGridView`.