### PR TITLE
fix: fill all fields of `NotesEditRequest`

### DIFF
--- a/lib/provider/api/post_notifier_provider.dart
+++ b/lib/provider/api/post_notifier_provider.dart
@@ -217,9 +217,15 @@ class PostNotifier extends _$PostNotifier {
         final response = await ref.read(misskeyProvider(account)).notes.edit(
               NotesEditRequest(
                 editId: noteId!,
+                visibility: state.visibility,
+                visibleUserIds: state.visibleUserIds,
                 text: state.text,
                 cw: state.cw,
+                localOnly: state.localOnly,
                 fileIds: fileIds,
+                replyId: state.replyId,
+                renoteId: state.renoteId,
+                channelId: state.channelId,
                 poll: state.poll,
               ),
             );

--- a/lib/provider/api/post_notifier_provider.g.dart
+++ b/lib/provider/api/post_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'post_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$postNotifierHash() => r'd3b9fa7474049def66005a38ed5b7c221e643ced';
+String _$postNotifierHash() => r'f9a32eddc12dfa6a3e1bf1b808644768ee606c92';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1249,8 +1249,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: a456581c1b0aa4862a0ab8c7667df1dc842d986a
-      resolved-ref: a456581c1b0aa4862a0ab8c7667df1dc842d986a
+      ref: "484fb1e4efda35b32380eb7b025429709e724850"
+      resolved-ref: "484fb1e4efda35b32380eb7b025429709e724850"
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: a456581c1b0aa4862a0ab8c7667df1dc842d986a
+      ref: 484fb1e4efda35b32380eb7b025429709e724850
   multi_split_view: ^3.2.1
   package_info_plus: ^8.0.0
   photo_view: ^0.15.0


### PR DESCRIPTION
Firefish requires the request for `notes/edit` to specify `visibility`.

https://firefish.dev/firefish/firefish/-/blob/78fdc56c3de4a2312504b55c487ad6d26f3065f2/packages/backend/src/server/api/endpoints/notes/edit.ts#L558