### PR TITLE
fix: collapse renoted long notes

### DIFF
--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -169,8 +169,8 @@ class NoteWidget extends HookConsumerWidget {
           : null,
       [parsed],
     );
-    final isLong =
-        note.cw == null && ref.watch(noteIsLongProvider(account, noteId));
+    final isLong = appearNote.cw == null &&
+        ref.watch(noteIsLongProvider(account, appearNote.id));
     final isCollapsed = useState(appearNote.cw == null && isLong);
     final showTicker = ref.watch(
       generalSettingsNotifierProvider.select(


### PR DESCRIPTION
Changed to collapse renotes if targeted notes are long.