### PR TITLE
fix: add quote button setting to appearance page

### DIFF
--- a/lib/view/page/settings/note_display_page.dart
+++ b/lib/view/page/settings/note_display_page.dart
@@ -218,6 +218,13 @@ class NoteDisplayPage extends HookConsumerWidget {
                       .setShowAvatarDecorations(value),
                 ),
                 SwitchListTile(
+                  title: Text(t.aria.showQuoteButtonInNoteFooter),
+                  value: settings.showQuoteButtonInNoteFooter,
+                  onChanged: (value) => ref
+                      .read(generalSettingsNotifierProvider.notifier)
+                      .setShowQuoteButtonInNoteFooter(value),
+                ),
+                SwitchListTile(
                   title: Text(t.aria.showLikeButtonInNoteFooter),
                   value: settings.showLikeButtonInNoteFooter,
                   onChanged: (value) => ref


### PR DESCRIPTION
Add a missing switch for `showQuoteButtonInNoteFooter` setting.