### PR TITLE
fix: add space between note and replies

### DIFF
--- a/lib/view/widget/note_detailed_widget.dart
+++ b/lib/view/widget/note_detailed_widget.dart
@@ -510,7 +510,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                           valueOrNull: PaginationState(items: final notes),
                         ))
                       Container(
-                        margin: const EdgeInsets.only(left: 8.0),
+                        margin: const EdgeInsets.only(left: 8.0, top: 8.0),
                         decoration: BoxDecoration(
                           border: Border(
                             left: BorderSide(


### PR DESCRIPTION
In `NodeDetailedWidget`, added a margin on top of replies to add more
space around action buttons.