### PR TITLE
fix: unawait deleting tab

### DIFF
--- a/lib/view/page/settings/tab_settings_page.dart
+++ b/lib/view/page/settings/tab_settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart' hide ImageIcon;
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -183,9 +185,11 @@ class TabSettingsPage extends HookConsumerWidget {
                         message: t.aria.deleteTabConfirm,
                       );
                       if (confirmed) {
-                        await ref
-                            .read(timelineTabsNotifierProvider.notifier)
-                            .delete(initialTabSettings.id!);
+                        unawaited(
+                          ref
+                              .read(timelineTabsNotifierProvider.notifier)
+                              .delete(initialTabSettings.id!),
+                        );
                         if (!context.mounted) return;
                         context.pop();
                       }


### PR DESCRIPTION
This fixes an issue where `TabSettingsPage` does not close after tapping the delete button.