### PR TITLE
fix: show emojis in Plays immediately

### DIFF
--- a/lib/view/widget/as_ui_widget.dart
+++ b/lib/view/widget/as_ui_widget.dart
@@ -209,6 +209,7 @@ class AsUiWidget extends HookConsumerWidget {
           onClickEv: onClickEv != null
               ? (clickEv) => onClickEv.call(value: clickEv)
               : null,
+          enableEmojiFadeIn: false,
         );
       },
       button: (component) {

--- a/lib/view/widget/custom_emoji.dart
+++ b/lib/view/widget/custom_emoji.dart
@@ -23,6 +23,7 @@ class CustomEmoji extends ConsumerWidget {
     this.disableTooltip = false,
     this.fallbackTextStyle,
     this.fallbackToImage = true,
+    this.enableFadeIn = true,
   });
 
   final Account account;
@@ -36,6 +37,7 @@ class CustomEmoji extends ConsumerWidget {
   final bool disableTooltip;
   final TextStyle? fallbackTextStyle;
   final bool fallbackToImage;
+  final bool enableFadeIn;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -104,6 +106,7 @@ class CustomEmoji extends ConsumerWidget {
                         ),
             ),
             semanticLabel: emoji,
+            enableFadeIn: enableFadeIn,
           ),
         ),
       ),

--- a/lib/view/widget/image_widget.dart
+++ b/lib/view/widget/image_widget.dart
@@ -18,6 +18,7 @@ class ImageWidget extends ConsumerWidget {
     this.alignment = Alignment.center,
     this.errorBuilder,
     this.semanticLabel,
+    this.enableFadeIn = true,
   });
 
   final String url;
@@ -29,6 +30,7 @@ class ImageWidget extends ConsumerWidget {
   final Alignment alignment;
   final Widget Function(BuildContext, Object, Object?)? errorBuilder;
   final String? semanticLabel;
+  final bool enableFadeIn;
 
   Widget _buildPlaceholder() {
     if (blurHash != null) {
@@ -106,6 +108,8 @@ class ImageWidget extends ConsumerWidget {
           errorWidget: errorBuilder ?? (_, __, ___) => _buildPlaceholder(),
           color: Color.fromRGBO(255, 255, 255, opacity),
           colorBlendMode: BlendMode.modulate,
+          fadeInDuration:
+              enableFadeIn ? const Duration(milliseconds: 500) : Duration.zero,
         ),
       );
     }

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -31,6 +31,7 @@ List<InlineSpan> buildMfm(
   TextAlign? textAlign,
   TextOverflow? overflow,
   int? maxLines,
+  bool enableEmojiFadeIn = true,
 }) {
   final brightness = Theme.of(ref.context).brightness;
   final colors = ref.read(misskeyColorsProvider(brightness));
@@ -59,6 +60,7 @@ List<InlineSpan> buildMfm(
           : null,
       fallbackTextStyle: fallbackTextStyle,
       fallbackToImage: false,
+      enableFadeIn: enableEmojiFadeIn,
     ),
     mentionBuilder: (username, host, scale, opacity) {
       final absoluteHost = host ??
@@ -124,6 +126,7 @@ class Mfm extends HookConsumerWidget {
     this.textAlign,
     this.overflow,
     this.maxLines,
+    this.enableEmojiFadeIn = true,
   });
 
   final Account account;
@@ -141,6 +144,7 @@ class Mfm extends HookConsumerWidget {
   final TextAlign? textAlign;
   final TextOverflow? overflow;
   final int? maxLines;
+  final bool enableEmojiFadeIn;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -163,6 +167,7 @@ class Mfm extends HookConsumerWidget {
           textAlign: textAlign,
           overflow: overflow,
           maxLines: maxLines,
+          enableEmojiFadeIn: enableEmojiFadeIn,
         ),
       ),
       [account, text, nodes, simple, style, author, colors, emojis],


### PR DESCRIPTION
Disabled fade-in animations of emoji images in Plays because some of Plays updates their content quickly and emojis are not displayed if they are removed while fading-in.