### PR TITLE
fix: clip background of note preview

### DIFF
--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -193,6 +193,7 @@ class PostPage extends HookConsumerWidget {
                           color: colors.panel,
                           elevation: 0.0,
                           margin: const EdgeInsets.all(8.0),
+                          clipBehavior: Clip.antiAlias,
                           child: request.isRenote
                               ? NoteWidget(
                                   account: account.value,


### PR DESCRIPTION
Added clip behavior to `Card` to apply a circular border to the preview of the note even if a background color is specified.