### PR TITLE
feat: use inputted host to open `TokenLoginPage`

### DIFF
--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -123,7 +123,9 @@ GoRouter router(RouterRef ref) {
           ),
           GoRoute(
             path: 'token',
-            builder: (_, __) => const TokenLoginPage(),
+            builder: (_, state) => TokenLoginPage(
+              host: state.uri.queryParameters['host'],
+            ),
           ),
         ],
       ),

--- a/lib/router/router.g.dart
+++ b/lib/router/router.g.dart
@@ -6,7 +6,7 @@ part of 'router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'78ec8f098d73703df414cb80fff35db35172a595';
+String _$routerHash() => r'a1067d1e46d3fde44c3eae8e8ea4ea85113b4ad9';
 
 /// See also [router].
 @ProviderFor(router)

--- a/lib/view/page/login_page.dart
+++ b/lib/view/page/login_page.dart
@@ -63,7 +63,8 @@ class LoginPage extends HookConsumerWidget {
                     PopupMenuButton<void>(
                       itemBuilder: (context) => [
                         PopupMenuItem(
-                          onTap: () => context.push('/login/token'),
+                          onTap: () =>
+                              context.push('/login/token?host=${host.value}'),
                           child: Text(t.aria.loginWithAccessToken),
                         ),
                       ],

--- a/lib/view/page/token_login_page.dart
+++ b/lib/view/page/token_login_page.dart
@@ -18,7 +18,9 @@ import '../widget/misskey_server_autocomplete.dart';
 import '../widget/misskey_server_background.dart';
 
 class TokenLoginPage extends HookConsumerWidget {
-  const TokenLoginPage({super.key});
+  const TokenLoginPage({super.key, this.host});
+
+  final String? host;
 
   Future<void> _login(WidgetRef ref, String host, String token) async {
     final trimmed =
@@ -37,8 +39,8 @@ class TokenLoginPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final servers = ref.watch(misskeyServersProvider).valueOrNull ?? [];
-    final hostController = useTextEditingController();
-    final host = useState('');
+    final hostController = useTextEditingController(text: this.host);
+    final host = useState(this.host ?? '');
     final hostFocusNode = useFocusNode();
     final server =
         servers.firstWhereOrNull((server) => server.url == host.value);


### PR DESCRIPTION
When opening `TokenLoginPage` from `LoginPage`, send the host in the `TextField` to avoid re-entering it.