### PR TITLE
fix: make query of MFM search scrollable

### DIFF
--- a/lib/view/widget/mfm/search.dart
+++ b/lib/view/widget/mfm/search.dart
@@ -23,7 +23,10 @@ class Search extends HookWidget {
           Expanded(
             child: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: SelectableText(query),
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SelectableText(query),
+              ),
             ),
           ),
           Material(


### PR DESCRIPTION
To avoid long queries from being displayed in multiple lines, wrapped the text with scroll view.