### PR TITLE
fix: use panel color for default note background color

### DIFF
--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -219,7 +219,7 @@ class NoteWidget extends HookConsumerWidget {
     final style = DefaultTextStyle.of(context).style;
 
     return Material(
-      color: backgroundColor,
+      color: backgroundColor ?? colors.panel,
       clipBehavior: Clip.hardEdge,
       child: InkWell(
         onTap: getNoteAction(


### PR DESCRIPTION
Changed to display notes on panel color if background colors for them are not specified.