### PR TITLE
fix: do not pass token to Play

### DIFF
--- a/lib/view/widget/play_widget.dart
+++ b/lib/view/widget/play_widget.dart
@@ -18,7 +18,6 @@ import '../../provider/api/post_notifier_provider.dart';
 import '../../provider/dio_provider.dart';
 import '../../provider/emojis_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
-import '../../provider/token_provider.dart';
 import '../../rust/api/aiscript.dart';
 import '../../rust/api/aiscript/api.dart';
 import '../../rust/api/aiscript/play.dart';
@@ -299,7 +298,6 @@ class PlayWidget extends HookConsumerWidget {
                                     );
                                     return result ?? false;
                                   },
-                                  token: ref.read(tokenProvider(account)),
                                   api: (ep, param, token) async {
                                     final json = jsonDecode(param);
                                     final dio = ref.read(dioProvider);


### PR DESCRIPTION
Changed not to use the access token stored on Aria for `Mk:api` function inside Play to make the behavior compatible with Misskey Web.

ref: https://github.com/misskey-dev/misskey/blob/9ef6c4716ca25d8adeb5344c82a433370a086f88/packages/frontend/src/pages/flash/flash.vue#L190-L192