### PR TITLE
 release: 0.10.2 

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1249,8 +1249,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "484fb1e4efda35b32380eb7b025429709e724850"
-      resolved-ref: "484fb1e4efda35b32380eb7b025429709e724850"
+      ref: "4a66437fa2e2562666ce9c052112cbd343d32dc2"
+      resolved-ref: "4a66437fa2e2562666ce9c052112cbd343d32dc2"
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: aria
 description: "A client app for Misskey, a federated social media platform."
 publish_to: 'none'
-version: 0.10.1+26
+version: 0.10.2+27
 
 environment:
   sdk: '>=3.3.2 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: 484fb1e4efda35b32380eb7b025429709e724850
+      ref: 4a66437fa2e2562666ce9c052112cbd343d32dc2
   multi_split_view: ^3.2.1
   package_info_plus: ^8.0.0
   photo_view: ^0.15.0


### PR DESCRIPTION
## [0.10.2](https://github.com/poppingmoon/aria/compare/v0.10.1...v0.10.2) (2024-06-27)


### Bug Fixes

* add a dialog for delete and edit ([#252](https://github.com/poppingmoon/aria/issues/252)) ([7cb44e4](https://github.com/poppingmoon/aria/commit/7cb44e423a511dd1ae2c85be8c1cf37540e70f62))
* add Menlo for fonts of code ([#258](https://github.com/poppingmoon/aria/issues/258)) ([72a4a82](https://github.com/poppingmoon/aria/commit/72a4a82e30023bf4cce709db191947799783aba6))
* disable text scaling inside WidgetSpan ([#255](https://github.com/poppingmoon/aria/issues/255)) ([6a8d2ba](https://github.com/poppingmoon/aria/commit/6a8d2baa8a62e662df4e33871a6f194aaef454c0))
* hide children if the note has no children ([#256](https://github.com/poppingmoon/aria/issues/256)) ([d4171cb](https://github.com/poppingmoon/aria/commit/d4171cb5a445e3daf4559e678f38cb31302e254a))
* show icon for verified url  ([#254](https://github.com/poppingmoon/aria/issues/254)) ([60104cd](https://github.com/poppingmoon/aria/commit/60104cd1b799c73cf9be049ee89de91355d4ab69))
* use wrap to display remote caution buttons ([#253](https://github.com/poppingmoon/aria/issues/253)) ([dfcd000](https://github.com/poppingmoon/aria/commit/dfcd0002199a4fdd6264a53b76d10c833bb9352c))