### PR TITLE
chore: change icon of scroll to new banner

### DIFF
--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -312,7 +312,7 @@ class TimelineWidget extends HookConsumerWidget {
                     },
                     child: Row(
                       children: [
-                        const Icon(Icons.history),
+                        const Icon(Icons.update),
                         const SizedBox(width: 8.0),
                         if (Id.tryParse(nextNoteId)?.date
                             case final nextNoteDate?)


### PR DESCRIPTION
Changed the icon at the top of `TimelineWidget` that appears when newer notes exist from `Icons.history` to `Icons.update`.