### PR TITLE
ci: split Android build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           echo version=$(grep flutter .fvmrc | cut -d ":" -f2|cut -d "\"" -f2)
           >> $GITHUB_OUTPUT
 
-  build-android:
+  build-apk:
     runs-on: ubuntu-latest
 
     needs: get-flutter-version
@@ -104,20 +104,58 @@ jobs:
             ${{ env.APK_BUILD_DIR }}/build/app/outputs/apk/release/aria-${{ github.ref_name }}-x86_64.apk
           draft: true
 
+  build-appbundle:
+    runs-on: ubuntu-latest
+
+    needs: get-flutter-version
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          cache: true
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+
+      - name: Dump keystore
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: upload.keystore
+          fileDir: android/app/
+          encodedString: ${{ secrets.UPLOAD_KEYSTORE }}
+
+      - name: Get build number
+        id: get-build-number
+        run: >
+          echo build-number=$(grep version pubspec.yaml | cut -d "+" -f2)
+          >> $GITHUB_OUTPUT
+
       - name: Build App Bundle
-        working-directory: ${{ env.APK_BUILD_DIR }}
         env:
-          HOME: /tmp
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
-        run: flutter build appbundle
+        run: >
+          flutter build appbundle
+          --build-number ${{ steps.get-build-number.outputs.build-number }}3
 
       - name: Upload App Bundle
         uses: actions/upload-artifact@v4
         with:
           name: App Bundle
-          path: ${{ env.APK_BUILD_DIR }}/build/app/outputs/bundle/release/app-release.aab
+          path: build/app/outputs/bundle/release/app-release.aab
 
   build-ios:
     runs-on: macos-latest


### PR DESCRIPTION
Split the job that builds APK and App Bundle into two jobs that build each.

Also, changed build number for App Bundle to make it compatible with the separated APKs.