### PR TITLE
fix: replace unnecessary null check for i

### DIFF
--- a/lib/view/widget/timeline_menu.dart
+++ b/lib/view/widget/timeline_menu.dart
@@ -38,7 +38,7 @@ class TimelineMenu extends ConsumerWidget {
           ),
           childrenDelegate: SliverChildListDelegate.fixed(
             [
-              if (i != null)
+              if (!account.isGuest)
                 Card(
                   clipBehavior: Clip.hardEdge,
                   child: InkWell(
@@ -54,7 +54,7 @@ class TimelineMenu extends ConsumerWidget {
                         Stack(
                           children: [
                             const Icon(Icons.notifications),
-                            if (i.hasUnreadNotification)
+                            if (i?.hasUnreadNotification ?? false)
                               DecoratedBox(
                                 decoration: BoxDecoration(
                                   shape: BoxShape.circle,

--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -72,7 +72,7 @@ class TimelineWidget extends HookConsumerWidget {
       },
       [],
     );
-    if (i != null) {
+    if (!account.isGuest) {
       ref.listen(
         mainStreamNotifierProvider(account),
         (_, next) => next.whenData(


### PR DESCRIPTION
Removed use of `if (i != null)` for a condition of showing buttons and replaced with `if (!account.isGuest)`.
These checks are meant to hide unusable buttons for guest users and `i` can be `null` even if `token` is available due to server conditions.

ref: #151 