### PR TITLE
fix: change scroll physics to clamping

### DIFF
--- a/lib/view/widget/notifications_list_view.dart
+++ b/lib/view/widget/notifications_list_view.dart
@@ -24,10 +24,12 @@ class NotificationsListView extends HookConsumerWidget {
     super.key,
     required this.account,
     this.controller,
+    this.physics,
   });
 
   final Account account;
   final ScrollController? controller;
+  final ScrollPhysics? physics;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -105,6 +107,7 @@ class NotificationsListView extends HookConsumerWidget {
               margin: const EdgeInsets.symmetric(horizontal: 8.0),
               child: CustomScrollView(
                 controller: controller,
+                physics: physics,
                 center: centerKey,
                 slivers: [
                   if ((notifications.valueOrNull?.items.isNotEmpty ?? false) ||

--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -26,11 +26,13 @@ class TimelineListView extends HookConsumerWidget {
   const TimelineListView({
     super.key,
     required this.tabSettings,
+    this.physics,
     this.postFormFocusNode,
     this.lastViewedAtKey,
   });
 
   final TabSettings tabSettings;
+  final ScrollPhysics? physics;
   final FocusNode? postFormFocusNode;
   final Key? lastViewedAtKey;
 
@@ -41,6 +43,7 @@ class TimelineListView extends HookConsumerWidget {
       return NotificationsListView(
         account: tabSettings.account,
         controller: controller,
+        physics: physics,
       );
     }
     final centerId = ref.watch(timelineCenterNotifierProvider(tabSettings));
@@ -192,8 +195,9 @@ class TimelineListView extends HookConsumerWidget {
               width: 800.0,
               margin: const EdgeInsets.symmetric(horizontal: 8.0),
               child: CustomScrollView(
-                center: centerKey,
                 controller: controller,
+                physics: physics,
+                center: centerKey,
                 slivers: [
                   if (centerId != null)
                     SliverToBoxAdapter(

--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -291,6 +291,7 @@ class TimelineWidget extends HookConsumerWidget {
               Expanded(
                 child: TimelineListView(
                   tabSettings: tabSettings,
+                  physics: const ClampingScrollPhysics(),
                   postFormFocusNode: postFormFocusNode,
                   lastViewedAtKey: lastViewedAtKey,
                 ),


### PR DESCRIPTION
Changed scroll physics of timelines on the main page to `ClampingScrollPhysics`.

With `BouncingScrollPhysics` of iOS, the tab header gets hidden after triggering pull-to-refresh.
