### PR TITLE
fix: use svg if path part of the url ends with .svg

### DIFF
--- a/lib/view/widget/image_widget.dart
+++ b/lib/view/widget/image_widget.dart
@@ -69,7 +69,7 @@ class ImageWidget extends ConsumerWidget {
         );
       }
     }
-    if (url.endsWith('.svg')) {
+    if (url.split('?').first.endsWith('.svg')) {
       return FutureBuilder(
         future: ref.read(cacheManagerProvider).getSingleFile(url),
         builder: (context, snapshot) {


### PR DESCRIPTION
Changed to use `SvgPicture` only if the image url before `?` ends with `.svg`.

For example, an image url `https://example.tld/image.svg` can be converted to `https://example.tld/proxy/preview.webp?url=https://example.tld/image.svg` with a media proxy.
The proxied url directs to a webp image file, so it should not be parsed as a svg image.