### PR TITLE
fix: disable intra-app predictive back

### DIFF
--- a/lib/provider/theme_data_provider.dart
+++ b/lib/provider/theme_data_provider.dart
@@ -89,12 +89,5 @@ ThemeData themeData(ThemeDataRef ref, Brightness brightness) {
     ),
     sliderTheme:
         const SliderThemeData(showValueIndicator: ShowValueIndicator.always),
-    pageTransitionsTheme: const PageTransitionsTheme(
-      builders: {
-        TargetPlatform.android: PredictiveBackPageTransitionsBuilder(),
-        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-        TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
-      },
-    ),
   );
 }

--- a/lib/provider/theme_data_provider.g.dart
+++ b/lib/provider/theme_data_provider.g.dart
@@ -6,7 +6,7 @@ part of 'theme_data_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$themeDataHash() => r'34c8a09a41a01f8fde33bc9d24f0be096b3a015c';
+String _$themeDataHash() => r'0bd2c8f88640d19386ed76d6bfd165aa1d6a3273';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
When using `PredictiveBackPageTransitionsBuilder`, after pushing another page and popping back to `TimelinesPage`, `PostForm` loses the focus and will never get focused again.

Maybe related to `https://github.com/flutter/flutter/issues/148573`.