### PR TITLE
fix: remove colorFilter for Impeller

### DIFF
--- a/lib/view/widget/image_widget.dart
+++ b/lib/view/widget/image_widget.dart
@@ -110,7 +110,7 @@ class ImageWidget extends ConsumerWidget {
           cacheManager: ref.watch(cacheManagerProvider),
           placeholder: (_, __) => _buildPlaceholder(),
           errorWidget: errorBuilder ?? (_, __, ___) => _buildPlaceholder(),
-          color: Color.fromRGBO(255, 255, 255, opacity),
+          color: opacity < 1.0 ? Color.fromRGBO(255, 255, 255, opacity) : null,
           colorBlendMode: BlendMode.modulate,
           fadeOutDuration: Duration.zero,
         ),

--- a/lib/view/widget/media_card.dart
+++ b/lib/view/widget/media_card.dart
@@ -256,13 +256,17 @@ class MediaCard extends HookConsumerWidget {
                   alignment: Alignment.center,
                   children: [
                     if (file case DriveFile(:final blurhash?))
-                      ColorFiltered(
-                        colorFilter: const ColorFilter.mode(
-                          Color(0xffb4b4b4),
-                          BlendMode.multiply,
-                        ),
-                        child: BlurHash(hash: blurhash),
-                      )
+                      if (defaultTargetPlatform
+                          case TargetPlatform.iOS || TargetPlatform.macOS)
+                        BlurHash(hash: blurhash)
+                      else
+                        ColorFiltered(
+                          colorFilter: const ColorFilter.mode(
+                            Color(0xffb4b4b4),
+                            BlendMode.multiply,
+                          ),
+                          child: BlurHash(hash: blurhash),
+                        )
                     else
                       const Positioned.fill(
                         child: ColoredBox(color: Color(0xff888888)),


### PR DESCRIPTION
This is a temporary workaround for an issue where clipping is not working for Impeller in Flutter 3.24.0 (`https://github.com/flutter/flutter/issues/153118`).