### PR TITLE
fix: use correct endpoint to unmute

### DIFF
--- a/lib/provider/api/mutings_notifier_provider.dart
+++ b/lib/provider/api/mutings_notifier_provider.dart
@@ -40,7 +40,7 @@ class MutingsNotifier extends _$MutingsNotifier {
   }
 
   Future<void> delete(String userId) async {
-    await _misskey.blocking.delete(BlockDeleteRequest(userId: userId));
+    await _misskey.mute.delete(MuteDeleteRequest(userId: userId));
     final value = state.valueOrNull;
     if (value != null) {
       state = AsyncValue.data(

--- a/lib/provider/api/mutings_notifier_provider.g.dart
+++ b/lib/provider/api/mutings_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'mutings_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$mutingsNotifierHash() => r'a19972d00e7ebed464f2415fdc5280a0c938a561';
+String _$mutingsNotifierHash() => r'92fc7ab2e0152e40bcf4e285375c58ece0b1aa29';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
In `MutedUsersPage`, call `mute/delete` instead of `blocking/delete` when a delete button for the muted user is tapped.