### PR TITLE
fix: fold notifications on the client side

### DIFF
--- a/lib/provider/api/endpoints_provider.dart
+++ b/lib/provider/api/endpoints_provider.dart
@@ -5,7 +5,13 @@ import 'misskey_provider.dart';
 
 part 'endpoints_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 FutureOr<List<String>> endpoints(EndpointsRef ref, String host) {
-  return ref.watch(misskeyProvider(Account(host: host))).endpoints();
+  final link = ref.keepAlive();
+  try {
+    return ref.watch(misskeyProvider(Account(host: host))).endpoints();
+  } catch (_) {
+    link.close();
+    rethrow;
+  }
 }

--- a/lib/provider/api/endpoints_provider.g.dart
+++ b/lib/provider/api/endpoints_provider.g.dart
@@ -6,7 +6,7 @@ part of 'endpoints_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$endpointsHash() => r'b8f5b5d555addca90ac246440a517480ea478095';
+String _$endpointsHash() => r'5502a21f7e93fe1b9a6c684f7038707069b6decb';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -72,7 +72,7 @@ class EndpointsFamily extends Family<AsyncValue<List<String>>> {
 }
 
 /// See also [endpoints].
-class EndpointsProvider extends FutureProvider<List<String>> {
+class EndpointsProvider extends AutoDisposeFutureProvider<List<String>> {
   /// See also [endpoints].
   EndpointsProvider(
     String host,
@@ -123,7 +123,7 @@ class EndpointsProvider extends FutureProvider<List<String>> {
   }
 
   @override
-  FutureProviderElement<List<String>> createElement() {
+  AutoDisposeFutureProviderElement<List<String>> createElement() {
     return _EndpointsProviderElement(this);
   }
 
@@ -141,13 +141,13 @@ class EndpointsProvider extends FutureProvider<List<String>> {
   }
 }
 
-mixin EndpointsRef on FutureProviderRef<List<String>> {
+mixin EndpointsRef on AutoDisposeFutureProviderRef<List<String>> {
   /// The parameter `host` of this provider.
   String get host;
 }
 
-class _EndpointsProviderElement extends FutureProviderElement<List<String>>
-    with EndpointsRef {
+class _EndpointsProviderElement
+    extends AutoDisposeFutureProviderElement<List<String>> with EndpointsRef {
   _EndpointsProviderElement(super.provider);
 
   @override

--- a/lib/provider/api/notifications_notifier_provider.dart
+++ b/lib/provider/api/notifications_notifier_provider.dart
@@ -5,6 +5,7 @@ import '../../model/account.dart';
 import '../../model/pagination_state.dart';
 import '../general_settings_notifier_provider.dart';
 import '../notes_notifier_provider.dart';
+import 'endpoints_provider.dart';
 import 'misskey_provider.dart';
 
 part 'notifications_notifier_provider.g.dart';
@@ -19,23 +20,132 @@ class NotificationsNotifier extends _$NotificationsNotifier {
     return PaginationState.fromIterable(response);
   }
 
+  List<INotificationsResponse> _foldNotifications(
+    Iterable<INotificationsResponse> notifications,
+  ) {
+    return notifications.fold(
+      [],
+      (acc, notification) => switch (notification.type) {
+        NotificationType.reaction => switch (acc.lastOrNull) {
+            final previousNotification? => switch (previousNotification.type) {
+                NotificationType.reaction => [
+                    ...acc.toList().sublist(0, acc.length - 1),
+                    if (previousNotification.note?.id == notification.note?.id)
+                      previousNotification.copyWith(
+                        id: notification.id,
+                        type: NotificationType.reactionGrouped,
+                        reaction: null,
+                        user: null,
+                        reactions: [
+                          if (previousNotification
+                              case INotificationsResponse(
+                                :final user?,
+                                :final reaction?
+                              ))
+                            INotificationsReaction(
+                              user: user,
+                              reaction: reaction,
+                            ),
+                          if (notification
+                              case INotificationsResponse(
+                                :final user?,
+                                :final reaction?
+                              ))
+                            INotificationsReaction(
+                              user: user,
+                              reaction: reaction,
+                            ),
+                        ],
+                      )
+                    else ...[previousNotification, notification],
+                  ],
+                NotificationType.reactionGrouped => [
+                    ...acc.toList().sublist(0, acc.length - 1),
+                    if (previousNotification.note?.id == notification.note?.id)
+                      previousNotification.copyWith(
+                        id: notification.id,
+                        reactions: [
+                          ...?previousNotification.reactions,
+                          if (notification
+                              case INotificationsResponse(
+                                :final user?,
+                                :final reaction?
+                              ))
+                            INotificationsReaction(
+                              user: user,
+                              reaction: reaction,
+                            ),
+                        ],
+                      )
+                    else ...[previousNotification, notification],
+                  ],
+                _ => [...acc, notification],
+              },
+            _ => [...acc, notification],
+          },
+        NotificationType.renote => switch (acc.lastOrNull) {
+            final previousNotification? => switch (previousNotification.type) {
+                NotificationType.renote => [
+                    ...acc.toList().sublist(0, acc.length - 1),
+                    if (previousNotification.note?.renoteId ==
+                        notification.note?.renoteId)
+                      previousNotification.copyWith(
+                        id: notification.id,
+                        type: NotificationType.renoteGrouped,
+                        userId: null,
+                        user: null,
+                        users: [previousNotification.user, notification.user]
+                            .nonNulls
+                            .toList(),
+                      )
+                    else ...[previousNotification, notification],
+                  ],
+                NotificationType.renoteGrouped => [
+                    ...acc.toList().sublist(0, acc.length - 1),
+                    if (previousNotification.note?.renoteId ==
+                        notification.note?.renoteId)
+                      previousNotification.copyWith(
+                        id: notification.id,
+                        users: [
+                          ...?previousNotification.users,
+                          notification.user,
+                        ].nonNulls.toList(),
+                      )
+                    else ...[previousNotification, notification],
+                  ],
+                _ => [...acc, notification],
+              },
+            _ => [...acc, notification],
+          },
+        _ => [...acc, notification],
+      },
+    );
+  }
+
   Future<Iterable<INotificationsResponse>> _fetchNotifications({
     String? untilId,
   }) async {
-    final notifications =
-        ref.read(generalSettingsNotifierProvider).useGroupedNotifications
-            ? await ref.read(misskeyProvider(account)).i.notificationsGrouped(
-                  INotificationsGroupedRequest(
-                    untilId: untilId,
-                    limit: 20,
-                  ),
-                )
-            : await ref.read(misskeyProvider(account)).i.notifications(
-                  INotificationsRequest(
-                    untilId: untilId,
-                    limit: 20,
-                  ),
+    final Iterable<INotificationsResponse> notifications;
+    if (ref.read(generalSettingsNotifierProvider).useGroupedNotifications) {
+      final endpoints = await ref.read(endpointsProvider(account.host).future);
+      if (endpoints.contains('i/notifications-grouped')) {
+        notifications =
+            await ref.read(misskeyProvider(account)).i.notificationsGrouped(
+                  INotificationsGroupedRequest(untilId: untilId, limit: 20),
                 );
+      } else {
+        final response = await ref
+            .read(misskeyProvider(account))
+            .i
+            .notifications(INotificationsRequest(untilId: untilId, limit: 20));
+        notifications = _foldNotifications(response);
+      }
+    } else {
+      notifications = await ref
+          .read(misskeyProvider(account))
+          .i
+          .notifications(INotificationsRequest(untilId: untilId, limit: 20));
+    }
     ref.read(notesNotifierProvider(account).notifier).addAll(
           notifications.map((notification) => notification.note).nonNulls,
         );

--- a/lib/provider/api/notifications_notifier_provider.g.dart
+++ b/lib/provider/api/notifications_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'notifications_notifier_provider.dart';
 // **************************************************************************
 
 String _$notificationsNotifierHash() =>
-    r'a846d8448c9c1c4010b991233ba83f679abc3edb';
+    r'fc5677a1a6366835cb145027398178c2ff0dfded';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
If `useGroupedNotifications` is enabled and the server doesn't have `i/notifications-grouped` endpoint, create grouped notifications from response from `i/notifications`.