### PR TITLE
fix: use key to prevent reuse of note state

### DIFF
--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -229,6 +229,9 @@ class TimelineListView extends HookConsumerWidget {
                     itemBuilder: (context, index) => Material(
                       color: Theme.of(context).colorScheme.surface,
                       child: TimelineNote(
+                        key: ValueKey(
+                          previousNotes.valueOrNull!.items[index].id,
+                        ),
                         tabSettings: tabSettings,
                         noteId: nextNotes
                             .valueOrNull!
@@ -270,6 +273,9 @@ class TimelineListView extends HookConsumerWidget {
                     itemBuilder: (context, index) => Material(
                       color: Theme.of(context).colorScheme.surface,
                       child: TimelineNote(
+                        key: ValueKey(
+                          previousNotes.valueOrNull!.items[index].id,
+                        ),
                         tabSettings: tabSettings,
                         noteId: previousNotes.valueOrNull!.items[index].id,
                         postFormFocusNode: postFormFocusNode,


### PR DESCRIPTION
Supply `TimelineNote` with `ValueKey` of the note id.
This change will prevent the issue where when the index of a note in `TimelineListView` changes, statuses like the note is muted are applied to the adjacent note.