### PR TITLE
fix: add space between text and reactions in sub note

### DIFF
--- a/lib/view/widget/sub_note_content.dart
+++ b/lib/view/widget/sub_note_content.dart
@@ -191,12 +191,14 @@ class SubNoteContent extends HookConsumerWidget {
             ),
           ),
         if (showReactionsViewer &&
-            note.reactionAcceptance != ReactionAcceptance.likeOnly)
+            note.reactionAcceptance != ReactionAcceptance.likeOnly) ...[
+          const SizedBox(height: 4.0),
           ReactionsViewer(
             account: account,
             noteId: noteId,
             note: this.note,
           ),
+        ],
         if (showFooter)
           NoteFooter(
             account: account,


### PR DESCRIPTION
Added space above `ReactionsViewer` in `SubNoteContent` to separate it from the text.