### PR TITLE
fix: disable text scaling inside WidgetSpan

### DIFF
--- a/lib/view/page/about_aria_page.dart
+++ b/lib/view/page/about_aria_page.dart
@@ -76,6 +76,7 @@ class AboutAriaPage extends HookConsumerWidget {
                               child: Text(
                                 'Miria',
                                 style: TextStyle(color: colors.link),
+                                textScaler: TextScaler.noScaling,
                               ),
                             ),
                           ),
@@ -95,6 +96,7 @@ class AboutAriaPage extends HookConsumerWidget {
                               child: Text(
                                 'Misskey',
                                 style: TextStyle(color: colors.link),
+                                textScaler: TextScaler.noScaling,
                               ),
                             ),
                           ),
@@ -117,6 +119,7 @@ class AboutAriaPage extends HookConsumerWidget {
                               child: Text(
                                 '@sevenc_nanashi@voskey.icalo.net',
                                 style: TextStyle(color: colors.mention),
+                                textScaler: TextScaler.noScaling,
                               ),
                             ),
                           ),
@@ -140,6 +143,7 @@ class AboutAriaPage extends HookConsumerWidget {
                               child: Text(
                                 'CC-BY 4.0',
                                 style: TextStyle(color: colors.link),
+                                textScaler: TextScaler.noScaling,
                               ),
                             ),
                           ),

--- a/lib/view/page/gallery/gallery_post_page.dart
+++ b/lib/view/page/gallery/gallery_post_page.dart
@@ -220,6 +220,7 @@ class GalleryPostPage extends ConsumerWidget {
                             child: TimeWidget(
                               time: post.createdAt,
                               detailed: true,
+                              textScaler: TextScaler.noScaling,
                             ),
                           ),
                         ],
@@ -246,6 +247,7 @@ class GalleryPostPage extends ConsumerWidget {
                               child: TimeWidget(
                                 time: post.updatedAt,
                                 detailed: true,
+                                textScaler: TextScaler.noScaling,
                               ),
                             ),
                           ],

--- a/lib/view/page/page/page_page.dart
+++ b/lib/view/page/page/page_page.dart
@@ -382,6 +382,7 @@ class PagePage extends ConsumerWidget {
                                 child: TimeWidget(
                                   time: page.createdAt,
                                   detailed: true,
+                                  textScaler: TextScaler.noScaling,
                                 ),
                               ),
                             ],
@@ -409,6 +410,7 @@ class PagePage extends ConsumerWidget {
                                   child: TimeWidget(
                                     time: page.updatedAt,
                                     detailed: true,
+                                    textScaler: TextScaler.noScaling,
                                   ),
                                 ),
                               ],

--- a/lib/view/page/play/play_page.dart
+++ b/lib/view/page/play/play_page.dart
@@ -164,6 +164,7 @@ class PlayPage extends HookConsumerWidget {
                                     child: TimeWidget(
                                       time: play.createdAt,
                                       detailed: true,
+                                      textScaler: TextScaler.noScaling,
                                     ),
                                   ),
                                 ],
@@ -187,6 +188,7 @@ class PlayPage extends HookConsumerWidget {
                                       child: TimeWidget(
                                         time: play.updatedAt,
                                         detailed: true,
+                                        textScaler: TextScaler.noScaling,
                                       ),
                                     ),
                                   ],

--- a/lib/view/page/settings/languages_page.dart
+++ b/lib/view/page/settings/languages_page.dart
@@ -71,6 +71,7 @@ class LanguagesPage extends ConsumerWidget {
                             ],
                           ),
                           textAlign: TextAlign.center,
+                          textScaler: TextScaler.noScaling,
                         ),
                       ),
                     ),

--- a/lib/view/page/user/user_home.dart
+++ b/lib/view/page/user/user_home.dart
@@ -451,22 +451,24 @@ class _UserHome extends ConsumerWidget {
                               children: [
                                 Padding(
                                   padding: const EdgeInsets.all(4.0),
-                                  child: Center(
-                                    child: Row(
-                                      mainAxisSize: MainAxisSize.min,
+                                  child: Text.rich(
+                                    TextSpan(
                                       children: [
-                                        const Padding(
-                                          padding: EdgeInsets.only(right: 2.0),
+                                        const WidgetSpan(
                                           child: Icon(Icons.cake),
                                         ),
-                                        Text(
-                                          t.misskey.birthday,
+                                        const WidgetSpan(
+                                          child: SizedBox(width: 2.0),
+                                        ),
+                                        TextSpan(
+                                          text: t.misskey.birthday,
                                           style: const TextStyle(
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
                                       ],
                                     ),
+                                    textAlign: TextAlign.center,
                                   ),
                                 ),
                                 Padding(
@@ -481,22 +483,24 @@ class _UserHome extends ConsumerWidget {
                             children: [
                               Padding(
                                 padding: const EdgeInsets.all(4.0),
-                                child: Center(
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
+                                child: Text.rich(
+                                  TextSpan(
                                     children: [
-                                      const Padding(
-                                        padding: EdgeInsets.only(right: 2.0),
+                                      const WidgetSpan(
                                         child: Icon(Icons.calendar_today),
                                       ),
-                                      Text(
-                                        t.misskey.registeredDate,
+                                      const WidgetSpan(
+                                        child: SizedBox(width: 2.0),
+                                      ),
+                                      TextSpan(
+                                        text: t.misskey.registeredDate,
                                         style: const TextStyle(
                                           fontWeight: FontWeight.bold,
                                         ),
                                       ),
                                     ],
                                   ),
+                                  textAlign: TextAlign.center,
                                 ),
                               ),
                               Padding(

--- a/lib/view/widget/bot_badge.dart
+++ b/lib/view/widget/bot_badge.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 class BotBadge extends StatelessWidget {
-  const BotBadge({super.key});
+  const BotBadge({super.key, this.textScaler});
+
+  final TextScaler? textScaler;
 
   @override
   Widget build(BuildContext context) {
@@ -13,9 +15,9 @@ class BotBadge extends StatelessWidget {
               Border.all(color: Theme.of(context).colorScheme.outlineVariant),
           borderRadius: BorderRadius.circular(4.0),
         ),
-        child: const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 4.0),
-          child: Text('bot'),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4.0),
+          child: Text('bot', textScaler: textScaler),
         ),
       ),
     );

--- a/lib/view/widget/note_detailed_widget.dart
+++ b/lib/view/widget/note_detailed_widget.dart
@@ -423,6 +423,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                                           color: colors.renote,
                                           fontStyle: FontStyle.italic,
                                         ),
+                                        textScaler: TextScaler.noScaling,
                                       ),
                                     ),
                                   ),

--- a/lib/view/widget/note_header.dart
+++ b/lib/view/widget/note_header.dart
@@ -70,7 +70,9 @@ class NoteHeader extends HookConsumerWidget {
                               color: style.color?.withOpacity(0.8),
                               fontSizeFactor: 0.8,
                             ),
-                            child: const BotBadge(),
+                            child: const BotBadge(
+                              textScaler: TextScaler.noScaling,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/view/widget/sub_note_content.dart
+++ b/lib/view/widget/sub_note_content.dart
@@ -122,6 +122,7 @@ class SubNoteContent extends HookConsumerWidget {
                             color: colors.renote,
                             fontStyle: FontStyle.italic,
                           ),
+                          textScaler: TextScaler.noScaling,
                         ),
                       ),
                     ),


### PR DESCRIPTION
Applied `TextScaler.noScaling` for every `Text` in `WidgetSpan` for a better appearance with devices with a modified text scaler.