### PR TITLE
fix: unawait push inside `futureWithDialog`

### DIFF
--- a/lib/util/open_as_guest.dart
+++ b/lib/util/open_as_guest.dart
@@ -15,5 +15,5 @@ Future<void> openUserAsGuest(WidgetRef ref, UserDetailed user) async {
     userNotifierProvider(guest, username: user.username).future,
   );
   if (!ref.context.mounted) return;
-  await ref.context.push('/$guest/users/${userAsLocal.id}');
+  unawaited(ref.context.push('/$guest/users/${userAsLocal.id}'));
 }


### PR DESCRIPTION
On `futureWithDialog`, `PopupEntry` is closed after future is completed and `context.push()` completes when the new page is popped. So awaiting `context.push()` prevents the `PopupEntry` from being closed as expected.