### PR TITLE
fix: catch error for api call by user

### DIFF
--- a/lib/view/widget/note_sheet.dart
+++ b/lib/view/widget/note_sheet.dart
@@ -387,6 +387,7 @@ class NoteSheet extends ConsumerWidget {
                     context,
                     message: t.misskey.deleteAndEditConfirm,
                   );
+                  if (!context.mounted) return;
                   if (confirmed) {
                     ref
                         .read(postNotifierProvider(account).notifier)
@@ -396,10 +397,15 @@ class NoteSheet extends ConsumerWidget {
                             (file) => DrivePostFile.fromDriveFile(file),
                           ),
                         );
-                    await ref
-                        .read(misskeyProvider(account))
-                        .notes
-                        .delete(NotesDeleteRequest(noteId: appearNote.id));
+                    final deleted = await futureWithDialog(
+                      context,
+                      ref
+                          .read(misskeyProvider(account))
+                          .notes
+                          .delete(NotesDeleteRequest(noteId: appearNote.id))
+                          .then((_) => true),
+                    );
+                    if (!(deleted ?? false)) return;
                     ref
                         .read(notesNotifierProvider(account).notifier)
                         .remove(appearNote.id);
@@ -424,14 +430,20 @@ class NoteSheet extends ConsumerWidget {
                     context,
                     message: t.misskey.noteDeleteConfirm,
                   );
+                  if (!context.mounted) return;
                   if (confirmed) {
-                    await ref
-                        .read(misskeyProvider(account))
-                        .notes
-                        .delete(NotesDeleteRequest(noteId: appearNote.id));
-                    ref
-                        .read(notesNotifierProvider(account).notifier)
-                        .remove(appearNote.id);
+                    await futureWithDialog(
+                      context,
+                      ref
+                          .read(misskeyProvider(account))
+                          .notes
+                          .delete(NotesDeleteRequest(noteId: appearNote.id))
+                          .then(
+                            (_) => ref
+                                .read(notesNotifierProvider(account).notifier)
+                                .remove(appearNote.id),
+                          ),
+                    );
                     if (!context.mounted) return;
                     context.pop();
                   }
@@ -442,13 +454,19 @@ class NoteSheet extends ConsumerWidget {
                   leading: const Icon(Icons.delete),
                   title: Text(t.misskey.unrenote),
                   onTap: () async {
-                    await ref
-                        .read(misskeyProvider(account))
-                        .notes
-                        .delete(NotesDeleteRequest(noteId: noteId));
-                    ref
-                        .read(notesNotifierProvider(account).notifier)
-                        .remove(noteId);
+                    await futureWithDialog(
+                      context,
+                      ref
+                          .read(misskeyProvider(account))
+                          .notes
+                          .delete(NotesDeleteRequest(noteId: noteId))
+                          .then(
+                            (_) => ref
+                                .read(notesNotifierProvider(account).notifier)
+                                .remove(noteId),
+                          ),
+                    );
+
                     if (!context.mounted) return;
                     context.pop();
                   },

--- a/lib/view/widget/user_sheet.dart
+++ b/lib/view/widget/user_sheet.dart
@@ -171,14 +171,17 @@ class UserSheet extends ConsumerWidget {
                 if (destination.host == account.host) {
                   await context.push('/$destination/users/$userId');
                 } else {
-                  final userAsLocal = await ref.read(
-                    userNotifierProvider(
-                      destination,
-                      username: user.username,
-                      host: user.host ?? account.host,
-                    ).future,
+                  final userAsLocal = await futureWithDialog(
+                    context,
+                    ref.read(
+                      userNotifierProvider(
+                        destination,
+                        username: user.username,
+                        host: user.host ?? account.host,
+                      ).future,
+                    ),
                   );
-                  if (!context.mounted) return;
+                  if (!context.mounted || userAsLocal == null) return;
                   await context.push('/$destination/users/${userAsLocal.id}');
                 }
               },
@@ -205,11 +208,15 @@ class UserSheet extends ConsumerWidget {
                 );
                 if (!context.mounted) return;
                 if (memo != null) {
-                  await ref
-                      .read(
-                        userNotifierProvider(account, userId: userId).notifier,
-                      )
-                      .updateMemo(memo);
+                  await futureWithDialog(
+                    context,
+                    ref
+                        .read(
+                          userNotifierProvider(account, userId: userId)
+                              .notifier,
+                        )
+                        .updateMemo(memo),
+                  );
                 }
               },
             ),


### PR DESCRIPTION
Wrapped api calls in `onTap` callbacks in `NoteSheet` and `UserSheet` with `futureWithDialog()`.