### PR TITLE
fix: mark notifications as read when open

### DIFF
--- a/lib/view/widget/notifications_list_view.dart
+++ b/lib/view/widget/notifications_list_view.dart
@@ -48,6 +48,7 @@ class NotificationsListView extends HookConsumerWidget {
         ref
             .read(notificationsLastViewedAtNotifierProvider(account).notifier)
             .save(DateTime.now());
+        ref.read(iNotifierProvider(account).notifier).readNotifications();
         controller.addListener(() {
           if (controller.position.extentBefore == 0) {
             hasNewNotification.value = false;

--- a/lib/view/widget/timeline_drawer.dart
+++ b/lib/view/widget/timeline_drawer.dart
@@ -125,12 +125,7 @@ class TimelineDrawer extends HookConsumerWidget {
                   ],
                 ),
                 title: Text(t.misskey.notifications),
-                onTap: () {
-                  ref
-                      .read(iNotifierProvider(account).notifier)
-                      .readNotifications();
-                  context.push('/$account/notifications');
-                },
+                onTap: () => context.push('/$account/notifications'),
               ),
               ListTile(
                 leading: const Icon(Icons.attach_file),

--- a/lib/view/widget/timeline_menu.dart
+++ b/lib/view/widget/timeline_menu.dart
@@ -42,12 +42,7 @@ class TimelineMenu extends ConsumerWidget {
                 Card(
                   clipBehavior: Clip.hardEdge,
                   child: InkWell(
-                    onTap: () {
-                      ref
-                          .read(iNotifierProvider(account).notifier)
-                          .readNotifications();
-                      context.push('/$account/notifications');
-                    },
+                    onTap: () => context.push('/$account/notifications'),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [


### PR DESCRIPTION
When opening a notifications tab, set `hasUnreadNotification` to `true` and hide the badge on the notifications icon.