### PR TITLE
fix: reset channel after post

### DIFF
--- a/lib/provider/api/post_notifier_provider.dart
+++ b/lib/provider/api/post_notifier_provider.dart
@@ -181,13 +181,7 @@ class PostNotifier extends _$PostNotifier {
   }
 
   void reset() {
-    state = _defaultRequest.copyWith(
-      channelId: state.channelId,
-      localOnly: state.channelId != null ? true : _defaultRequest.localOnly,
-      visibility: state.channelId != null
-          ? NoteVisibility.public
-          : _defaultRequest.visibility,
-    );
+    state = _defaultRequest;
     ref.read(sharedPreferencesProvider).remove(_key);
   }
 

--- a/lib/provider/api/post_notifier_provider.g.dart
+++ b/lib/provider/api/post_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'post_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$postNotifierHash() => r'3d91f03110ea5dc0015442266a0c2c87a182a5fd';
+String _$postNotifierHash() => r'605985d90782fa4b9b9782f9ecf9926b31543ce3';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/timeline_tab_index_notifier_provider.dart
+++ b/lib/provider/timeline_tab_index_notifier_provider.dart
@@ -1,0 +1,30 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'timeline_last_viewed_at_notifier_provider.dart';
+import 'timeline_tabs_notifier_provider.dart';
+
+part 'timeline_tab_index_notifier_provider.g.dart';
+
+@riverpod
+class TimelineTabIndexNotifier extends _$TimelineTabIndexNotifier {
+  @override
+  int build() {
+    final tabs = ref.watch(timelineTabsNotifierProvider);
+    int latestIndex = 0;
+    DateTime latestDate = DateTime(0);
+    for (final (index, tabSettings) in tabs.indexed) {
+      final lastViewedAt =
+          ref.read(timelineLastViewedAtNotifierProvider(tabSettings));
+      if (lastViewedAt != null && lastViewedAt.isAfter(latestDate)) {
+        latestIndex = index;
+        latestDate = lastViewedAt;
+      }
+    }
+    return latestIndex;
+  }
+
+  // ignore: use_setters_to_change_properties
+  void updateIndex(int index) {
+    state = index;
+  }
+}

--- a/lib/provider/timeline_tab_index_notifier_provider.g.dart
+++ b/lib/provider/timeline_tab_index_notifier_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'timeline_tab_index_notifier_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$timelineTabIndexNotifierHash() =>
+    r'c9af333f0f8c082a8293a8bd889e9b478757a2bf';
+
+/// See also [TimelineTabIndexNotifier].
+@ProviderFor(TimelineTabIndexNotifier)
+final timelineTabIndexNotifierProvider =
+    AutoDisposeNotifierProvider<TimelineTabIndexNotifier, int>.internal(
+  TimelineTabIndexNotifier.new,
+  name: r'timelineTabIndexNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$timelineTabIndexNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$TimelineTabIndexNotifier = AutoDisposeNotifier<int>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/provider/timeline_tab_settings_provider.dart
+++ b/lib/provider/timeline_tab_settings_provider.dart
@@ -1,0 +1,15 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../model/tab_settings.dart';
+import 'timeline_tab_index_notifier_provider.dart';
+import 'timeline_tabs_notifier_provider.dart';
+
+part 'timeline_tab_settings_provider.g.dart';
+
+@riverpod
+TabSettings? timelineTabSettings(TimelineTabSettingsRef ref) {
+  final index = ref.watch(timelineTabIndexNotifierProvider);
+  return ref.watch(
+    timelineTabsNotifierProvider.select((tabs) => tabs.elementAtOrNull(index)),
+  );
+}

--- a/lib/provider/timeline_tab_settings_provider.g.dart
+++ b/lib/provider/timeline_tab_settings_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'timeline_tab_settings_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$timelineTabSettingsHash() =>
+    r'a59c07a28158fd5cde50fe269f04c41b9a401161';
+
+/// See also [timelineTabSettings].
+@ProviderFor(timelineTabSettings)
+final timelineTabSettingsProvider = AutoDisposeProvider<TabSettings?>.internal(
+  timelineTabSettings,
+  name: r'timelineTabSettingsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$timelineTabSettingsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef TimelineTabSettingsRef = AutoDisposeProviderRef<TabSettings?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -18,6 +18,7 @@ import '../../provider/api/i_notifier_provider.dart';
 import '../../provider/api/post_notifier_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
+import '../../provider/timeline_tab_settings_provider.dart';
 import '../../util/future_with_dialog.dart';
 import '../dialog/post_confirmation_dialog.dart';
 import '../widget/mfm_keyboard.dart';
@@ -87,6 +88,12 @@ class PostPage extends HookConsumerWidget {
               .read(accountSettingsNotifierProvider(account).notifier)
               .setHashtags({...hashtags, ...history}.toList()),
         );
+      }
+      if (ref.read(timelineTabSettingsProvider)?.channelId
+          case final channelId?) {
+        ref
+            .read(postNotifierProvider(account, noteId: noteId).notifier)
+            .setChannel(channelId);
       }
       ref.invalidate(attachesNotifierProvider(account, noteId: noteId));
       ref.context.pop();


### PR DESCRIPTION
With #69, the same channel is set to a new request after posting a note to a channel, but this behavior is confusing if the current tab is not a channel tab. This PR changes this behavior to only be effective if the tab is a channel tab.