### PR TITLE
fix: scroll to top twice on receiving a note

### DIFF
--- a/lib/extension/scroll_controller_extension.dart
+++ b/lib/extension/scroll_controller_extension.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 
 extension ScrollControllerExtension on ScrollController {
-  void scrollToTop() {
-    if (position.extentBefore < 1000) {
-      animateTo(
+  Future<void> scrollToTop() async {
+    final extentBefore = position.extentBefore;
+    if (extentBefore == 0.0) {
+      return;
+    }
+    if (extentBefore < 10000.0) {
+      await animateTo(
         position.minScrollExtent,
         duration: const Duration(milliseconds: 125),
         curve: Curves.ease,

--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -114,12 +114,16 @@ class TimelineListView extends HookConsumerWidget {
                     )
                     .save(note.createdAt);
               }
-              Future<void>.delayed(
-                const Duration(milliseconds: 100),
-                controller.scrollToTop,
-              );
+              Future<void>.delayed(const Duration(milliseconds: 100), () async {
+                await controller.scrollToTop();
+                await Future<void>.delayed(
+                  const Duration(milliseconds: 100),
+                  controller.scrollToTop,
+                );
+              });
             } else {
               keepAnimation.value = false;
+              hasUnread.value = true;
             }
           } else {
             hasUnread.value = true;
@@ -243,18 +247,7 @@ class TimelineListView extends HookConsumerWidget {
                         ),
                       );
                     },
-                    separatorBuilder: (context, index) =>
-                        lastViewedAt?.isBetween(
-                                  nextNotes.valueOrNull?.items
-                                      .elementAtOrNull(index + 1)
-                                      ?.createdAt,
-                                  nextNotes.valueOrNull?.items
-                                      .elementAtOrNull(index)
-                                      ?.createdAt,
-                                ) ??
-                                false
-                            ? _NewNotesDivider(key: lastViewedAtKey)
-                            : const Divider(height: 1.0),
+                    separatorBuilder: (_, __) => const Divider(height: 1.0),
                     itemCount: nextNotes.valueOrNull?.items.length ?? 0,
                   ),
                   if ((nextNotes.valueOrNull?.items.isNotEmpty ?? false) &&


### PR DESCRIPTION
Changed to call `scrollToTop` twice when receiving a note from a stream.

The first call will be done 100 ms after the event, and the second call will be 100 ms after the first scroll is done.

This change makes timelines scroll to their exact top edge even though the size of notes changes over time while rendering emojis or images.