### PR TITLE
fix: change max width of drive items

### DIFF
--- a/lib/view/page/drive_page.dart
+++ b/lib/view/page/drive_page.dart
@@ -39,7 +39,7 @@ class DrivePage extends HookConsumerWidget {
   final bool selectFolder;
   final FileType type;
 
-  static const itemMaxCrossAxisExtent = 400.0;
+  static const itemMaxCrossAxisExtent = 300.0;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
Changed `maxCrossAxisExtent` of grid items in `DrivePage` from 400 to 300 for better appearance in smaller devices.