### PR TITLE
fix: disable rotation animation of fab

### DIFF
--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -381,7 +381,7 @@ class TimelinesPage extends HookConsumerWidget {
                         ),
                       ],
                     )
-                  : null,
+                  : const SizedBox.shrink(),
               floatingActionButtonLocation:
                   FloatingActionButtonLocation.centerFloat,
             ),


### PR DESCRIPTION
The default animation for showing FAB rotates the button.
`TimelinesPage` uses a `Row` of buttons as FAB, so the animation rotates a wide widget, which is kind of confusing.