### PR TITLE
fix: pick single file from device

### DIFF
--- a/lib/view/page/settings/profile_page.dart
+++ b/lib/view/page/settings/profile_page.dart
@@ -83,7 +83,7 @@ class ProfilePage extends HookConsumerWidget {
                   folderId: folderId,
                   force: true,
                 ),
-                data,
+                cropped,
               ),
         );
         return file;

--- a/lib/view/widget/file_picker_sheet.dart
+++ b/lib/view/widget/file_picker_sheet.dart
@@ -53,7 +53,7 @@ class FilePickerSheet extends ConsumerWidget {
               } else if (files.length == 1) {
                 context.pop(
                   LocalPostFile.fromFile(
-                    ref.read(fileSystemProvider).file(files.single),
+                    ref.read(fileSystemProvider).file(files.single.path),
                   ),
                 );
               }


### PR DESCRIPTION
Fixed the argument of `FileSystem.file()`.

Also changed to use cropped images when changing avatar or banner images.