### PR TITLE
fix: clear composing range when inserting text

### DIFF
--- a/lib/extension/text_editing_controller_extension.dart
+++ b/lib/extension/text_editing_controller_extension.dart
@@ -15,6 +15,7 @@ extension TextEditingControllerExtension on TextEditingController {
         baseOffset: startIndex + insertText.length,
         extentOffset: endIndex + insertText.length,
       ),
+      composing: TextRange.empty,
     );
   }
 
@@ -26,6 +27,7 @@ extension TextEditingControllerExtension on TextEditingController {
       text: '$beforeSelection$replace$afterSelection',
       selection:
           TextSelection.collapsed(offset: startIndex - length + replace.length),
+      composing: TextRange.empty,
     );
   }
 }


### PR DESCRIPTION
This fixes an issue where inputted text gets overwritten after inserting text from `MfmKeyboard` when using Japanese IME.