### PR TITLE
fix: search emojis with isolate

### DIFF
--- a/lib/provider/search_custom_emojis_provider.dart
+++ b/lib/provider/search_custom_emojis_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -6,20 +7,10 @@ import 'custom_emoji_index_provider.dart';
 
 part 'search_custom_emojis_provider.g.dart';
 
-@Riverpod(keepAlive: true)
-Set<Emoji> searchCustomEmojis(
-  SearchCustomEmojisRef ref,
-  String host,
+Set<Emoji> _searchCustomEmojis(
+  Map<String, Set<Emoji>> customEmojiIndex,
   String query,
 ) {
-  if (query.isEmpty) {
-    return {};
-  }
-  final customEmojiIndex =
-      ref.watch(customEmojiIndexProvider(host)).valueOrNull;
-  if (customEmojiIndex == null) {
-    return {};
-  }
   const maxEmojis = 50;
   final hankakuQuery = query.replaceAllMapped(
     RegExp('[Ａ-Ｚａ-ｚ０-９]'),
@@ -64,4 +55,24 @@ Set<Emoji> searchCustomEmojis(
   }
 
   return result;
+}
+
+@Riverpod(keepAlive: true)
+FutureOr<Set<Emoji>> searchCustomEmojis(
+  SearchCustomEmojisRef ref,
+  String host,
+  String query,
+) {
+  if (query.isEmpty) {
+    return {};
+  }
+  final customEmojiIndex =
+      ref.watch(customEmojiIndexProvider(host)).valueOrNull;
+  if (customEmojiIndex == null) {
+    return {};
+  }
+  return compute(
+    (args) => _searchCustomEmojis(args.$1, args.$2),
+    (customEmojiIndex, query),
+  );
 }

--- a/lib/provider/search_custom_emojis_provider.g.dart
+++ b/lib/provider/search_custom_emojis_provider.g.dart
@@ -7,7 +7,7 @@ part of 'search_custom_emojis_provider.dart';
 // **************************************************************************
 
 String _$searchCustomEmojisHash() =>
-    r'2af3337d4793d4c18e7014c7b4699988dd831b9d';
+    r'469712ef5fad309b04f437720c8fcbda7136f4a2';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -35,7 +35,7 @@ class _SystemHash {
 const searchCustomEmojisProvider = SearchCustomEmojisFamily();
 
 /// See also [searchCustomEmojis].
-class SearchCustomEmojisFamily extends Family<Set<Emoji>> {
+class SearchCustomEmojisFamily extends Family<AsyncValue<Set<Emoji>>> {
   /// See also [searchCustomEmojis].
   const SearchCustomEmojisFamily();
 
@@ -76,7 +76,7 @@ class SearchCustomEmojisFamily extends Family<Set<Emoji>> {
 }
 
 /// See also [searchCustomEmojis].
-class SearchCustomEmojisProvider extends Provider<Set<Emoji>> {
+class SearchCustomEmojisProvider extends FutureProvider<Set<Emoji>> {
   /// See also [searchCustomEmojis].
   SearchCustomEmojisProvider(
     String host,
@@ -116,7 +116,7 @@ class SearchCustomEmojisProvider extends Provider<Set<Emoji>> {
 
   @override
   Override overrideWith(
-    Set<Emoji> Function(SearchCustomEmojisRef provider) create,
+    FutureOr<Set<Emoji>> Function(SearchCustomEmojisRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -134,7 +134,7 @@ class SearchCustomEmojisProvider extends Provider<Set<Emoji>> {
   }
 
   @override
-  ProviderElement<Set<Emoji>> createElement() {
+  FutureProviderElement<Set<Emoji>> createElement() {
     return _SearchCustomEmojisProviderElement(this);
   }
 
@@ -155,7 +155,7 @@ class SearchCustomEmojisProvider extends Provider<Set<Emoji>> {
   }
 }
 
-mixin SearchCustomEmojisRef on ProviderRef<Set<Emoji>> {
+mixin SearchCustomEmojisRef on FutureProviderRef<Set<Emoji>> {
   /// The parameter `host` of this provider.
   String get host;
 
@@ -163,8 +163,8 @@ mixin SearchCustomEmojisRef on ProviderRef<Set<Emoji>> {
   String get query;
 }
 
-class _SearchCustomEmojisProviderElement extends ProviderElement<Set<Emoji>>
-    with SearchCustomEmojisRef {
+class _SearchCustomEmojisProviderElement
+    extends FutureProviderElement<Set<Emoji>> with SearchCustomEmojisRef {
   _SearchCustomEmojisProviderElement(super.provider);
 
   @override

--- a/lib/provider/search_unicode_emojis_provider.dart
+++ b/lib/provider/search_unicode_emojis_provider.dart
@@ -1,14 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../constant/unicode_emoji_index.g.dart';
 
 part 'search_unicode_emojis_provider.g.dart';
 
-@riverpod
-Set<String> searchUnicodeEmojis(SearchUnicodeEmojisRef ref, String query) {
-  if (query.isEmpty) {
-    return {};
-  }
+Set<String> _searchUnicodeEmojis(String query) {
   const maxEmojis = 50;
   final result = {...?unicodeEmojiIndex[query]};
   if (result.length >= maxEmojis) {
@@ -34,4 +31,15 @@ Set<String> searchUnicodeEmojis(SearchUnicodeEmojisRef ref, String query) {
     }
   }
   return result;
+}
+
+@riverpod
+FutureOr<Set<String>> searchUnicodeEmojis(
+  SearchUnicodeEmojisRef ref,
+  String query,
+) {
+  if (query.isEmpty) {
+    return {};
+  }
+  return compute(_searchUnicodeEmojis, query);
 }

--- a/lib/provider/search_unicode_emojis_provider.g.dart
+++ b/lib/provider/search_unicode_emojis_provider.g.dart
@@ -7,7 +7,7 @@ part of 'search_unicode_emojis_provider.dart';
 // **************************************************************************
 
 String _$searchUnicodeEmojisHash() =>
-    r'955c5db14c6703cca645636d3166834adbc72d4a';
+    r'3fefff2af4f2e13236c85b11d9977219d72c035b';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -35,7 +35,7 @@ class _SystemHash {
 const searchUnicodeEmojisProvider = SearchUnicodeEmojisFamily();
 
 /// See also [searchUnicodeEmojis].
-class SearchUnicodeEmojisFamily extends Family<Set<String>> {
+class SearchUnicodeEmojisFamily extends Family<AsyncValue<Set<String>>> {
   /// See also [searchUnicodeEmojis].
   const SearchUnicodeEmojisFamily();
 
@@ -73,7 +73,8 @@ class SearchUnicodeEmojisFamily extends Family<Set<String>> {
 }
 
 /// See also [searchUnicodeEmojis].
-class SearchUnicodeEmojisProvider extends AutoDisposeProvider<Set<String>> {
+class SearchUnicodeEmojisProvider
+    extends AutoDisposeFutureProvider<Set<String>> {
   /// See also [searchUnicodeEmojis].
   SearchUnicodeEmojisProvider(
     String query,
@@ -108,7 +109,7 @@ class SearchUnicodeEmojisProvider extends AutoDisposeProvider<Set<String>> {
 
   @override
   Override overrideWith(
-    Set<String> Function(SearchUnicodeEmojisRef provider) create,
+    FutureOr<Set<String>> Function(SearchUnicodeEmojisRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -125,7 +126,7 @@ class SearchUnicodeEmojisProvider extends AutoDisposeProvider<Set<String>> {
   }
 
   @override
-  AutoDisposeProviderElement<Set<String>> createElement() {
+  AutoDisposeFutureProviderElement<Set<String>> createElement() {
     return _SearchUnicodeEmojisProviderElement(this);
   }
 
@@ -143,13 +144,13 @@ class SearchUnicodeEmojisProvider extends AutoDisposeProvider<Set<String>> {
   }
 }
 
-mixin SearchUnicodeEmojisRef on AutoDisposeProviderRef<Set<String>> {
+mixin SearchUnicodeEmojisRef on AutoDisposeFutureProviderRef<Set<String>> {
   /// The parameter `query` of this provider.
   String get query;
 }
 
 class _SearchUnicodeEmojisProviderElement
-    extends AutoDisposeProviderElement<Set<String>>
+    extends AutoDisposeFutureProviderElement<Set<String>>
     with SearchUnicodeEmojisRef {
   _SearchUnicodeEmojisProviderElement(super.provider);
 

--- a/lib/view/page/server/server_emojis.dart
+++ b/lib/view/page/server/server_emojis.dart
@@ -31,7 +31,8 @@ class ServerEmojis extends HookConsumerWidget {
       [],
     );
     final customEmojis =
-        ref.watch(searchCustomEmojisProvider(host, query.value));
+        ref.watch(searchCustomEmojisProvider(host, query.value)).valueOrNull ??
+            {};
     final style = DefaultTextStyle.of(context).style;
 
     return RefreshIndicator(

--- a/lib/view/widget/emoji_picker.dart
+++ b/lib/view/widget/emoji_picker.dart
@@ -136,9 +136,12 @@ class EmojiPicker extends HookConsumerWidget {
     final emojiPickerAutofocus = generalSettings.emojiPickerAutofocus;
     final emojiPickerScale = generalSettings.emojiPickerScale;
     final fontScaleFactor = 2.0 * emojiPickerScale;
-    final customEmojis =
-        ref.watch(searchCustomEmojisProvider(account.host, query.value));
-    final unicodeEmojis = ref.watch(searchUnicodeEmojisProvider(query.value));
+    final customEmojis = ref
+            .watch(searchCustomEmojisProvider(account.host, query.value))
+            .valueOrNull ??
+        {};
+    final unicodeEmojis =
+        ref.watch(searchUnicodeEmojisProvider(query.value)).valueOrNull ?? {};
     final pinnedEmojis =
         ref.watch(pinnedEmojisNotifierProvider(account, reaction: reaction));
     final recentlyUsedEmojis =

--- a/lib/view/widget/mfm_keyboard.dart
+++ b/lib/view/widget/mfm_keyboard.dart
@@ -168,10 +168,11 @@ class MfmKeyboard extends HookConsumerWidget {
                     .watch(recentlyUsedEmojisNotifierProvider(account))
                     .map((emoji) => emoji.replaceAll('@.', ''))
               else ...[
-                ...ref
+                ...?ref
                     .watch(searchCustomEmojisProvider(account.host, query))
-                    .map((emoji) => ':${emoji.name}:'),
-                ...ref.watch(searchUnicodeEmojisProvider(query)),
+                    .valueOrNull
+                    ?.map((emoji) => ':${emoji.name}:'),
+                ...?ref.watch(searchUnicodeEmojisProvider(query)).valueOrNull,
               ],
             ];
             if (emojis.isNotEmpty) {


### PR DESCRIPTION
Use isolate for searching custom and unicode emojis to prevent blocking UI.

May fix #216 