### PR TITLE
fix: increment reaction count if cache is not updated

### DIFF
--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -172,7 +172,7 @@ class NotesNotifier extends _$NotesNotifier {
         ? '${reaction.substring(0, reaction.length - 1)}@.:'
         : reaction;
     final cachedNote = state[noteId];
-    if (cachedNote != null) {
+    if (cachedNote != null && cachedNote.myReaction != emoji) {
       add(
         cachedNote.copyWith(
           reactionCount: (cachedNote.reactionCount ?? 0) + 1,

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'8560d6797d38ea88f86e8f9b6039f7f4eff3ebd3';
+String _$notesNotifierHash() => r'56e736a66b8b319aaf9ad8320152e25028c5d897';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Suppress incrementing reaction count when adding a reaction if the cached note has already been updated via streaming event.