### PR TITLE
fix: use id to open user page from lookup

### DIFF
--- a/lib/view/widget/timeline_drawer.dart
+++ b/lib/view/widget/timeline_drawer.dart
@@ -197,7 +197,7 @@ class TimelineDrawer extends HookConsumerWidget {
                           if (!context.mounted) return;
                           if (response.type == 'User') {
                             await context.push(
-                              '/$account/users/${response.object}',
+                              '/$account/users/${response.object['id']}',
                             );
                           } else if (response.type == 'Note') {
                             await context.push(


### PR DESCRIPTION
Corrected the path to a user page when the response is a user.