### PR TITLE
fix: remove const from `GeneralSettingsNavigation`

### DIFF
--- a/lib/view/page/settings/settings_page.dart
+++ b/lib/view/page/settings/settings_page.dart
@@ -97,8 +97,10 @@ class SettingsPage extends HookConsumerWidget {
                       color: Theme.of(context).colorScheme.surface,
                     ),
                   ),
-                  const GeneralSettingsNavigation(
-                    physics: NeverScrollableScrollPhysics(),
+                  // Adding "const" to this prevents update of translations.
+                  // ignore: prefer_const_constructors
+                  GeneralSettingsNavigation(
+                    physics: const NeverScrollableScrollPhysics(),
                   ),
                   Container(
                     height: 8.0,


### PR DESCRIPTION
This fixes an issue where the texts of the navigation are not updated after updating ui language.