### PR TITLE
fix: press enter to confirm

### DIFF
--- a/lib/view/dialog/confirmation_dialog.dart
+++ b/lib/view/dialog/confirmation_dialog.dart
@@ -49,6 +49,7 @@ class ConfirmationDialog extends StatelessWidget {
       content: content ?? Text(message ?? ''),
       actions: [
         ElevatedButton(
+          autofocus: true,
           onPressed: () => context.pop(true),
           child: Text(okText ?? t.misskey.ok),
         ),

--- a/lib/view/dialog/error_message_dialog.dart
+++ b/lib/view/dialog/error_message_dialog.dart
@@ -25,6 +25,7 @@ class ErrorMessageDialog extends StatelessWidget {
       ),
       actions: [
         TextButton(
+          autofocus: true,
           onPressed: () => context.pop(),
           child: Text(t.misskey.gotIt),
         ),

--- a/lib/view/dialog/message_dialog.dart
+++ b/lib/view/dialog/message_dialog.dart
@@ -24,6 +24,7 @@ class MessageDialog extends StatelessWidget {
       content: Text(message),
       actions: [
         ElevatedButton(
+          autofocus: true,
           onPressed: () => context.pop(),
           child: Text(t.misskey.gotIt),
         ),

--- a/lib/view/dialog/post_confirmation_dialog.dart
+++ b/lib/view/dialog/post_confirmation_dialog.dart
@@ -61,8 +61,9 @@ class PostConfirmationDialog extends ConsumerWidget {
     final note = request.toNote(i: i, channel: channel);
 
     return Dialog(
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
+      child: Container(
+        width: 800.0,
+        margin: const EdgeInsets.all(8.0),
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -96,6 +97,7 @@ class PostConfirmationDialog extends ConsumerWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       ElevatedButton(
+                        autofocus: true,
                         onPressed: () => context.pop(true),
                         child: Text(t.misskey.ok),
                       ),

--- a/lib/view/dialog/reaction_confirmation_dialog.dart
+++ b/lib/view/dialog/reaction_confirmation_dialog.dart
@@ -79,6 +79,7 @@ class ReactionConfirmationDialog extends ConsumerWidget {
       ),
       actions: [
         ElevatedButton(
+          autofocus: true,
           onPressed: () => context.pop(true),
           child: Text(t.misskey.ok),
         ),


### PR DESCRIPTION
Added autofocus to confirmation buttons of dialogs to make it easy to proceed by　pressing the enter key on the keyboard.