### PR TITLE
fix: add space on pages with extended FABs

### DIFF
--- a/lib/view/page/channel/channel_home.dart
+++ b/lib/view/page/channel/channel_home.dart
@@ -242,6 +242,7 @@ class ChannelHome extends ConsumerWidget {
             ),
             itemCount: channel.pinnedNoteIds.length,
           ),
+          const SliverToBoxAdapter(child: SizedBox(height: 80.0)),
         ],
       ),
     );

--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -978,6 +978,7 @@ class PostPage extends HookConsumerWidget {
                                   showFooter: false,
                                 ),
                         ),
+                        const SizedBox(height: 80.0),
                       ],
                     ),
                   ),

--- a/lib/view/page/settings/accounts_page.dart
+++ b/lib/view/page/settings/accounts_page.dart
@@ -25,30 +25,40 @@ class AccountsPage extends HookConsumerWidget {
           ? Center(child: Text(t.aria.noAccounts))
           : ReorderableListView.builder(
               itemBuilder: (context, index) {
-                final account = accounts[index];
-                final i = ref.watch(iNotifierProvider(account)).valueOrNull;
-                return ReorderableDragStartListenerWrapper(
-                  key: ValueKey(index),
-                  index: index,
-                  child: Card(
-                    color: Theme.of(context).colorScheme.surface,
-                    elevation: 0.0,
-                    clipBehavior: Clip.hardEdge,
-                    child: ListTile(
-                      leading: i != null
-                          ? UserAvatar(account: account, user: i, size: 40.0)
-                          : null,
-                      title: i != null
-                          ? UsernameWidget(account: account, user: i)
-                          : null,
-                      subtitle: Text(account.toString()),
-                      trailing: const Icon(Icons.drag_handle),
-                      onTap: () => context.push('/settings/accounts/$account'),
+                if (index < accounts.length) {
+                  final account = accounts[index];
+                  final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+                  return ReorderableDragStartListenerWrapper(
+                    key: ValueKey(index),
+                    index: index,
+                    child: Card(
+                      color: Theme.of(context).colorScheme.surface,
+                      elevation: 0.0,
+                      clipBehavior: Clip.hardEdge,
+                      child: ListTile(
+                        leading: i != null
+                            ? UserAvatar(account: account, user: i, size: 40.0)
+                            : null,
+                        title: i != null
+                            ? UsernameWidget(account: account, user: i)
+                            : null,
+                        subtitle: Text(account.toString()),
+                        trailing: const Icon(Icons.drag_handle),
+                        onTap: () =>
+                            context.push('/settings/accounts/$account'),
+                      ),
                     ),
-                  ),
-                );
+                  );
+                } else {
+                  return ReorderableDragStartListener(
+                    key: ValueKey(index),
+                    index: index,
+                    enabled: false,
+                    child: const SizedBox(height: 80.0),
+                  );
+                }
               },
-              itemCount: accounts.length,
+              itemCount: accounts.length + 1,
               onReorder: (oldIndex, newIndex) => ref
                   .read(accountsNotifierProvider.notifier)
                   .reorder(oldIndex, newIndex),

--- a/lib/view/page/settings/tab_settings_page.dart
+++ b/lib/view/page/settings/tab_settings_page.dart
@@ -692,6 +692,7 @@ class TabSettingsPage extends HookConsumerWidget {
                         tabSettings.value.copyWith(withSensitive: value),
                   ),
                 ],
+                const SizedBox(height: 80.0),
               ],
             ),
           ),

--- a/lib/view/page/settings/theme_manage_page.dart
+++ b/lib/view/page/settings/theme_manage_page.dart
@@ -81,10 +81,9 @@ class ThemeManagePage extends ConsumerWidget {
         child: SizedBox(
           width: 800.0,
           child: codes.isNotEmpty
-              ? ListView(
-                  children: List.generate(
-                    codes.length,
-                    (index) {
+              ? ListView.builder(
+                  itemBuilder: (context, index) {
+                    if (index < codes.length) {
                       final theme = themes[index];
                       return ExpansionTile(
                         leading: Icon(
@@ -185,8 +184,11 @@ class ThemeManagePage extends ConsumerWidget {
                           ),
                         ],
                       );
-                    },
-                  ),
+                    } else {
+                      return const SizedBox(height: 80.0);
+                    }
+                  },
+                  itemCount: codes.length + 1,
                 )
               : Center(child: Text(t.aria.noThemes)),
         ),


### PR DESCRIPTION
Added space on the bottom of the pages that has floating action buttons with labels to prevent the contents from being overwrapped by the buttons.

Fix #182 