### PR TITLE
fix: add hero tags for FABs

### DIFF
--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -228,6 +228,7 @@ class TimelinesPage extends HookConsumerWidget {
                       children: [
                         if (!isLargeScreen)
                           FloatingActionButton(
+                            heroTag: const ValueKey(0),
                             tooltip: t.misskey.menu,
                             foregroundColor: colors.fg,
                             backgroundColor: colors.panel,
@@ -237,6 +238,7 @@ class TimelinesPage extends HookConsumerWidget {
                             child: const Icon(Icons.menu),
                           ),
                         FloatingActionButton(
+                          heroTag: const ValueKey(1),
                           tooltip: t.misskey.home,
                           foregroundColor: colors.fg,
                           backgroundColor: colors.panel,
@@ -253,6 +255,7 @@ class TimelinesPage extends HookConsumerWidget {
                           child: const Icon(Icons.home),
                         ),
                         FloatingActionButton(
+                          heroTag: const ValueKey(2),
                           tooltip: t.misskey.notifications,
                           foregroundColor: colors.fg.withOpacity(
                             tabSettings != null && !tabSettings.account.isGuest
@@ -289,6 +292,7 @@ class TimelinesPage extends HookConsumerWidget {
                           ),
                         ),
                         FloatingActionButton(
+                          heroTag: const ValueKey(3),
                           tooltip: t.aria.showPostForm,
                           foregroundColor: colors.fg.withOpacity(
                             tabSettings != null && !tabSettings.account.isGuest
@@ -309,6 +313,7 @@ class TimelinesPage extends HookConsumerWidget {
                           child: const Icon(Icons.keyboard),
                         ),
                         FloatingActionButton(
+                          heroTag: const ValueKey(4),
                           tooltip: t.misskey.note,
                           onPressed: tabSettings != null &&
                                   !tabSettings.account.isGuest

--- a/lib/view/widget/post_form.dart
+++ b/lib/view/widget/post_form.dart
@@ -246,19 +246,38 @@ class PostForm extends HookConsumerWidget {
         } else {
           visibleUsers.value = [];
         }
-        cwController.addListener(
-          () => ref
+
+        void cwControllerCallback() {
+          ref
               .read(postNotifierProvider(account.value).notifier)
-              .setCw(cwController.text),
-        );
-        controller.addListener(
-          () => ref
+              .setCw(cwController.text);
+        }
+
+        void controllerCallback() {
+          ref
               .read(postNotifierProvider(account.value).notifier)
-              .setText(controller.text),
-        );
-        cwFocusNode.addListener(() => isCwFocused.value = cwFocusNode.hasFocus);
-        focusNode.addListener(() => isFocused.value = focusNode.hasFocus);
-        return;
+              .setText(controller.text);
+        }
+
+        void cwFocusNodeCallback() {
+          isCwFocused.value = cwFocusNode.hasFocus;
+        }
+
+        void focusNodeCallback() {
+          isFocused.value = focusNode.hasFocus;
+        }
+
+        cwController.addListener(cwControllerCallback);
+        controller.addListener(controllerCallback);
+        cwFocusNode.addListener(cwFocusNodeCallback);
+        focusNode.addListener(focusNodeCallback);
+
+        return () {
+          cwController.removeListener(cwControllerCallback);
+          controller.removeListener(controllerCallback);
+          cwFocusNode.removeListener(cwFocusNodeCallback);
+          focusNode.removeListener(focusNodeCallback);
+        };
       },
       [account.value],
     );


### PR DESCRIPTION
Added unique hero tags for each FABs in `TimelinesPage` to avoid the error `There are multiple heroes that share the same tag within a subtree.`