### PR TITLE
fix: do not add account if failed to save token

### DIFF
--- a/lib/provider/accounts_notifier_provider.dart
+++ b/lib/provider/accounts_notifier_provider.dart
@@ -5,7 +5,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../model/account.dart';
 import 'dio_provider.dart';
-import 'emojis_notifier_provider.dart';
 import 'shared_preferences_provider.dart';
 import 'tokens_notifier_provider.dart';
 
@@ -37,14 +36,9 @@ class AccountsNotifier extends _$AccountsNotifier {
     if (state.contains(account)) {
       return;
     }
+    await ref.read(tokensNotifierProvider.notifier).add(account, token);
     state = [...state, account];
-    await Future.wait([
-      _save(),
-      ref.read(tokensNotifierProvider.notifier).add(account, token),
-    ]);
-    await ref
-        .read(emojisNotifierProvider(account.host).notifier)
-        .reloadEmojis();
+    await _save();
   }
 
   Future<bool> loginWithToken(String host, String token) async {

--- a/lib/provider/accounts_notifier_provider.g.dart
+++ b/lib/provider/accounts_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'accounts_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$accountsNotifierHash() => r'b189860bade1f41f2db460cdf5b5175acf9cc01f';
+String _$accountsNotifierHash() => r'dc094b075969eda4ca721c99b8351f9d51b8ed5e';
 
 /// See also [AccountsNotifier].
 @ProviderFor(AccountsNotifier)

--- a/lib/view/page/authenticate_page.dart
+++ b/lib/view/page/authenticate_page.dart
@@ -32,19 +32,18 @@ class AuthenticatePage extends ConsumerWidget {
       ),
       body: Center(
         child: ElevatedButton(
-          onPressed: () => futureWithDialog(
-            context,
-            Future(() async {
-              final succeeded =
-                  await ref.read(miAuthNotifierProvider.notifier).check();
-              if (!context.mounted) return;
-              if (succeeded) {
-                context.go('/timelines');
-              } else {
-                await showMessageDialog(context, t.misskey.loginFailed);
-              }
-            }),
-          ),
+          onPressed: () async {
+            final succeeded = await futureWithDialog(
+              context,
+              ref.read(miAuthNotifierProvider.notifier).check(),
+            );
+            if (!context.mounted) return;
+            if (succeeded ?? false) {
+              context.go('/timelines');
+            } else {
+              await showMessageDialog(context, t.misskey.loginFailed);
+            }
+          },
           child: Text(t.aria.authenticated),
         ),
       ),


### PR DESCRIPTION
Changed to save token before adding an account when signing in. This change prevents the `CREDENTIAL_REQUIRED` error if storing the token failed while signing in.