### PR TITLE
fix: remove host when coping local emoji

### DIFF
--- a/lib/view/widget/emoji_sheet.dart
+++ b/lib/view/widget/emoji_sheet.dart
@@ -75,7 +75,7 @@ class EmojiSheet extends ConsumerWidget {
         ListTile(
           leading: const Icon(Icons.copy),
           title: Text(t.misskey.copy),
-          onTap: () => copyToClipboard(context, emoji),
+          onTap: () => copyToClipboard(context, emoji.replaceAll('@.', '')),
         ),
         if (canReact)
           ListTile(


### PR DESCRIPTION
When the "Copy" button in `EmojiSheet` is tapped, copy the name with the trailing `@.` removed.