### PR TITLE
fix: add Menlo for fonts of code

### DIFF
--- a/lib/constant/fonts.dart
+++ b/lib/constant/fonts.dart
@@ -1,0 +1,8 @@
+const monospaceFallback = [
+  'Consolas',
+  'Monaco',
+  'Menlo',
+  'Andale Mono',
+  'Ubuntu Mono',
+  'monospace',
+];

--- a/lib/view/widget/mfm/code.dart
+++ b/lib/view/widget/mfm/code.dart
@@ -50,6 +50,7 @@ class Code extends StatelessWidget {
                 fontFamilyFallback: const [
                   'Consolas',
                   'Monaco',
+                  'Menlo',
                   'Andale Mono',
                   'Ubuntu Mono',
                   'monospace',

--- a/lib/view/widget/mfm/code.dart
+++ b/lib/view/widget/mfm/code.dart
@@ -4,6 +4,7 @@ import 'package:flutter_highlighting/themes/atelier-cave-light.dart';
 import 'package:flutter_highlighting/themes/atom-one-dark.dart';
 import 'package:highlighting/languages/all.dart';
 
+import '../../../constant/fonts.dart';
 import '../../../util/copy_text.dart';
 
 class Code extends StatelessWidget {
@@ -47,14 +48,7 @@ class Code extends StatelessWidget {
                   : const EdgeInsets.all(8.0),
               textStyle: TextStyle(
                 fontSize: fontSize,
-                fontFamilyFallback: const [
-                  'Consolas',
-                  'Monaco',
-                  'Menlo',
-                  'Andale Mono',
-                  'Ubuntu Mono',
-                  'monospace',
-                ],
+                fontFamilyFallback: monospaceFallback,
               ),
             ),
           ),

--- a/lib/view/widget/mfm/mfm_builder.dart
+++ b/lib/view/widget/mfm/mfm_builder.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart' as material show Border;
 import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:mfm_parser/mfm_parser.dart';
 
+import '../../../constant/fonts.dart';
 import '../../../extension/text_style_extension.dart';
 import '../../../gen/fonts.gen.dart';
 import '../../../model/misskey_colors.dart';
@@ -547,6 +548,7 @@ class MfmBuilder {
               },
               fontFamilyFallback: switch (args.keys.firstOrNull) {
                 'serif' => [FontFamily.notoSerifJP],
+                'monospace' => monospaceFallback,
                 _ => null,
               },
             ),


### PR DESCRIPTION
Added Menlo to `fontFamilyFallback` of `Code`.

Related to #257 