### PR TITLE
feat: upload from url

### DIFF
--- a/lib/model/streaming/main_event.dart
+++ b/lib/model/streaming/main_event.dart
@@ -1,4 +1,8 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:misskey_dart/misskey_dart.dart';
+
+part 'main_event.freezed.dart';
+part 'main_event.g.dart';
 
 sealed class MainEvent {}
 
@@ -36,4 +40,15 @@ class AnnouncementCreated implements MainEvent {
   const AnnouncementCreated(this.announcement);
 
   final AnnouncementsResponse announcement;
+}
+
+@freezed
+class UrlUploadFinished with _$UrlUploadFinished implements MainEvent {
+  const factory UrlUploadFinished({
+    String? marker,
+    required DriveFile file,
+  }) = _UrlUploadFinished;
+
+  factory UrlUploadFinished.fromJson(Map<String, Object?> json) =>
+      _$UrlUploadFinishedFromJson(json);
 }

--- a/lib/model/streaming/main_event.freezed.dart
+++ b/lib/model/streaming/main_event.freezed.dart
@@ -1,0 +1,183 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'main_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+UrlUploadFinished _$UrlUploadFinishedFromJson(Map<String, dynamic> json) {
+  return _UrlUploadFinished.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UrlUploadFinished {
+  String? get marker => throw _privateConstructorUsedError;
+  DriveFile get file => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UrlUploadFinishedCopyWith<UrlUploadFinished> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UrlUploadFinishedCopyWith<$Res> {
+  factory $UrlUploadFinishedCopyWith(
+          UrlUploadFinished value, $Res Function(UrlUploadFinished) then) =
+      _$UrlUploadFinishedCopyWithImpl<$Res, UrlUploadFinished>;
+  @useResult
+  $Res call({String? marker, DriveFile file});
+
+  $DriveFileCopyWith<$Res> get file;
+}
+
+/// @nodoc
+class _$UrlUploadFinishedCopyWithImpl<$Res, $Val extends UrlUploadFinished>
+    implements $UrlUploadFinishedCopyWith<$Res> {
+  _$UrlUploadFinishedCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? marker = freezed,
+    Object? file = null,
+  }) {
+    return _then(_value.copyWith(
+      marker: freezed == marker
+          ? _value.marker
+          : marker // ignore: cast_nullable_to_non_nullable
+              as String?,
+      file: null == file
+          ? _value.file
+          : file // ignore: cast_nullable_to_non_nullable
+              as DriveFile,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $DriveFileCopyWith<$Res> get file {
+    return $DriveFileCopyWith<$Res>(_value.file, (value) {
+      return _then(_value.copyWith(file: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$UrlUploadFinishedImplCopyWith<$Res>
+    implements $UrlUploadFinishedCopyWith<$Res> {
+  factory _$$UrlUploadFinishedImplCopyWith(_$UrlUploadFinishedImpl value,
+          $Res Function(_$UrlUploadFinishedImpl) then) =
+      __$$UrlUploadFinishedImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? marker, DriveFile file});
+
+  @override
+  $DriveFileCopyWith<$Res> get file;
+}
+
+/// @nodoc
+class __$$UrlUploadFinishedImplCopyWithImpl<$Res>
+    extends _$UrlUploadFinishedCopyWithImpl<$Res, _$UrlUploadFinishedImpl>
+    implements _$$UrlUploadFinishedImplCopyWith<$Res> {
+  __$$UrlUploadFinishedImplCopyWithImpl(_$UrlUploadFinishedImpl _value,
+      $Res Function(_$UrlUploadFinishedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? marker = freezed,
+    Object? file = null,
+  }) {
+    return _then(_$UrlUploadFinishedImpl(
+      marker: freezed == marker
+          ? _value.marker
+          : marker // ignore: cast_nullable_to_non_nullable
+              as String?,
+      file: null == file
+          ? _value.file
+          : file // ignore: cast_nullable_to_non_nullable
+              as DriveFile,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UrlUploadFinishedImpl implements _UrlUploadFinished {
+  const _$UrlUploadFinishedImpl({this.marker, required this.file});
+
+  factory _$UrlUploadFinishedImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UrlUploadFinishedImplFromJson(json);
+
+  @override
+  final String? marker;
+  @override
+  final DriveFile file;
+
+  @override
+  String toString() {
+    return 'UrlUploadFinished(marker: $marker, file: $file)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UrlUploadFinishedImpl &&
+            (identical(other.marker, marker) || other.marker == marker) &&
+            (identical(other.file, file) || other.file == file));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, marker, file);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UrlUploadFinishedImplCopyWith<_$UrlUploadFinishedImpl> get copyWith =>
+      __$$UrlUploadFinishedImplCopyWithImpl<_$UrlUploadFinishedImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UrlUploadFinishedImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _UrlUploadFinished implements UrlUploadFinished {
+  const factory _UrlUploadFinished(
+      {final String? marker,
+      required final DriveFile file}) = _$UrlUploadFinishedImpl;
+
+  factory _UrlUploadFinished.fromJson(Map<String, dynamic> json) =
+      _$UrlUploadFinishedImpl.fromJson;
+
+  @override
+  String? get marker;
+  @override
+  DriveFile get file;
+  @override
+  @JsonKey(ignore: true)
+  _$$UrlUploadFinishedImplCopyWith<_$UrlUploadFinishedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/streaming/main_event.g.dart
+++ b/lib/model/streaming/main_event.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'main_event.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$UrlUploadFinishedImpl _$$UrlUploadFinishedImplFromJson(
+        Map<String, dynamic> json) =>
+    _$UrlUploadFinishedImpl(
+      marker: json['marker'] as String?,
+      file: DriveFile.fromJson(json['file'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$UrlUploadFinishedImplToJson(
+    _$UrlUploadFinishedImpl instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('marker', instance.marker);
+  val['file'] = instance.file.toJson();
+  return val;
+}

--- a/lib/provider/api/drive_files_notifier_provider.dart
+++ b/lib/provider/api/drive_files_notifier_provider.dart
@@ -102,6 +102,22 @@ class DriveFilesNotifier extends _$DriveFilesNotifier {
     state = AsyncValue.data(value.copyWith(items: [response, ...value.items]));
   }
 
+  Future<void> uploadFromUrl(
+    String url, {
+    String? comment,
+    bool? isSensitive,
+  }) async {
+    await _misskey.drive.files.uploadFromUrl(
+      DriveFilesUploadFromUrlRequest(
+        url: url,
+        folderId: folderId,
+        comment: comment,
+        isSensitive: isSensitive,
+        force: true,
+      ),
+    );
+  }
+
   Future<void> delete(String fileId) async {
     await _misskey.drive.files.delete(DriveFilesDeleteRequest(fileId: fileId));
     final value = state.valueOrNull ?? const PaginationState();

--- a/lib/provider/api/drive_files_notifier_provider.g.dart
+++ b/lib/provider/api/drive_files_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'drive_files_notifier_provider.dart';
 // **************************************************************************
 
 String _$driveFilesNotifierHash() =>
-    r'335fbe3c700243069df878df78c2996e25464159';
+    r'fdbd5e32cabf0f1c8b6c9d8580fe83c39fff7f29';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/streaming/main_stream_notifier_provider.dart
+++ b/lib/provider/streaming/main_stream_notifier_provider.dart
@@ -57,6 +57,8 @@ class MainStreamNotifier extends _$MainStreamNotifier {
             body!['announcement'] as Map<String, dynamic>,
           );
           yield AnnouncementCreated(announcement);
+        case 'urlUploadFinished':
+          yield UrlUploadFinished.fromJson(body!);
       }
     }
   }

--- a/lib/provider/streaming/main_stream_notifier_provider.g.dart
+++ b/lib/provider/streaming/main_stream_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'main_stream_notifier_provider.dart';
 // **************************************************************************
 
 String _$mainStreamNotifierHash() =>
-    r'c3249d4feee548966cd8635f696b6205c7bab8d8';
+    r'f26fa046b955d6a98b913fe9b937d83eacc5fe01';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -68,23 +68,22 @@ class TimelinesPage extends HookConsumerWidget {
     useEffect(
       () {
         void callback() {
+          if (tabs.isEmpty) return;
           final previousIndex = tabIndex.value;
           final nextIndex = controller.index;
-          if (previousIndex == nextIndex) {
-            return;
-          }
-          final previousAccount = tabSettings?.account;
+          if (previousIndex == nextIndex) return;
+          final previousAccount = tabs[previousIndex].account;
           final nextTab = tabs[nextIndex];
           final nextAccount = nextTab.account;
           if (previousAccount != nextAccount) {
-            if (previousAccount?.host != nextAccount.host) {
+            if (previousAccount.host != nextAccount.host) {
               ref
                   .read(
                     emojisNotifierProvider(nextAccount.host).notifier,
                   )
                   .reloadEmojis();
             }
-            if (previousAccount != null && !previousAccount.isGuest) {
+            if (!previousAccount.isGuest) {
               ref
                   .read(mainStreamNotifierProvider(previousAccount).notifier)
                   .disconnect();
@@ -112,6 +111,15 @@ class TimelinesPage extends HookConsumerWidget {
           tabIndex.value = nextIndex;
         }
 
+        if (tabSettings != null) {
+          final account = tabSettings.account;
+          ref
+              .read(emojisNotifierProvider(account.host).notifier)
+              .reloadEmojis();
+          if (!account.isGuest) {
+            ref.read(mainStreamNotifierProvider(account).notifier).connect();
+          }
+        }
         controller.addListener(callback);
         return () => controller.removeListener(callback);
       },

--- a/lib/view/widget/drive_create_sheet.dart
+++ b/lib/view/widget/drive_create_sheet.dart
@@ -16,6 +16,7 @@ import '../../provider/file_system_provider.dart';
 import '../../util/compress_image.dart';
 import '../../util/future_with_dialog.dart';
 import '../../util/randomize_filename.dart';
+import '../dialog/message_dialog.dart';
 import '../dialog/text_field_dialog.dart';
 
 class DriveCreateSheet extends HookConsumerWidget {
@@ -62,6 +63,29 @@ class DriveCreateSheet extends HookConsumerWidget {
           }
         }),
       ),
+    );
+    if (!ref.context.mounted) return;
+    ref.context.pop();
+  }
+
+  Future<void> _uploadFromUrl(WidgetRef ref) async {
+    final result = await showTextFieldDialog(
+      ref.context,
+      title: Text(t.misskey.uploadFromUrl),
+    );
+    if (!ref.context.mounted) return;
+    if (result == null) return;
+    final url = Uri.tryParse(result.trim());
+    if (url == null) {
+      await showMessageDialog(ref.context, t.misskey.invalidValue);
+      return;
+    }
+    await futureWithDialog(
+      ref.context,
+      ref
+          .read(driveFilesNotifierProvider(account, folder?.id).notifier)
+          .uploadFromUrl(url.toString()),
+      message: t.misskey.uploadFromUrlRequested,
     );
     if (!ref.context.mounted) return;
     ref.context.pop();
@@ -123,6 +147,11 @@ class DriveCreateSheet extends HookConsumerWidget {
             keepOriginalUploading.value,
             keepOriginalFilename.value,
           ),
+        ),
+        ListTile(
+          leading: const Icon(Icons.link),
+          title: Text(t.misskey.fromUrl),
+          onTap: () => _uploadFromUrl(ref),
         ),
         ListTile(
           leading: const Icon(Icons.folder),

--- a/lib/view/widget/file_picker_sheet.dart
+++ b/lib/view/widget/file_picker_sheet.dart
@@ -1,14 +1,24 @@
+import 'dart:async';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:misskey_dart/misskey_dart.dart';
+import 'package:uuid/uuid.dart';
 
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../model/post_file.dart';
+import '../../model/streaming/main_event.dart';
+import '../../provider/account_settings_notifier_provider.dart';
+import '../../provider/api/misskey_provider.dart';
 import '../../provider/file_system_provider.dart';
+import '../../provider/streaming/main_stream_notifier_provider.dart';
+import '../../util/future_with_dialog.dart';
+import '../dialog/message_dialog.dart';
+import '../dialog/text_field_dialog.dart';
 import '../page/drive_page.dart';
 
 class FilePickerSheet extends ConsumerWidget {
@@ -127,6 +137,89 @@ class FilePickerSheet extends ConsumerWidget {
               if (result != null) {
                 context.pop(DrivePostFile.fromDriveFile(result));
               }
+            }
+          },
+        ),
+        ListTile(
+          leading: const Icon(Icons.link),
+          title: Text(t.misskey.fromUrl),
+          onTap: () async {
+            final result = await showTextFieldDialog(
+              context,
+              title: Text(t.misskey.uploadFromUrl),
+            );
+            if (!context.mounted) return;
+            if (result == null) return;
+            final url = Uri.tryParse(result.trim());
+            if (url == null) {
+              await showMessageDialog(context, t.misskey.invalidValue);
+              return;
+            }
+            final marker = const Uuid().v4();
+            final completer = Completer<DriveFile>();
+            unawaited(
+              ref.read(mainStreamNotifierProvider(account).notifier).connect(),
+            );
+            final sub = ref.listenManual(mainStreamNotifierProvider(account),
+                (_, next) async {
+              if (next
+                  case AsyncData(
+                    value: UrlUploadFinished(
+                      marker: final m?,
+                      :final file,
+                    ),
+                  )) {
+                if (m == marker) {
+                  completer.complete(file);
+                }
+              }
+            });
+            final folderId =
+                ref.read(accountSettingsNotifierProvider(account)).uploadFolder;
+            await futureWithDialog(
+              context,
+              ref.read(misskeyProvider(account)).drive.files.uploadFromUrl(
+                    DriveFilesUploadFromUrlRequest(
+                      url: url.toString(),
+                      folderId: folderId,
+                      // Set comment to distinguish requested file while polling
+                      comment: marker,
+                      marker: marker,
+                      force: true,
+                    ),
+                  ),
+            );
+            final timer = Timer.periodic(const Duration(seconds: 5), (_) async {
+              try {
+                final files = await ref
+                    .read(misskeyProvider(account))
+                    .drive
+                    .files
+                    .files(DriveFilesRequest(folderId: folderId, limit: 1));
+                final file = files.firstOrNull;
+                if (file != null && file.comment == marker) {
+                  completer.complete(file);
+                }
+              } catch (_) {}
+            });
+            if (!context.mounted) return;
+            final file = await futureWithDialog(context, completer.future);
+            sub.close();
+            timer.cancel();
+            if (!context.mounted) return;
+            if (file == null) return;
+            final updated = await futureWithDialog(
+              context,
+              ref.read(misskeyProvider(account)).drive.files.update(
+                    DriveFilesUpdateRequest(fileId: file.id, comment: ''),
+                  ),
+            );
+            if (!context.mounted) return;
+            if (updated == null) return;
+            if (allowMultiple) {
+              context.pop([DrivePostFile.fromDriveFile(updated)]);
+            } else {
+              context.pop(DrivePostFile.fromDriveFile(updated));
             }
           },
         ),


### PR DESCRIPTION
Made it possible to attach a file to a note from its URL.

Misskey sends the file via the main streaming channel when the upload request is completed, but sometimes it does not appear on the stream.
To get the uploaded file in that case, request `drive/files/files` periodically and check if the file is already created.

Also added an option to upload a file to the drive from the URL.

Resolve #200