### PR TITLE
fix: disable nyaize by default

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -25,6 +25,7 @@ List<InlineSpan> buildMfm(
   TextStyle? style,
   Map<String, String>? emojis,
   User? author,
+  bool nyaize = false,
   void Function(String emoji)? onTapEmoji,
   void Function(String link)? onLinkTap,
   TextAlign? textAlign,
@@ -94,7 +95,7 @@ List<InlineSpan> buildMfm(
       builder: (context) => UrlSheet(url: url),
     ),
     onHashtagTap: (hashtag) => ref.context.push('/$account/tags/$hashtag'),
-    shouldNyaize: author?.isCat ?? false,
+    shouldNyaize: nyaize && (author?.isCat ?? false),
     useAdvanced: useAdvanced,
     useAnimation: useAnimation,
     opacity: DefaultTextStyle.of(ref.context).style.color?.opacity ?? 1.0,
@@ -121,6 +122,7 @@ class Mfm extends HookConsumerWidget {
     this.style,
     this.emojis,
     this.author,
+    this.nyaize = false,
     this.selectable = false,
     this.onTapEmoji,
     this.textAlign,
@@ -135,6 +137,7 @@ class Mfm extends HookConsumerWidget {
   final TextStyle? style;
   final Map<String, String>? emojis;
   final User? author;
+  final bool nyaize;
   final bool selectable;
   final void Function(String emoji)? onTapEmoji;
   final TextAlign? textAlign;
@@ -154,8 +157,8 @@ class Mfm extends HookConsumerWidget {
           nodes: nodes,
           simple: simple,
           style: style,
-          author: author,
           emojis: emojis,
+          author: author,
           onLinkTap: (link) => navigate(ref, account, link),
           textAlign: textAlign,
           overflow: overflow,

--- a/lib/view/widget/note_detailed_widget.dart
+++ b/lib/view/widget/note_detailed_widget.dart
@@ -276,6 +276,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                         text: cw,
                         emojis: appearNote.emojis,
                         author: appearNote.user,
+                        nyaize: true,
                         selectable: true,
                         onTapEmoji: (emoji) => showModalBottomSheet<void>(
                           context: context,
@@ -328,8 +329,9 @@ class NoteDetailedWidget extends HookConsumerWidget {
                                     ref,
                                     account: account,
                                     nodes: parsed,
-                                    author: appearNote.user,
                                     emojis: appearNote.emojis,
+                                    author: appearNote.user,
+                                    nyaize: true,
                                     onTapEmoji: (emoji) =>
                                         showModalBottomSheet<void>(
                                       context: context,

--- a/lib/view/widget/note_simple_widget.dart
+++ b/lib/view/widget/note_simple_widget.dart
@@ -105,6 +105,7 @@ class NoteSimpleWidget extends HookConsumerWidget {
                       text: note.cw,
                       emojis: note.emojis,
                       author: note.user,
+                      nyaize: true,
                       onTapEmoji: (emoji) => showModalBottomSheet<void>(
                         context: context,
                         builder: (context) => EmojiSheet(

--- a/lib/view/widget/note_sub_widget.dart
+++ b/lib/view/widget/note_sub_widget.dart
@@ -117,6 +117,7 @@ class NoteSubWidget extends HookConsumerWidget {
                             text: note.cw,
                             emojis: note.emojis,
                             author: note.user,
+                            nyaize: true,
                             onTapEmoji: (emoji) => showModalBottomSheet<void>(
                               context: context,
                               builder: (context) => EmojiSheet(

--- a/lib/view/widget/note_summary.dart
+++ b/lib/view/widget/note_summary.dart
@@ -37,6 +37,8 @@ class NoteSummary extends ConsumerWidget {
         ].join(' '),
         simple: true,
         emojis: note.emojis,
+        author: note.user,
+        nyaize: true,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),

--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -328,6 +328,7 @@ class NoteWidget extends HookConsumerWidget {
                                   text: cw,
                                   emojis: appearNote.emojis,
                                   author: appearNote.user,
+                                  nyaize: true,
                                   onTapEmoji: (emoji) =>
                                       showModalBottomSheet<void>(
                                     context: context,
@@ -383,8 +384,9 @@ class NoteWidget extends HookConsumerWidget {
                                             ref,
                                             account: account,
                                             nodes: parsed,
-                                            author: appearNote.user,
                                             emojis: appearNote.emojis,
+                                            author: appearNote.user,
+                                            nyaize: true,
                                             onTapEmoji: (emoji) =>
                                                 showModalBottomSheet<void>(
                                               context: context,

--- a/lib/view/widget/sub_note_content.dart
+++ b/lib/view/widget/sub_note_content.dart
@@ -91,8 +91,9 @@ class SubNoteContent extends HookConsumerWidget {
                       ref,
                       account: account,
                       nodes: parsed,
-                      author: note.user,
                       emojis: note.emojis,
+                      author: note.user,
+                      nyaize: true,
                       onTapEmoji: (emoji) => showModalBottomSheet<void>(
                         context: context,
                         builder: (context) => EmojiSheet(

--- a/lib/view/widget/translated_note_sheet.dart
+++ b/lib/view/widget/translated_note_sheet.dart
@@ -53,6 +53,7 @@ class TranslatedNoteSheet extends ConsumerWidget {
                     text: translatedNote.text,
                     emojis: note.emojis,
                     author: note.user,
+                    nyaize: true,
                   ),
                 ),
               ),


### PR DESCRIPTION
Disabled nyaize for user descriptions by changing the default nyaize setting to disabled, which follows the setting of the `Mfm` component of Misskey Web.