### PR TITLE
fix: prevent child of interactive mfm from being tapped 

### DIFF
--- a/lib/model/mfm_config.dart
+++ b/lib/model/mfm_config.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'misskey_colors.dart';
+
+part 'mfm_config.freezed.dart';
+
+@freezed
+class MfmConfig with _$MfmConfig {
+  const factory MfmConfig({
+    required MisskeyColors colors,
+    required bool simple,
+    required TextStyle style,
+    required Widget Function(
+      String name,
+      double scale,
+      double opacity,
+      TextStyle fallbackTextStyle,
+    ) emojiBuilder,
+    required Widget Function(
+      String username,
+      String? host,
+      double scale,
+      double opacity,
+    ) mentionBuilder,
+    void Function(String emoji)? onTapEmoji,
+    void Function(String url)? onLinkTap,
+    void Function(String url)? onLinkLongPress,
+    void Function(String hashtag)? onHashtagTap,
+    void Function(String clickEv)? onClickEv,
+    @Default(false) bool shouldNyaize,
+    @Default(true) bool useAdvanced,
+    @Default(false) bool useAnimation,
+    @Default(1.0) double scale,
+    @Default(1.0) double opacity,
+    TextAlign? align,
+    TextOverflow? overflow,
+    int? maxLines,
+  }) = _MfmConfig;
+}

--- a/lib/model/mfm_config.freezed.dart
+++ b/lib/model/mfm_config.freezed.dart
@@ -1,0 +1,529 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mfm_config.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$MfmConfig {
+  MisskeyColors get colors => throw _privateConstructorUsedError;
+  bool get simple => throw _privateConstructorUsedError;
+  TextStyle get style => throw _privateConstructorUsedError;
+  Widget Function(String, double, double, TextStyle) get emojiBuilder =>
+      throw _privateConstructorUsedError;
+  Widget Function(String, String?, double, double) get mentionBuilder =>
+      throw _privateConstructorUsedError;
+  void Function(String)? get onTapEmoji => throw _privateConstructorUsedError;
+  void Function(String)? get onLinkTap => throw _privateConstructorUsedError;
+  void Function(String)? get onLinkLongPress =>
+      throw _privateConstructorUsedError;
+  void Function(String)? get onHashtagTap => throw _privateConstructorUsedError;
+  void Function(String)? get onClickEv => throw _privateConstructorUsedError;
+  bool get shouldNyaize => throw _privateConstructorUsedError;
+  bool get useAdvanced => throw _privateConstructorUsedError;
+  bool get useAnimation => throw _privateConstructorUsedError;
+  double get scale => throw _privateConstructorUsedError;
+  double get opacity => throw _privateConstructorUsedError;
+  TextAlign? get align => throw _privateConstructorUsedError;
+  TextOverflow? get overflow => throw _privateConstructorUsedError;
+  int? get maxLines => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $MfmConfigCopyWith<MfmConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MfmConfigCopyWith<$Res> {
+  factory $MfmConfigCopyWith(MfmConfig value, $Res Function(MfmConfig) then) =
+      _$MfmConfigCopyWithImpl<$Res, MfmConfig>;
+  @useResult
+  $Res call(
+      {MisskeyColors colors,
+      bool simple,
+      TextStyle style,
+      Widget Function(String, double, double, TextStyle) emojiBuilder,
+      Widget Function(String, String?, double, double) mentionBuilder,
+      void Function(String)? onTapEmoji,
+      void Function(String)? onLinkTap,
+      void Function(String)? onLinkLongPress,
+      void Function(String)? onHashtagTap,
+      void Function(String)? onClickEv,
+      bool shouldNyaize,
+      bool useAdvanced,
+      bool useAnimation,
+      double scale,
+      double opacity,
+      TextAlign? align,
+      TextOverflow? overflow,
+      int? maxLines});
+
+  $MisskeyColorsCopyWith<$Res> get colors;
+}
+
+/// @nodoc
+class _$MfmConfigCopyWithImpl<$Res, $Val extends MfmConfig>
+    implements $MfmConfigCopyWith<$Res> {
+  _$MfmConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? colors = null,
+    Object? simple = null,
+    Object? style = null,
+    Object? emojiBuilder = null,
+    Object? mentionBuilder = null,
+    Object? onTapEmoji = freezed,
+    Object? onLinkTap = freezed,
+    Object? onLinkLongPress = freezed,
+    Object? onHashtagTap = freezed,
+    Object? onClickEv = freezed,
+    Object? shouldNyaize = null,
+    Object? useAdvanced = null,
+    Object? useAnimation = null,
+    Object? scale = null,
+    Object? opacity = null,
+    Object? align = freezed,
+    Object? overflow = freezed,
+    Object? maxLines = freezed,
+  }) {
+    return _then(_value.copyWith(
+      colors: null == colors
+          ? _value.colors
+          : colors // ignore: cast_nullable_to_non_nullable
+              as MisskeyColors,
+      simple: null == simple
+          ? _value.simple
+          : simple // ignore: cast_nullable_to_non_nullable
+              as bool,
+      style: null == style
+          ? _value.style
+          : style // ignore: cast_nullable_to_non_nullable
+              as TextStyle,
+      emojiBuilder: null == emojiBuilder
+          ? _value.emojiBuilder
+          : emojiBuilder // ignore: cast_nullable_to_non_nullable
+              as Widget Function(String, double, double, TextStyle),
+      mentionBuilder: null == mentionBuilder
+          ? _value.mentionBuilder
+          : mentionBuilder // ignore: cast_nullable_to_non_nullable
+              as Widget Function(String, String?, double, double),
+      onTapEmoji: freezed == onTapEmoji
+          ? _value.onTapEmoji
+          : onTapEmoji // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onLinkTap: freezed == onLinkTap
+          ? _value.onLinkTap
+          : onLinkTap // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onLinkLongPress: freezed == onLinkLongPress
+          ? _value.onLinkLongPress
+          : onLinkLongPress // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onHashtagTap: freezed == onHashtagTap
+          ? _value.onHashtagTap
+          : onHashtagTap // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onClickEv: freezed == onClickEv
+          ? _value.onClickEv
+          : onClickEv // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      shouldNyaize: null == shouldNyaize
+          ? _value.shouldNyaize
+          : shouldNyaize // ignore: cast_nullable_to_non_nullable
+              as bool,
+      useAdvanced: null == useAdvanced
+          ? _value.useAdvanced
+          : useAdvanced // ignore: cast_nullable_to_non_nullable
+              as bool,
+      useAnimation: null == useAnimation
+          ? _value.useAnimation
+          : useAnimation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      scale: null == scale
+          ? _value.scale
+          : scale // ignore: cast_nullable_to_non_nullable
+              as double,
+      opacity: null == opacity
+          ? _value.opacity
+          : opacity // ignore: cast_nullable_to_non_nullable
+              as double,
+      align: freezed == align
+          ? _value.align
+          : align // ignore: cast_nullable_to_non_nullable
+              as TextAlign?,
+      overflow: freezed == overflow
+          ? _value.overflow
+          : overflow // ignore: cast_nullable_to_non_nullable
+              as TextOverflow?,
+      maxLines: freezed == maxLines
+          ? _value.maxLines
+          : maxLines // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $MisskeyColorsCopyWith<$Res> get colors {
+    return $MisskeyColorsCopyWith<$Res>(_value.colors, (value) {
+      return _then(_value.copyWith(colors: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$MfmConfigImplCopyWith<$Res>
+    implements $MfmConfigCopyWith<$Res> {
+  factory _$$MfmConfigImplCopyWith(
+          _$MfmConfigImpl value, $Res Function(_$MfmConfigImpl) then) =
+      __$$MfmConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {MisskeyColors colors,
+      bool simple,
+      TextStyle style,
+      Widget Function(String, double, double, TextStyle) emojiBuilder,
+      Widget Function(String, String?, double, double) mentionBuilder,
+      void Function(String)? onTapEmoji,
+      void Function(String)? onLinkTap,
+      void Function(String)? onLinkLongPress,
+      void Function(String)? onHashtagTap,
+      void Function(String)? onClickEv,
+      bool shouldNyaize,
+      bool useAdvanced,
+      bool useAnimation,
+      double scale,
+      double opacity,
+      TextAlign? align,
+      TextOverflow? overflow,
+      int? maxLines});
+
+  @override
+  $MisskeyColorsCopyWith<$Res> get colors;
+}
+
+/// @nodoc
+class __$$MfmConfigImplCopyWithImpl<$Res>
+    extends _$MfmConfigCopyWithImpl<$Res, _$MfmConfigImpl>
+    implements _$$MfmConfigImplCopyWith<$Res> {
+  __$$MfmConfigImplCopyWithImpl(
+      _$MfmConfigImpl _value, $Res Function(_$MfmConfigImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? colors = null,
+    Object? simple = null,
+    Object? style = null,
+    Object? emojiBuilder = null,
+    Object? mentionBuilder = null,
+    Object? onTapEmoji = freezed,
+    Object? onLinkTap = freezed,
+    Object? onLinkLongPress = freezed,
+    Object? onHashtagTap = freezed,
+    Object? onClickEv = freezed,
+    Object? shouldNyaize = null,
+    Object? useAdvanced = null,
+    Object? useAnimation = null,
+    Object? scale = null,
+    Object? opacity = null,
+    Object? align = freezed,
+    Object? overflow = freezed,
+    Object? maxLines = freezed,
+  }) {
+    return _then(_$MfmConfigImpl(
+      colors: null == colors
+          ? _value.colors
+          : colors // ignore: cast_nullable_to_non_nullable
+              as MisskeyColors,
+      simple: null == simple
+          ? _value.simple
+          : simple // ignore: cast_nullable_to_non_nullable
+              as bool,
+      style: null == style
+          ? _value.style
+          : style // ignore: cast_nullable_to_non_nullable
+              as TextStyle,
+      emojiBuilder: null == emojiBuilder
+          ? _value.emojiBuilder
+          : emojiBuilder // ignore: cast_nullable_to_non_nullable
+              as Widget Function(String, double, double, TextStyle),
+      mentionBuilder: null == mentionBuilder
+          ? _value.mentionBuilder
+          : mentionBuilder // ignore: cast_nullable_to_non_nullable
+              as Widget Function(String, String?, double, double),
+      onTapEmoji: freezed == onTapEmoji
+          ? _value.onTapEmoji
+          : onTapEmoji // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onLinkTap: freezed == onLinkTap
+          ? _value.onLinkTap
+          : onLinkTap // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onLinkLongPress: freezed == onLinkLongPress
+          ? _value.onLinkLongPress
+          : onLinkLongPress // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onHashtagTap: freezed == onHashtagTap
+          ? _value.onHashtagTap
+          : onHashtagTap // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      onClickEv: freezed == onClickEv
+          ? _value.onClickEv
+          : onClickEv // ignore: cast_nullable_to_non_nullable
+              as void Function(String)?,
+      shouldNyaize: null == shouldNyaize
+          ? _value.shouldNyaize
+          : shouldNyaize // ignore: cast_nullable_to_non_nullable
+              as bool,
+      useAdvanced: null == useAdvanced
+          ? _value.useAdvanced
+          : useAdvanced // ignore: cast_nullable_to_non_nullable
+              as bool,
+      useAnimation: null == useAnimation
+          ? _value.useAnimation
+          : useAnimation // ignore: cast_nullable_to_non_nullable
+              as bool,
+      scale: null == scale
+          ? _value.scale
+          : scale // ignore: cast_nullable_to_non_nullable
+              as double,
+      opacity: null == opacity
+          ? _value.opacity
+          : opacity // ignore: cast_nullable_to_non_nullable
+              as double,
+      align: freezed == align
+          ? _value.align
+          : align // ignore: cast_nullable_to_non_nullable
+              as TextAlign?,
+      overflow: freezed == overflow
+          ? _value.overflow
+          : overflow // ignore: cast_nullable_to_non_nullable
+              as TextOverflow?,
+      maxLines: freezed == maxLines
+          ? _value.maxLines
+          : maxLines // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MfmConfigImpl implements _MfmConfig {
+  const _$MfmConfigImpl(
+      {required this.colors,
+      required this.simple,
+      required this.style,
+      required this.emojiBuilder,
+      required this.mentionBuilder,
+      this.onTapEmoji,
+      this.onLinkTap,
+      this.onLinkLongPress,
+      this.onHashtagTap,
+      this.onClickEv,
+      this.shouldNyaize = false,
+      this.useAdvanced = true,
+      this.useAnimation = false,
+      this.scale = 1.0,
+      this.opacity = 1.0,
+      this.align,
+      this.overflow,
+      this.maxLines});
+
+  @override
+  final MisskeyColors colors;
+  @override
+  final bool simple;
+  @override
+  final TextStyle style;
+  @override
+  final Widget Function(String, double, double, TextStyle) emojiBuilder;
+  @override
+  final Widget Function(String, String?, double, double) mentionBuilder;
+  @override
+  final void Function(String)? onTapEmoji;
+  @override
+  final void Function(String)? onLinkTap;
+  @override
+  final void Function(String)? onLinkLongPress;
+  @override
+  final void Function(String)? onHashtagTap;
+  @override
+  final void Function(String)? onClickEv;
+  @override
+  @JsonKey()
+  final bool shouldNyaize;
+  @override
+  @JsonKey()
+  final bool useAdvanced;
+  @override
+  @JsonKey()
+  final bool useAnimation;
+  @override
+  @JsonKey()
+  final double scale;
+  @override
+  @JsonKey()
+  final double opacity;
+  @override
+  final TextAlign? align;
+  @override
+  final TextOverflow? overflow;
+  @override
+  final int? maxLines;
+
+  @override
+  String toString() {
+    return 'MfmConfig(colors: $colors, simple: $simple, style: $style, emojiBuilder: $emojiBuilder, mentionBuilder: $mentionBuilder, onTapEmoji: $onTapEmoji, onLinkTap: $onLinkTap, onLinkLongPress: $onLinkLongPress, onHashtagTap: $onHashtagTap, onClickEv: $onClickEv, shouldNyaize: $shouldNyaize, useAdvanced: $useAdvanced, useAnimation: $useAnimation, scale: $scale, opacity: $opacity, align: $align, overflow: $overflow, maxLines: $maxLines)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MfmConfigImpl &&
+            (identical(other.colors, colors) || other.colors == colors) &&
+            (identical(other.simple, simple) || other.simple == simple) &&
+            (identical(other.style, style) || other.style == style) &&
+            (identical(other.emojiBuilder, emojiBuilder) ||
+                other.emojiBuilder == emojiBuilder) &&
+            (identical(other.mentionBuilder, mentionBuilder) ||
+                other.mentionBuilder == mentionBuilder) &&
+            (identical(other.onTapEmoji, onTapEmoji) ||
+                other.onTapEmoji == onTapEmoji) &&
+            (identical(other.onLinkTap, onLinkTap) ||
+                other.onLinkTap == onLinkTap) &&
+            (identical(other.onLinkLongPress, onLinkLongPress) ||
+                other.onLinkLongPress == onLinkLongPress) &&
+            (identical(other.onHashtagTap, onHashtagTap) ||
+                other.onHashtagTap == onHashtagTap) &&
+            (identical(other.onClickEv, onClickEv) ||
+                other.onClickEv == onClickEv) &&
+            (identical(other.shouldNyaize, shouldNyaize) ||
+                other.shouldNyaize == shouldNyaize) &&
+            (identical(other.useAdvanced, useAdvanced) ||
+                other.useAdvanced == useAdvanced) &&
+            (identical(other.useAnimation, useAnimation) ||
+                other.useAnimation == useAnimation) &&
+            (identical(other.scale, scale) || other.scale == scale) &&
+            (identical(other.opacity, opacity) || other.opacity == opacity) &&
+            (identical(other.align, align) || other.align == align) &&
+            (identical(other.overflow, overflow) ||
+                other.overflow == overflow) &&
+            (identical(other.maxLines, maxLines) ||
+                other.maxLines == maxLines));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      colors,
+      simple,
+      style,
+      emojiBuilder,
+      mentionBuilder,
+      onTapEmoji,
+      onLinkTap,
+      onLinkLongPress,
+      onHashtagTap,
+      onClickEv,
+      shouldNyaize,
+      useAdvanced,
+      useAnimation,
+      scale,
+      opacity,
+      align,
+      overflow,
+      maxLines);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MfmConfigImplCopyWith<_$MfmConfigImpl> get copyWith =>
+      __$$MfmConfigImplCopyWithImpl<_$MfmConfigImpl>(this, _$identity);
+}
+
+abstract class _MfmConfig implements MfmConfig {
+  const factory _MfmConfig(
+      {required final MisskeyColors colors,
+      required final bool simple,
+      required final TextStyle style,
+      required final Widget Function(String, double, double, TextStyle)
+          emojiBuilder,
+      required final Widget Function(String, String?, double, double)
+          mentionBuilder,
+      final void Function(String)? onTapEmoji,
+      final void Function(String)? onLinkTap,
+      final void Function(String)? onLinkLongPress,
+      final void Function(String)? onHashtagTap,
+      final void Function(String)? onClickEv,
+      final bool shouldNyaize,
+      final bool useAdvanced,
+      final bool useAnimation,
+      final double scale,
+      final double opacity,
+      final TextAlign? align,
+      final TextOverflow? overflow,
+      final int? maxLines}) = _$MfmConfigImpl;
+
+  @override
+  MisskeyColors get colors;
+  @override
+  bool get simple;
+  @override
+  TextStyle get style;
+  @override
+  Widget Function(String, double, double, TextStyle) get emojiBuilder;
+  @override
+  Widget Function(String, String?, double, double) get mentionBuilder;
+  @override
+  void Function(String)? get onTapEmoji;
+  @override
+  void Function(String)? get onLinkTap;
+  @override
+  void Function(String)? get onLinkLongPress;
+  @override
+  void Function(String)? get onHashtagTap;
+  @override
+  void Function(String)? get onClickEv;
+  @override
+  bool get shouldNyaize;
+  @override
+  bool get useAdvanced;
+  @override
+  bool get useAnimation;
+  @override
+  double get scale;
+  @override
+  double get opacity;
+  @override
+  TextAlign? get align;
+  @override
+  TextOverflow? get overflow;
+  @override
+  int? get maxLines;
+  @override
+  @JsonKey(ignore: true)
+  _$$MfmConfigImplCopyWith<_$MfmConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -6,6 +6,7 @@ import 'package:mfm_parser/mfm_parser.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../model/account.dart';
+import '../../model/mfm_config.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
 import '../../util/navigate.dart';
@@ -41,7 +42,7 @@ List<InlineSpan> buildMfm(
   final useAdvanced = generalSettings.advancedMfm;
   final useAnimation = useAdvanced && generalSettings.animatedMfm;
 
-  return MfmBuilder(
+  return MfmConfig(
     colors: colors,
     simple: simple,
     style: textStyle,

--- a/lib/view/widget/mfm/blur.dart
+++ b/lib/view/widget/mfm/blur.dart
@@ -26,7 +26,7 @@ class Blur extends HookWidget {
                 sigmaY: 6.0,
                 tileMode: TileMode.decal,
               ),
-              child: child,
+              child: AbsorbPointer(child: child),
             )
           : child,
     );

--- a/lib/view/widget/mfm/mfm_builder.dart
+++ b/lib/view/widget/mfm/mfm_builder.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart' hide Border;
 import 'package:flutter/material.dart' as material show Border;
+import 'package:flutter/material.dart' hide Border;
 import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:mfm_parser/mfm_parser.dart';
 
@@ -9,7 +9,7 @@ import '../../../constant/fonts.dart';
 import '../../../extension/text_style_extension.dart';
 import '../../../gen/fonts.gen.dart';
 import '../../../i18n/strings.g.dart';
-import '../../../model/misskey_colors.dart';
+import '../../../model/mfm_config.dart';
 import '../../../util/format_datetime.dart';
 import '../../../util/nyaize.dart';
 import '../../../util/safe_parse_color.dart';
@@ -50,57 +50,7 @@ const _richTextFn = [
   'border',
 ];
 
-class MfmBuilder {
-  const MfmBuilder({
-    required this.colors,
-    this.simple = false,
-    required this.style,
-    required this.emojiBuilder,
-    required this.mentionBuilder,
-    this.onTapEmoji,
-    this.onLinkTap,
-    this.onLinkLongPress,
-    this.onHashtagTap,
-    this.onClickEv,
-    this.shouldNyaize = false,
-    this.useAdvanced = true,
-    this.useAnimation = false,
-    this.scale = 1.0,
-    this.opacity = 1.0,
-    this.align,
-    this.overflow,
-    this.maxLines,
-  });
-
-  final MisskeyColors colors;
-  final bool simple;
-  final TextStyle style;
-  final Widget Function(
-    String name,
-    double scale,
-    double opacity,
-    TextStyle fallbackTextStyle,
-  ) emojiBuilder;
-  final Widget Function(
-    String username,
-    String? host,
-    double scale,
-    double opacity,
-  ) mentionBuilder;
-  final void Function(String emoji)? onTapEmoji;
-  final void Function(String url)? onLinkTap;
-  final void Function(String url)? onLinkLongPress;
-  final void Function(String hashtag)? onHashtagTap;
-  final void Function(String clickEv)? onClickEv;
-  final bool shouldNyaize;
-  final bool useAdvanced;
-  final bool useAnimation;
-  final double scale;
-  final double opacity;
-  final TextAlign? align;
-  final TextOverflow? overflow;
-  final int? maxLines;
-
+extension MfmBuilder on MfmConfig {
   List<InlineSpan> build(
     List<MfmNode> nodes, {
     bool disableNyaize = false,
@@ -137,7 +87,7 @@ class MfmBuilder {
                 style: style.apply(fontStyle: FontStyle.italic),
                 children: build(children),
               ),
-            MfmFn(:final name, :final args, :final children?) => buildMfmFn(
+            MfmFn(:final name, :final args, :final children?) => _buildMfmFn(
                 name: name,
                 args: args,
                 children: children,
@@ -368,7 +318,7 @@ class MfmBuilder {
         .toList();
   }
 
-  InlineSpan buildMfmFn({
+  InlineSpan _buildMfmFn({
     required String name,
     required Map<String, dynamic> args,
     required List<MfmNode> children,
@@ -889,57 +839,39 @@ class MfmBuilder {
     return TextSpan(children: build(children));
   }
 
-  MfmBuilder copyWith({
-    TextStyle? style,
-    double? scale,
-    double? opacity,
-    TextAlign? align,
-  }) =>
-      MfmBuilder(
-        colors: colors,
-        simple: simple,
-        style: style ?? this.style,
-        emojiBuilder: emojiBuilder,
-        mentionBuilder: mentionBuilder,
-        onLinkTap: onLinkTap,
-        onHashtagTap: onHashtagTap,
-        shouldNyaize: shouldNyaize,
-        useAdvanced: useAdvanced,
-        useAnimation: useAnimation,
-        scale: scale ?? this.scale,
-        opacity: opacity ?? this.opacity,
-        align: align ?? this.align,
-      );
+  bool _containsNewLine(MfmNode node) {
+    return switch (node) {
+      MfmText(:final text) || MfmPlain(:final text) => text.contains('\n'),
+      MfmFn(:final name, :final children?) =>
+        !_richTextFn.contains(name) && children.any(_containsNewLine),
+      MfmNode(:final children?) => children.any(_containsNewLine),
+      _ => false,
+    };
+  }
 
-  bool _containsNewLine(MfmNode node) => switch (node) {
-        MfmText(:final text) || MfmPlain(:final text) => text.contains('\n'),
-        MfmFn(:final name, :final children?) =>
-          !_richTextFn.contains(name) && children.any(_containsNewLine),
-        MfmNode(:final children?) => children.any(_containsNewLine),
-        _ => false,
-      };
-
-  MfmInline _removeNewLines(MfmInline node) => switch (node) {
-        MfmText(:final text) => MfmText(text.replaceAll('\n', '')),
-        MfmPlain(:final text) => MfmPlain(text.replaceAll('\n', '')),
-        MfmBold(:final children?) => MfmBold(
-            children.whereType<MfmInline>().map(_removeNewLines).toList(),
-          ),
-        MfmSmall(:final children?) => MfmSmall(
-            children.whereType<MfmInline>().map(_removeNewLines).toList(),
-          ),
-        MfmItalic(:final children?) => MfmItalic(
-            children.whereType<MfmInline>().map(_removeNewLines).toList(),
-          ),
-        MfmStrike(:final children?) => MfmStrike(
-            children.whereType<MfmInline>().map(_removeNewLines).toList(),
-          ),
-        MfmFn(:final name, :final args, :final children?) => MfmFn(
-            name: name,
-            args: args,
-            children:
-                children.whereType<MfmInline>().map(_removeNewLines).toList(),
-          ),
-        _ => node,
-      };
+  MfmInline _removeNewLines(MfmInline node) {
+    return switch (node) {
+      MfmText(:final text) => MfmText(text.replaceAll('\n', '')),
+      MfmPlain(:final text) => MfmPlain(text.replaceAll('\n', '')),
+      MfmBold(:final children?) => MfmBold(
+          children.whereType<MfmInline>().map(_removeNewLines).toList(),
+        ),
+      MfmSmall(:final children?) => MfmSmall(
+          children.whereType<MfmInline>().map(_removeNewLines).toList(),
+        ),
+      MfmItalic(:final children?) => MfmItalic(
+          children.whereType<MfmInline>().map(_removeNewLines).toList(),
+        ),
+      MfmStrike(:final children?) => MfmStrike(
+          children.whereType<MfmInline>().map(_removeNewLines).toList(),
+        ),
+      MfmFn(:final name, :final args, :final children?) => MfmFn(
+          name: name,
+          args: args,
+          children:
+              children.whereType<MfmInline>().map(_removeNewLines).toList(),
+        ),
+      _ => node,
+    };
+  }
 }

--- a/lib/view/widget/mfm/mfm_builder.dart
+++ b/lib/view/widget/mfm/mfm_builder.dart
@@ -8,11 +8,12 @@ import 'package:mfm_parser/mfm_parser.dart';
 import '../../../constant/fonts.dart';
 import '../../../extension/text_style_extension.dart';
 import '../../../gen/fonts.gen.dart';
+import '../../../i18n/strings.g.dart';
 import '../../../model/misskey_colors.dart';
+import '../../../util/format_datetime.dart';
 import '../../../util/nyaize.dart';
 import '../../../util/safe_parse_color.dart';
 import '../../../util/safe_parse_double.dart';
-import '../time_widget.dart';
 import '../unicode_emoji.dart';
 import '../url_widget.dart';
 import 'blur.dart';
@@ -825,29 +826,30 @@ class MfmBuilder {
                 vertical: 4.0 * scale,
                 horizontal: 8.0 * scale,
               ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.access_time,
-                    color: style.color?.withOpacity(opacity),
-                    size: style.lineHeight * scale * 0.9,
-                  ),
-                  SizedBox(width: 2.0 * scale),
-                  Expanded(
-                    child: DefaultTextStyle(
-                      style: style.apply(
-                        fontSizeFactor: scale * 0.9,
+              child: Text.rich(
+                TextSpan(
+                  children: [
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.middle,
+                      child: Icon(
+                        Icons.access_time,
                         color: style.color?.withOpacity(opacity),
-                      ),
-                      child: TimeWidget(
-                        time: time,
-                        detailed: true,
-                        textScaler: TextScaler.noScaling,
+                        size: style.lineHeight * scale * 0.9,
                       ),
                     ),
-                  ),
-                ],
+                    WidgetSpan(child: SizedBox(width: 2.0 * scale)),
+                    if (time != null)
+                      TextSpan(
+                        text: '${absoluteTime(time)} (${relativeTime(time)})',
+                        style: style.apply(
+                          fontSizeFactor: scale * 0.9,
+                          color: style.color?.withOpacity(opacity),
+                        ),
+                      )
+                    else
+                      TextSpan(text: t.misskey.ago_.invalid),
+                  ],
+                ),
               ),
             ),
           ),
@@ -864,12 +866,14 @@ class MfmBuilder {
             onTap: clickEv != null && onClickEv != null
                 ? () => onClickEv?.call(clickEv)
                 : null,
-            child: Text.rich(
-              span,
-              textAlign: align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+            child: AbsorbPointer(
+              child: Text.rich(
+                span,
+                textAlign: align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );


### PR DESCRIPTION
Wrapped child of `[link]()` and `$[clickable]` with `AbsorbPointer` to capture gesture correctly even if tappable mfm like `:emoji:` is contained in it.