### PR TITLE
fix: show long helper text on multiple lines

### DIFF
--- a/lib/view/widget/as_ui_widget.dart
+++ b/lib/view/widget/as_ui_widget.dart
@@ -59,6 +59,7 @@ class AsUiWidget extends HookConsumerWidget {
             helperStyle: TextStyle(
               color: Theme.of(context).colorScheme.onSurface.withOpacity(0.75),
             ),
+            helperMaxLines: 100,
             isDense: true,
           ),
         ),


### PR DESCRIPTION
Removed single line limitation of `helperText` in `AsUiWidget` to show complete captions for input fields. 