### PR TITLE
fix: use previousIndex for comparing tabs

### DIFF
--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -70,7 +70,7 @@ class TimelinesPage extends HookConsumerWidget {
       () {
         void callback() {
           if (tabs.isEmpty) return;
-          final previousIndex = tabIndex;
+          final previousIndex = controller.previousIndex;
           final nextIndex = controller.index;
           ref
               .read(timelineTabIndexNotifierProvider.notifier)
@@ -121,6 +121,15 @@ class TimelinesPage extends HookConsumerWidget {
               .reloadEmojis();
           if (!account.isGuest) {
             ref.read(mainStreamNotifierProvider(account).notifier).connect();
+            Future(() {
+              if (tabSettings.tabType == TabType.channel) {
+                ref
+                    .read(postNotifierProvider(account).notifier)
+                    .setChannel(tabSettings.channelId);
+              } else {
+                ref.read(postNotifierProvider(account).notifier).clearChannel();
+              }
+            });
           }
         }
         controller.addListener(callback);


### PR DESCRIPTION
When changing timeline tabs, compare tabs using [`TabController.previousIndex`](https://api.flutter.dev/flutter/material/TabController/previousIndex.html) instead of the value of `timelineTabIndexNotifierProvider` because the provider value does not update inside the callback function.

Fix #329