### PR TITLE
fix: open remote users page on tap mention

### DIFF
--- a/lib/view/widget/mention_widget.dart
+++ b/lib/view/widget/mention_widget.dart
@@ -35,7 +35,7 @@ class MentionWidget extends ConsumerWidget {
     final url = 'https://${account.host}/avatar/@$username@$host';
     final colors =
         ref.watch(misskeyColorsProvider(Theme.of(context).brightness));
-    final isLocal = account.host == host.toLowerCase();
+    final isLocal = account.host.toLowerCase() == host.toLowerCase();
     final isMe = isLocal && account.username == username.toLowerCase();
     final color = isMe ? colors.mentionMe : colors.mention;
 

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -6,10 +6,8 @@ import 'package:mfm_parser/mfm_parser.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../model/account.dart';
-import '../../provider/api/user_notifier_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
-import '../../util/future_with_dialog.dart';
 import '../../util/navigate.dart';
 import 'custom_emoji.dart';
 import 'mention_widget.dart';
@@ -71,19 +69,10 @@ List<InlineSpan> buildMfm(
             account: account,
             username: username,
             host: absoluteHost,
-            onTap: () async {
-              final user = await futureWithDialog(
-                ref.context,
-                ref.read(
-                  userNotifierProvider(account, username: username, host: host)
-                      .future,
-                ),
-              );
-              if (!ref.context.mounted) return;
-              if (user != null) {
-                await ref.context.push('/$account/users/${user.id}');
-              }
-            },
+            onTap: () =>
+                account.host.toLowerCase() == absoluteHost.toLowerCase()
+                    ? ref.context.push('/$account/@$username')
+                    : ref.context.push('/$account/@$username@$absoluteHost'),
           ),
         ),
       );


### PR DESCRIPTION
When a mention in a remote note to a user in the same server is tapped, open the user page of the remote server.