### PR TITLE
fix: close dialog after deletion

### DIFF
--- a/lib/view/dialog/delete_and_edit_dialog.dart
+++ b/lib/view/dialog/delete_and_edit_dialog.dart
@@ -30,7 +30,6 @@ class DeleteAndEditDialog extends ConsumerWidget {
         ElevatedButton(
           autofocus: true,
           onPressed: () async {
-            context.pop();
             ref.read(postNotifierProvider(account).notifier).fromNote(note);
             ref.read(attachesNotifierProvider(account).notifier).addAll(
                   note.files.map(
@@ -48,6 +47,7 @@ class DeleteAndEditDialog extends ConsumerWidget {
             if (!(deleted ?? false)) return;
             if (!context.mounted) return;
             ref.read(notesNotifierProvider(account).notifier).remove(note.id);
+            context.pop();
             await context.push('/$account/post');
           },
           child: Text(t.misskey.ok),


### PR DESCRIPTION
This fixes an issue where "delete and edit" does not complete if the target note is a reply.