### PR TITLE
fix: add a dialog for delete and edit

### DIFF
--- a/lib/view/dialog/delete_and_edit_dialog.dart
+++ b/lib/view/dialog/delete_and_edit_dialog.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+import '../../i18n/strings.g.dart';
+import '../../model/account.dart';
+import '../../model/post_file.dart';
+import '../../provider/api/attaches_notifier_provider.dart';
+import '../../provider/api/misskey_provider.dart';
+import '../../provider/api/post_notifier_provider.dart';
+import '../../provider/notes_notifier_provider.dart';
+import '../../util/future_with_dialog.dart';
+
+class DeleteAndEditDialog extends ConsumerWidget {
+  const DeleteAndEditDialog({
+    super.key,
+    required this.account,
+    required this.note,
+  });
+
+  final Account account;
+  final Note note;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AlertDialog(
+      content: Text(t.misskey.deleteAndEditConfirm),
+      actions: [
+        ElevatedButton(
+          autofocus: true,
+          onPressed: () async {
+            context.pop();
+            ref.read(postNotifierProvider(account).notifier).fromNote(note);
+            ref.read(attachesNotifierProvider(account).notifier).addAll(
+                  note.files.map(
+                    (file) => DrivePostFile.fromDriveFile(file),
+                  ),
+                );
+            final deleted = await futureWithDialog(
+              context,
+              ref
+                  .read(misskeyProvider(account))
+                  .notes
+                  .delete(NotesDeleteRequest(noteId: note.id))
+                  .then((_) => true),
+            );
+            if (!(deleted ?? false)) return;
+            if (!context.mounted) return;
+            ref.read(notesNotifierProvider(account).notifier).remove(note.id);
+            await context.push('/$account/post');
+          },
+          child: Text(t.misskey.ok),
+        ),
+        OutlinedButton(
+          onPressed: () => context.pop(),
+          child: Text(t.misskey.cancel),
+        ),
+      ],
+      scrollable: true,
+    );
+  }
+}


### PR DESCRIPTION
Changed to use a new widget for delete and edit of the note.

The previous approach was to use the context of `NoteSheet` for showing indicators or routing.
The approach does not work well for some cases because the operation deletes the note `NoteSheet` is watching for, and the context is unmounted before pushing to the post page.
With this PR, adding `DeleteAndEditDialog`, a separate context is used during delete and edit so that the context will not be unmounted.