### PR TITLE
fix: remove padding of settings navigations

### DIFF
--- a/lib/view/widget/account_settings_navigation.dart
+++ b/lib/view/widget/account_settings_navigation.dart
@@ -96,6 +96,7 @@ class AccountSettingsNavigation extends ConsumerWidget {
     return ListView(
       shrinkWrap: true,
       physics: physics,
+      padding: EdgeInsets.zero,
       children: AccountSettingsDestination.values
           .map(
             (destination) => rail

--- a/lib/view/widget/general_settings_navigation.dart
+++ b/lib/view/widget/general_settings_navigation.dart
@@ -84,6 +84,7 @@ class GeneralSettingsNavigation extends StatelessWidget {
     return ListView(
       shrinkWrap: true,
       physics: physics,
+      padding: EdgeInsets.zero,
       children: GeneralSettingsDestination.values
           .map(
             (destination) => rail


### PR DESCRIPTION
This fixes an issue where paddings are inserted below navigations in `SettingsPage` and `AccountSettingsPage` on iOS.