### PR TITLE
fix: align ruby above baseline

### DIFF
--- a/lib/view/widget/mfm/mfm_builder.dart
+++ b/lib/view/widget/mfm/mfm_builder.dart
@@ -723,6 +723,8 @@ class MfmBuilder {
                 .build([MfmText(l.first.replaceAll('\n', ' '))]),
           );
           return WidgetSpan(
+            alignment: PlaceholderAlignment.aboveBaseline,
+            baseline: TextBaseline.ideographic,
             child: Ruby(
               style: rubyStyle,
               ruby: ruby,
@@ -751,6 +753,8 @@ class MfmBuilder {
             ),
           );
           return WidgetSpan(
+            alignment: PlaceholderAlignment.aboveBaseline,
+            baseline: TextBaseline.ideographic,
             child: Ruby(
               style: rubyStyle,
               ruby: ruby,


### PR DESCRIPTION
Changed alignment of `WidgetSpan` wrapping `Ruby` for a better appearance when texts with and without ruby are in the same line.