### PR TITLE
fix: skip if failed to load token

### DIFF
--- a/lib/provider/tokens_notifier_provider.dart
+++ b/lib/provider/tokens_notifier_provider.dart
@@ -14,15 +14,17 @@ class TokensNotifier extends _$TokensNotifier {
   }
 
   Future<void> load(Account account) async {
-    final token = await ref.read(tokenRepositoryProvider).readToken(account);
-    if (token == null) {
-      await ref.read(accountsNotifierProvider.notifier).remove(account);
-    } else {
-      state = {
-        ...state,
-        account: token,
-      };
-    }
+    try {
+      final token = await ref.read(tokenRepositoryProvider).readToken(account);
+      if (token != null) {
+        state = {
+          ...state,
+          account: token,
+        };
+      } else {
+        await ref.read(accountsNotifierProvider.notifier).remove(account);
+      }
+    } catch (_) {}
   }
 
   Future<void> add(Account account, String token) async {

--- a/lib/provider/tokens_notifier_provider.g.dart
+++ b/lib/provider/tokens_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'tokens_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tokensNotifierHash() => r'f3b4497e1d0ad81122e0857f8544b1a8521d5abd';
+String _$tokensNotifierHash() => r'b1337d2c48e7762430a75b2f175bf7d89718b996';
 
 /// See also [TokensNotifier].
 @ProviderFor(TokensNotifier)


### PR DESCRIPTION
If the secure storage throws an error when loading a token, return null for the account.