### PR TITLE
fix: fetch reply and renote in draft

### DIFF
--- a/lib/provider/api/page_provider.dart
+++ b/lib/provider/api/page_provider.dart
@@ -33,11 +33,8 @@ class PageNotifier extends _$PageNotifier {
     unawaited(
       Future.wait(
         noteIds.map(
-          (noteId) async {
-            final note =
-                await _misskey.notes.show(NotesShowRequest(noteId: noteId));
-            ref.read(notesNotifierProvider(account).notifier).add(note);
-          },
+          (noteId) =>
+              ref.read(notesNotifierProvider(account).notifier).show(noteId),
         ),
       ),
     );

--- a/lib/provider/api/page_provider.g.dart
+++ b/lib/provider/api/page_provider.g.dart
@@ -6,7 +6,7 @@ part of 'page_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$pageNotifierHash() => r'a6852715673bd32e4df20407131517a9ff0fcbe6';
+String _$pageNotifierHash() => r'4de4105411c45ac9e0219999e05152a2f85069ef';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/post_notifier_provider.dart
+++ b/lib/provider/api/post_notifier_provider.dart
@@ -106,11 +106,9 @@ class PostNotifier extends _$PostNotifier {
         return remoteNoteId;
       }
       try {
-        final note = await ref
-            .read(misskeyProvider(account))
-            .notes
-            .show(NotesShowRequest(noteId: remoteNoteId));
-        ref.read(notesNotifierProvider(account).notifier).add(note);
+        await ref
+            .read(notesNotifierProvider(account).notifier)
+            .show(remoteNoteId);
       } catch (_) {}
       return remoteNoteId;
     }

--- a/lib/provider/api/post_notifier_provider.g.dart
+++ b/lib/provider/api/post_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'post_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$postNotifierHash() => r'f9a32eddc12dfa6a3e1bf1b808644768ee606c92';
+String _$postNotifierHash() => r'3d91f03110ea5dc0015442266a0c2c87a182a5fd';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -50,6 +50,12 @@ class NotesNotifier extends _$NotesNotifier {
     }
   }
 
+  Future<Note> show(String noteId) async {
+    final note = await _misskey.notes.show(NotesShowRequest(noteId: noteId));
+    add(note);
+    return note;
+  }
+
   void remove(String noteId) {
     state = {
       ...state,

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'354ecd226bdf237cdd9a74c09a47505052eabd6a';
+String _$notesNotifierHash() => r'8560d6797d38ea88f86e8f9b6039f7f4eff3ebd3';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/dialog/post_confirmation_dialog.dart
+++ b/lib/view/dialog/post_confirmation_dialog.dart
@@ -6,27 +6,22 @@ import 'package:misskey_dart/misskey_dart.dart';
 import '../../extension/notes_create_request_extension.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
-import '../../model/post_file.dart';
-import '../../provider/api/attaches_notifier_provider.dart';
 import '../../provider/api/channel_notifier_provider.dart';
 import '../../provider/api/i_notifier_provider.dart';
-import '../../provider/api/post_notifier_provider.dart';
 import '../widget/note_widget.dart';
 
 Future<bool> confirmPost(
-  BuildContext context,
-  Account account, {
-  String? noteId,
-  NotesCreateRequest? request,
+  WidgetRef ref,
+  Account account,
+  NotesCreateRequest request, {
   List<DriveFile>? files,
 }) async {
   final result = await showDialog<bool>(
-    context: context,
+    context: ref.context,
     builder: (context) => PostConfirmationDialog(
       account: account,
-      noteId: noteId,
       request: request,
-      files: files,
+      files: files ?? [],
     ),
   );
   return result ?? false;
@@ -36,26 +31,16 @@ class PostConfirmationDialog extends ConsumerWidget {
   const PostConfirmationDialog({
     super.key,
     required this.account,
-    this.noteId,
-    this.request,
-    this.files,
+    required this.request,
+    required this.files,
   });
 
   final Account account;
-  final String? noteId;
-  final NotesCreateRequest? request;
-  final List<DriveFile>? files;
+  final NotesCreateRequest request;
+  final List<DriveFile> files;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final NotesCreateRequest request = this.request ??
-        ref.watch(postNotifierProvider(account, noteId: noteId));
-    final files = this.files ??
-        ref
-            .watch(attachesNotifierProvider(account, noteId: noteId))
-            .map((file) => file is DrivePostFile ? file.file : null)
-            .nonNulls
-            .toList();
     final i = ref.watch(iNotifierProvider(account)).valueOrNull;
     final channel = request.channelId != null
         ? ref

--- a/lib/view/page/note_page.dart
+++ b/lib/view/page/note_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:misskey_dart/misskey_dart.dart' hide Clip;
 
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
@@ -10,7 +9,6 @@ import '../../model/pagination_state.dart';
 import '../../model/tab_settings.dart';
 import '../../provider/api/i_notifier_provider.dart';
 import '../../provider/api/meta_notifier_provider.dart';
-import '../../provider/api/misskey_provider.dart';
 import '../../provider/api/timeline_notes_after_note_notifier_provider.dart';
 import '../../provider/api/timeline_notes_notifier_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
@@ -140,17 +138,12 @@ class NotePage extends HookConsumerWidget {
         title: Text(t.misskey.note),
         actions: [
           IconButton(
+            tooltip: t.misskey.reload,
             onPressed: () async {
-              final note = await futureWithDialog(
+              await futureWithDialog(
                 context,
-                ref
-                    .read(misskeyProvider(account))
-                    .notes
-                    .show(NotesShowRequest(noteId: noteId)),
+                ref.read(notesNotifierProvider(account).notifier).show(noteId),
               );
-              if (note != null) {
-                ref.read(notesNotifierProvider(account).notifier).add(note);
-              }
             },
             icon: const Icon(Icons.refresh),
           ),

--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -38,7 +38,7 @@ class PostPage extends HookConsumerWidget {
     WidgetRef ref,
     Account account,
   ) async {
-    final text = ref.read(postNotifierProvider(account, noteId: noteId)).text;
+    final request = ref.read(postNotifierProvider(account, noteId: noteId));
     final attaches =
         ref.read(attachesNotifierProvider(account, noteId: noteId));
     final hasFiles = attaches.isNotEmpty;
@@ -58,9 +58,10 @@ class PostPage extends HookConsumerWidget {
     if (needsUpload ||
         (ref.read(generalSettingsNotifierProvider).confirmBeforePost)) {
       final confirmed = await confirmPost(
-        ref.context,
+        ref,
         account,
-        noteId: noteId,
+        request,
+        files: files,
       );
       if (!confirmed) return;
       if (!ref.context.mounted) return;
@@ -73,7 +74,7 @@ class PostPage extends HookConsumerWidget {
     );
     if (!ref.context.mounted) return;
     if (result != null) {
-      if (text != null) {
+      if (request.text case final text?) {
         final nodes = const MfmParser().parse(text);
         final hashtags = nodes
             .extract((node) => node is MfmHashTag)

--- a/lib/view/widget/note_fallback_widget.dart
+++ b/lib/view/widget/note_fallback_widget.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../model/account.dart';
-import '../../provider/api/misskey_provider.dart';
 import '../../provider/notes_notifier_provider.dart';
 import 'error_message.dart';
 
@@ -20,13 +18,7 @@ class NoteFallbackWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return FutureBuilder(
-      future: Future(() async {
-        final note = await ref
-            .read(misskeyProvider(account))
-            .notes
-            .show(NotesShowRequest(noteId: noteId));
-        ref.read(notesNotifierProvider(account).notifier).add(note);
-      }),
+      future: ref.read(notesNotifierProvider(account).notifier).show(noteId),
       builder: (context, snapshot) {
         if (snapshot.hasError) {
           return ErrorMessage(

--- a/lib/view/widget/note_summary.dart
+++ b/lib/view/widget/note_summary.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/note_provider.dart';
+import '../../provider/notes_notifier_provider.dart';
 import 'mfm.dart';
 
 class NoteSummary extends ConsumerWidget {
@@ -22,7 +23,10 @@ class NoteSummary extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final note = ref.watch(noteProvider(account, noteId));
     if (note == null) {
-      return const SizedBox.shrink();
+      return FutureBuilder(
+        future: ref.read(notesNotifierProvider(account).notifier).show(noteId),
+        builder: (context, snapshot) => const SizedBox.shrink(),
+      );
     }
     return InkWell(
       onTap: onTap,

--- a/lib/view/widget/post_form.dart
+++ b/lib/view/widget/post_form.dart
@@ -105,9 +105,10 @@ class PostForm extends HookConsumerWidget {
         (ref.read(generalSettingsNotifierProvider).confirmBeforePost)) {
       final request = ref.read(postNotifierProvider(account, noteId: noteId));
       final confirmed = await confirmPost(
-        ref.context,
+        ref,
         account,
-        request: request,
+        request,
+        files: files,
       );
       if (!confirmed) return;
       if (!ref.context.mounted) return;

--- a/lib/view/widget/renote_sheet.dart
+++ b/lib/view/widget/renote_sheet.dart
@@ -199,10 +199,9 @@ class RenoteSheet extends HookConsumerWidget {
                         .read(generalSettingsNotifierProvider)
                         .confirmBeforePost) {
                       final confirmed = await confirmPost(
-                        context,
+                        ref,
                         account,
-                        request: request,
-                        files: [],
+                        request,
                       );
                       if (!confirmed) return;
                     }


### PR DESCRIPTION
Fixed an issue where replies or renotes in drafts of notes are not visible in `PostForm` and `PostConfirmationDialog`.