### PR TITLE
fix: close `NoteSheet` before deleting the note

### DIFF
--- a/lib/view/widget/note_sheet.dart
+++ b/lib/view/widget/note_sheet.dart
@@ -379,6 +379,7 @@ class NoteSheet extends ConsumerWidget {
                   );
                   if (!context.mounted) return;
                   if (confirmed) {
+                    context.pop();
                     ref
                         .read(postNotifierProvider(account).notifier)
                         .fromNote(appearNote);
@@ -400,7 +401,6 @@ class NoteSheet extends ConsumerWidget {
                         .read(notesNotifierProvider(account).notifier)
                         .remove(appearNote.id);
                     if (!context.mounted) return;
-                    context.pop();
                     await context.push('/$account/post');
                     if (!context.mounted) return;
                   }
@@ -422,6 +422,7 @@ class NoteSheet extends ConsumerWidget {
                   );
                   if (!context.mounted) return;
                   if (confirmed) {
+                    context.pop();
                     await futureWithDialog(
                       context,
                       ref
@@ -435,7 +436,6 @@ class NoteSheet extends ConsumerWidget {
                           ),
                     );
                     if (!context.mounted) return;
-                    context.pop();
                   }
                 },
               ),


### PR DESCRIPTION
When the "Delete and edit" or "Delete" button in `NoteSheet` is selected, close the modal sheet first and then request delete.

This change avoids the `NO_SUCH_NOTE` error from blocking the instruction when at the `NotePage`.