### PR TITLE
fix: add renote as detailed at `NotesNotifier`

### DIFF
--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -22,7 +22,7 @@ class NotesNotifier extends _$NotesNotifier {
   Note? add(Note note, {bool detail = true}) {
     final renote = note.renote;
     if (renote != null) {
-      add(renote, detail: false);
+      add(renote);
     }
     final reply = note.reply;
     if (reply != null) {
@@ -38,6 +38,7 @@ class NotesNotifier extends _$NotesNotifier {
         renote: renote ?? state[note.renoteId],
         reply: reply ?? state[note.replyId],
         poll: detail ? note.poll : cachedNote?.poll,
+        myReaction: detail ? note.myReaction : cachedNote?.myReaction,
       ),
     };
     return cachedNote;

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'8f317ab70fe8e6bfa42b4ed3150f79c4f73fa598';
+String _$notesNotifierHash() => r'968bdeff15453f941f975ac961e89154c3148a2c';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
This fixes an issue where polls contained in renotes are not visible.

ref: https://github.com/misskey-dev/misskey/blob/a6edd50a5d292e29e6292754a7be95205ac7dbc1/packages/backend/src/core/entities/NoteEntityService.ts#L371