### PR TITLE
fix: use wrap to display remote caution buttons

### DIFF
--- a/lib/view/page/note_page.dart
+++ b/lib/view/page/note_page.dart
@@ -286,8 +286,7 @@ class NotePage extends HookConsumerWidget {
                                   ),
                                 ),
                               ),
-                              Row(
-                                mainAxisSize: MainAxisSize.min,
+                              Wrap(
                                 children: [
                                   TextButton(
                                     onPressed: () => launchUrl(

--- a/lib/view/page/user/user_home.dart
+++ b/lib/view/page/user/user_home.dart
@@ -271,8 +271,7 @@ class _UserHome extends ConsumerWidget {
                             ),
                           ),
                         ),
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
+                        Wrap(
                           children: [
                             TextButton(
                               onPressed: () => launchUrl(


### PR DESCRIPTION
Changed parent of buttons in remote user caution from `Row` to `Wrap` to display buttons horizontally if device width is wide enough, otherwise vertically.