### PR TITLE
fix: check if notes from stream are already stored

### DIFF
--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -19,7 +19,7 @@ class NotesNotifier extends _$NotesNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  void add(Note note) {
+  Note? add(Note note) {
     final renote = note.renote;
     if (renote != null) {
       add(renote);
@@ -40,6 +40,7 @@ class NotesNotifier extends _$NotesNotifier {
         poll: note.poll ?? cachedNote?.poll,
       ),
     };
+    return cachedNote;
   }
 
   void addAll(Iterable<Note> notes) {

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'bde83693e280d4ff0087760981c7da280697c908';
+String _$notesNotifierHash() => r'c8f1103ce9fd085b1e897d2728f2d6fa2c0ac8be';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/streaming/timeline_stream_notifier.dart
+++ b/lib/provider/streaming/timeline_stream_notifier.dart
@@ -40,10 +40,12 @@ class TimelineStreamNotifier extends _$TimelineStreamNotifier {
           final event = message.body;
           if (event['type'] == 'note') {
             final note = Note.fromJson(event['body'] as Map<String, dynamic>);
-            ref
+            final cachedNote = ref
                 .read(notesNotifierProvider(tabSettings.account).notifier)
                 .add(note);
-            yield note;
+            if (cachedNote == null) {
+              yield note;
+            }
           }
         }
       case TabType.mention || TabType.direct:

--- a/lib/provider/streaming/timeline_stream_notifier.g.dart
+++ b/lib/provider/streaming/timeline_stream_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_stream_notifier.dart';
 // **************************************************************************
 
 String _$timelineStreamNotifierHash() =>
-    r'5e07d109037456c16812941128bd4ac7cb6172e6';
+    r'fdd6fb86433fe67f39a705b253b3c1091a337b24';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
When a note from a streaming channel is received, yield it only if `NotesNotifier` does not have a note with its id.
This prevents notes on timelines from being duplicated.