### PR TITLE
fix: hide children if the note has no children

### DIFF
--- a/lib/view/widget/note_detailed_widget.dart
+++ b/lib/view/widget/note_detailed_widget.dart
@@ -521,7 +521,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                     if (children
                         case AsyncValue(
                           valueOrNull: PaginationState(items: final notes),
-                        ))
+                        ) when notes.isNotEmpty)
                       Container(
                         margin: const EdgeInsets.only(left: 8.0, top: 8.0),
                         decoration: BoxDecoration(


### PR DESCRIPTION
Changed to omit children's area at the bottom of `NoteDetailedWidget` if the note has no replies or quotes.

This removes extra spaces with no meaning, which has a border on their left on iOS.