### PR TITLE
feat: hide user info from previews in "my-" tab

### DIFF
--- a/lib/view/page/clips_page.dart
+++ b/lib/view/page/clips_page.dart
@@ -68,6 +68,7 @@ class ClipsPage extends ConsumerWidget {
                                     (clip) => ClipPreview(
                                       account: account,
                                       clip: clip,
+                                      hideUserInfo: true,
                                       onTap: () => context
                                           .push('/$account/clips/${clip.id}'),
                                     ),

--- a/lib/view/page/gallery/gallery_my.dart
+++ b/lib/view/page/gallery/gallery_my.dart
@@ -22,6 +22,7 @@ class GalleryMy extends ConsumerWidget {
       itemBuilder: (context, post) => GalleryPostPreview(
         account: account,
         post: post,
+        hideUserInfo: true,
         onTap: () => context.push('/$account/gallery/${post.id}'),
       ),
       onRefresh: () =>

--- a/lib/view/page/play/plays_my.dart
+++ b/lib/view/page/play/plays_my.dart
@@ -22,6 +22,7 @@ class PlaysMy extends ConsumerWidget {
       itemBuilder: (context, play) => PlayPreview(
         account: account,
         play: play,
+        hideUserInfo: true,
         onTap: () => context.push('/$account/play/${play.id}'),
       ),
       onRefresh: () => ref.refresh(playsNotifierProvider(account).future),

--- a/lib/view/widget/clip_preview.dart
+++ b/lib/view/widget/clip_preview.dart
@@ -16,11 +16,13 @@ class ClipPreview extends ConsumerWidget {
     super.key,
     required this.account,
     required this.clip,
+    this.hideUserInfo = false,
     this.onTap,
   });
 
   final Account account;
   final Clip clip;
+  final bool hideUserInfo;
   final void Function()? onTap;
 
   @override
@@ -68,18 +70,19 @@ class ClipPreview extends ConsumerWidget {
                 ].join(),
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 2.0),
-            child: Row(
-              children: [
-                UserAvatar(account: account, user: clip.user),
-                const SizedBox(width: 2.0),
-                Expanded(
-                  child: UsernameWidget(account: account, user: clip.user),
-                ),
-              ],
+          if (!hideUserInfo)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2.0),
+              child: Row(
+                children: [
+                  UserAvatar(account: account, user: clip.user),
+                  const SizedBox(width: 2.0),
+                  Expanded(
+                    child: UsernameWidget(account: account, user: clip.user),
+                  ),
+                ],
+              ),
             ),
-          ),
         ],
       ),
       onTap: onTap,

--- a/lib/view/widget/gallery_post_preview.dart
+++ b/lib/view/widget/gallery_post_preview.dart
@@ -23,11 +23,13 @@ class GalleryPostPreview extends HookConsumerWidget {
     super.key,
     required this.account,
     required this.post,
+    this.hideUserInfo = false,
     this.onTap,
   });
 
   final Account account;
   final GalleryPost post;
+  final bool hideUserInfo;
   final void Function()? onTap;
 
   @override
@@ -141,29 +143,32 @@ class GalleryPostPreview extends HookConsumerWidget {
               ),
               const Divider(),
             ],
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Row(
-                children: [
-                  UserAvatar(
-                    account: account,
-                    user: post.user,
-                    onTap: () => context.push('/$account/users/${post.userId}'),
-                  ),
-                  const SizedBox(width: 2.0),
-                  UsernameWidget(
-                    account: account,
-                    user: post.user,
-                    onTap: () => context.push('/$account/users/${post.userId}'),
-                    onLongPress: () => showUserSheet(
-                      context: context,
+            if (!hideUserInfo)
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  children: [
+                    UserAvatar(
                       account: account,
-                      userId: post.userId,
+                      user: post.user,
+                      onTap: () =>
+                          context.push('/$account/users/${post.userId}'),
                     ),
-                  ),
-                ],
+                    const SizedBox(width: 2.0),
+                    UsernameWidget(
+                      account: account,
+                      user: post.user,
+                      onTap: () =>
+                          context.push('/$account/users/${post.userId}'),
+                      onLongPress: () => showUserSheet(
+                        context: context,
+                        account: account,
+                        userId: post.userId,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: Row(

--- a/lib/view/widget/play_preview.dart
+++ b/lib/view/widget/play_preview.dart
@@ -12,11 +12,13 @@ class PlayPreview extends StatelessWidget {
     super.key,
     required this.account,
     required this.play,
+    this.hideUserInfo = false,
     this.onTap,
   });
 
   final Account account;
   final Flash play;
+  final bool hideUserInfo;
   final void Function()? onTap;
 
   @override
@@ -37,18 +39,19 @@ class PlayPreview extends StatelessWidget {
                 maxLines: 1,
               ),
             ),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 2.0),
-            child: Row(
-              children: [
-                UserAvatar(account: account, user: play.user),
-                const SizedBox(width: 2.0),
-                Expanded(
-                  child: UsernameWidget(account: account, user: play.user),
-                ),
-              ],
+          if (!hideUserInfo)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2.0),
+              child: Row(
+                children: [
+                  UserAvatar(account: account, user: play.user),
+                  const SizedBox(width: 2.0),
+                  Expanded(
+                    child: UsernameWidget(account: account, user: play.user),
+                  ),
+                ],
+              ),
             ),
-          ),
         ],
       ),
       trailing: play.visibility == FlashVisibility.private


### PR DESCRIPTION
Removed user avatars from previews of clips, gallery posts, and Plays when listing those created by the user.

ref: `https://github.com/misskey-dev/misskey/pull/14256`