### PR TITLE
feat: support editing excludeBots option of antennas

### DIFF
--- a/lib/model/antenna_settings.dart
+++ b/lib/model/antenna_settings.dart
@@ -17,6 +17,7 @@ class AntennaSettings with _$AntennaSettings {
     bool? localOnly,
     bool? caseSensitive,
     bool? withFile,
+    bool? excludeBots,
   }) = _AntennaSettings;
 
   factory AntennaSettings.fromJson(Map<String, dynamic> json) =>
@@ -34,6 +35,7 @@ class AntennaSettings with _$AntennaSettings {
       localOnly: antenna.localOnly,
       caseSensitive: antenna.caseSensitive,
       withFile: antenna.withFile,
+      excludeBots: antenna.excludeBots,
     );
   }
 }

--- a/lib/model/antenna_settings.freezed.dart
+++ b/lib/model/antenna_settings.freezed.dart
@@ -30,6 +30,7 @@ mixin _$AntennaSettings {
   bool? get localOnly => throw _privateConstructorUsedError;
   bool? get caseSensitive => throw _privateConstructorUsedError;
   bool? get withFile => throw _privateConstructorUsedError;
+  bool? get excludeBots => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -53,7 +54,8 @@ abstract class $AntennaSettingsCopyWith<$Res> {
       List<List<String>>? excludeKeywords,
       bool? localOnly,
       bool? caseSensitive,
-      bool? withFile});
+      bool? withFile,
+      bool? excludeBots});
 }
 
 /// @nodoc
@@ -79,6 +81,7 @@ class _$AntennaSettingsCopyWithImpl<$Res, $Val extends AntennaSettings>
     Object? localOnly = freezed,
     Object? caseSensitive = freezed,
     Object? withFile = freezed,
+    Object? excludeBots = freezed,
   }) {
     return _then(_value.copyWith(
       name: freezed == name
@@ -121,6 +124,10 @@ class _$AntennaSettingsCopyWithImpl<$Res, $Val extends AntennaSettings>
           ? _value.withFile
           : withFile // ignore: cast_nullable_to_non_nullable
               as bool?,
+      excludeBots: freezed == excludeBots
+          ? _value.excludeBots
+          : excludeBots // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 }
@@ -143,7 +150,8 @@ abstract class _$$AntennaSettingsImplCopyWith<$Res>
       List<List<String>>? excludeKeywords,
       bool? localOnly,
       bool? caseSensitive,
-      bool? withFile});
+      bool? withFile,
+      bool? excludeBots});
 }
 
 /// @nodoc
@@ -167,6 +175,7 @@ class __$$AntennaSettingsImplCopyWithImpl<$Res>
     Object? localOnly = freezed,
     Object? caseSensitive = freezed,
     Object? withFile = freezed,
+    Object? excludeBots = freezed,
   }) {
     return _then(_$AntennaSettingsImpl(
       name: freezed == name
@@ -209,6 +218,10 @@ class __$$AntennaSettingsImplCopyWithImpl<$Res>
           ? _value.withFile
           : withFile // ignore: cast_nullable_to_non_nullable
               as bool?,
+      excludeBots: freezed == excludeBots
+          ? _value.excludeBots
+          : excludeBots // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -226,7 +239,8 @@ class _$AntennaSettingsImpl implements _AntennaSettings {
       final List<List<String>>? excludeKeywords,
       this.localOnly,
       this.caseSensitive,
-      this.withFile})
+      this.withFile,
+      this.excludeBots})
       : _users = users,
         _keywords = keywords,
         _excludeKeywords = excludeKeywords;
@@ -278,10 +292,12 @@ class _$AntennaSettingsImpl implements _AntennaSettings {
   final bool? caseSensitive;
   @override
   final bool? withFile;
+  @override
+  final bool? excludeBots;
 
   @override
   String toString() {
-    return 'AntennaSettings(name: $name, src: $src, userListId: $userListId, users: $users, withReplies: $withReplies, keywords: $keywords, excludeKeywords: $excludeKeywords, localOnly: $localOnly, caseSensitive: $caseSensitive, withFile: $withFile)';
+    return 'AntennaSettings(name: $name, src: $src, userListId: $userListId, users: $users, withReplies: $withReplies, keywords: $keywords, excludeKeywords: $excludeKeywords, localOnly: $localOnly, caseSensitive: $caseSensitive, withFile: $withFile, excludeBots: $excludeBots)';
   }
 
   @override
@@ -304,7 +320,9 @@ class _$AntennaSettingsImpl implements _AntennaSettings {
             (identical(other.caseSensitive, caseSensitive) ||
                 other.caseSensitive == caseSensitive) &&
             (identical(other.withFile, withFile) ||
-                other.withFile == withFile));
+                other.withFile == withFile) &&
+            (identical(other.excludeBots, excludeBots) ||
+                other.excludeBots == excludeBots));
   }
 
   @JsonKey(ignore: true)
@@ -320,7 +338,8 @@ class _$AntennaSettingsImpl implements _AntennaSettings {
       const DeepCollectionEquality().hash(_excludeKeywords),
       localOnly,
       caseSensitive,
-      withFile);
+      withFile,
+      excludeBots);
 
   @JsonKey(ignore: true)
   @override
@@ -348,7 +367,8 @@ abstract class _AntennaSettings implements AntennaSettings {
       final List<List<String>>? excludeKeywords,
       final bool? localOnly,
       final bool? caseSensitive,
-      final bool? withFile}) = _$AntennaSettingsImpl;
+      final bool? withFile,
+      final bool? excludeBots}) = _$AntennaSettingsImpl;
 
   factory _AntennaSettings.fromJson(Map<String, dynamic> json) =
       _$AntennaSettingsImpl.fromJson;
@@ -373,6 +393,8 @@ abstract class _AntennaSettings implements AntennaSettings {
   bool? get caseSensitive;
   @override
   bool? get withFile;
+  @override
+  bool? get excludeBots;
   @override
   @JsonKey(ignore: true)
   _$$AntennaSettingsImplCopyWith<_$AntennaSettingsImpl> get copyWith =>

--- a/lib/model/antenna_settings.g.dart
+++ b/lib/model/antenna_settings.g.dart
@@ -24,6 +24,7 @@ _$AntennaSettingsImpl _$$AntennaSettingsImplFromJson(
       localOnly: json['localOnly'] as bool?,
       caseSensitive: json['caseSensitive'] as bool?,
       withFile: json['withFile'] as bool?,
+      excludeBots: json['excludeBots'] as bool?,
     );
 
 Map<String, dynamic> _$$AntennaSettingsImplToJson(
@@ -46,6 +47,7 @@ Map<String, dynamic> _$$AntennaSettingsImplToJson(
   writeNotNull('localOnly', instance.localOnly);
   writeNotNull('caseSensitive', instance.caseSensitive);
   writeNotNull('withFile', instance.withFile);
+  writeNotNull('excludeBots', instance.excludeBots);
   return val;
 }
 

--- a/lib/provider/api/antennas_notifier_provider.dart
+++ b/lib/provider/api/antennas_notifier_provider.dart
@@ -25,6 +25,8 @@ class AntennasNotifier extends _$AntennasNotifier {
     bool? caseSensitive,
     bool? withReplies,
     bool? withFile,
+    bool? localOnly,
+    bool? excludeBots,
   }) async {
     final antenna = await _misskey.antennas.create(
       AntennasCreateRequest(
@@ -37,6 +39,8 @@ class AntennasNotifier extends _$AntennasNotifier {
         withReplies: withReplies ?? false,
         withFile: withFile ?? false,
         notify: false,
+        localOnly: localOnly,
+        excludeBots: excludeBots,
       ),
     );
     state = AsyncValue.data([
@@ -55,6 +59,8 @@ class AntennasNotifier extends _$AntennasNotifier {
     bool? caseSensitive,
     bool? withReplies,
     bool? withFile,
+    bool? localOnly,
+    bool? excludeBots,
   }) async {
     await _misskey.antennas.update(
       AntennasUpdateRequest(
@@ -68,6 +74,8 @@ class AntennasNotifier extends _$AntennasNotifier {
         withReplies: withReplies ?? antenna.withReplies ?? false,
         withFile: withFile ?? antenna.withFile ?? false,
         notify: antenna.notify ?? false,
+        localOnly: localOnly ?? antenna.localOnly ?? false,
+        excludeBots: excludeBots ?? antenna.excludeBots ?? false,
       ),
     );
     state = AsyncValue.data([
@@ -82,6 +90,8 @@ class AntennasNotifier extends _$AntennasNotifier {
                 caseSensitive: caseSensitive ?? antenna.caseSensitive,
                 withReplies: withReplies ?? antenna.withReplies,
                 withFile: withFile ?? antenna.withFile,
+                localOnly: localOnly ?? antenna.localOnly,
+                excludeBots: excludeBots ?? antenna.excludeBots,
               )
             : e,
       ),
@@ -110,6 +120,8 @@ class AntennasNotifier extends _$AntennasNotifier {
         withReplies: antenna.withReplies ?? false,
         withFile: antenna.withFile ?? false,
         notify: antenna.notify ?? false,
+        localOnly: antenna.localOnly ?? false,
+        excludeBots: antenna.excludeBots ?? false,
       ),
     );
     state = AsyncValue.data([
@@ -135,6 +147,8 @@ class AntennasNotifier extends _$AntennasNotifier {
         withReplies: antenna.withReplies ?? false,
         withFile: antenna.withFile ?? false,
         notify: antenna.notify ?? false,
+        localOnly: antenna.localOnly ?? false,
+        excludeBots: antenna.excludeBots ?? false,
       ),
     );
     state = AsyncValue.data([

--- a/lib/provider/api/antennas_notifier_provider.g.dart
+++ b/lib/provider/api/antennas_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'antennas_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$antennasNotifierHash() => r'ebd21ad2d92785cd070a1dd717b069b7f2e97d9c';
+String _$antennasNotifierHash() => r'979dac62337df72d94bf7404a120f3902caf6425';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/dialog/antenna_dialog.dart
+++ b/lib/view/dialog/antenna_dialog.dart
@@ -79,6 +79,8 @@ class AntennaDialog extends HookConsumerWidget {
                       caseSensitive: result.caseSensitive,
                       withReplies: result.withReplies,
                       withFile: result.withFile,
+                      localOnly: result.localOnly,
+                      excludeBots: result.excludeBots,
                     ),
               );
             }

--- a/lib/view/dialog/antenna_settings_dialog.dart
+++ b/lib/view/dialog/antenna_settings_dialog.dart
@@ -150,6 +150,12 @@ class AntennaSettingsDialog extends HookConsumerWidget {
               ),
             ),
           SwitchListTile(
+            title: Text(t.misskey.antennaExcludeBots),
+            value: settings.value.excludeBots ?? false,
+            onChanged: (value) =>
+                settings.value = settings.value.copyWith(excludeBots: value),
+          ),
+          SwitchListTile(
             title: Text(t.misskey.withReplies),
             value: settings.value.withReplies ?? false,
             onChanged: (value) =>

--- a/lib/view/page/antenna_page.dart
+++ b/lib/view/page/antenna_page.dart
@@ -50,6 +50,8 @@ class AntennaPage extends ConsumerWidget {
               caseSensitive: result.caseSensitive,
               withReplies: result.withReplies,
               withFile: result.withFile,
+              localOnly: result.localOnly,
+              excludeBots: result.excludeBots,
             ),
       );
     }

--- a/lib/view/page/antennas_page.dart
+++ b/lib/view/page/antennas_page.dart
@@ -102,6 +102,8 @@ class AntennasPage extends ConsumerWidget {
                     caseSensitive: result.caseSensitive,
                     withReplies: result.withReplies,
                     withFile: result.withFile,
+                    localOnly: result.localOnly,
+                    excludeBots: result.excludeBots,
                   ),
             );
           }


### PR DESCRIPTION
Added a switch to set the `excludeBots` option for creating or updating antennas.

Also, we already had a `localOnly` switch, but its value was not used, so fixed to use it.

ref: `https://github.com/misskey-dev/misskey/pull/13603`