### PR TITLE
fix: avoid expanding inline code

### DIFF
--- a/lib/view/widget/mfm/code.dart
+++ b/lib/view/widget/mfm/code.dart
@@ -34,7 +34,7 @@ class Code extends StatelessWidget {
         borderRadius: BorderRadius.circular(4.0),
         onLongPress: () => copyToClipboard(context, code),
         child: Container(
-          width: double.infinity,
+          width: inline ? null : double.infinity,
           color: theme['root']?.backgroundColor,
           child: SingleChildScrollView(
             scrollDirection: Axis.horizontal,


### PR DESCRIPTION
Fixed `Code` not to expand horizontally if used as inline code.