### PR TITLE
fix: extract original url from proxied url

### DIFF
--- a/lib/provider/emoji_url_provider.dart
+++ b/lib/provider/emoji_url_provider.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../model/account.dart';
@@ -18,34 +19,68 @@ part 'emoji_url_provider.g.dart';
   assert(emoji.startsWith(':') && emoji.endsWith(':'));
   ref.keepAlive();
   final customEmojiName = emoji.substring(1, emoji.length - 1);
-  final isLocal = host == null &&
-      (customEmojiName.endsWith('@.') || !customEmojiName.contains('@'));
-  final rawUrl = (url != null
-          ? Uri.tryParse(url)
-          : isLocal
-              ? ref.watch(emojiProvider(account.host, emoji))?.url
-              : null) ??
-      Uri(
-        scheme: 'https',
-        host: account.host,
-        pathSegments: [
-          'emoji',
-          if (host != null)
-            '$customEmojiName@$host.webp'
-          else
-            '$customEmojiName.webp',
-        ],
-      );
+
+  Uri? rawUrl;
+  if (url != null) {
+    rawUrl = Uri.tryParse(url);
+  } else {
+    final isLocal = host == null &&
+        (customEmojiName.endsWith('@.') || !customEmojiName.contains('@'));
+    if (isLocal) {
+      rawUrl = ref.watch(emojiProvider(account.host, emoji))?.url;
+    }
+  }
+  rawUrl ??= Uri(
+    scheme: 'https',
+    host: account.host,
+    pathSegments: [
+      'emoji',
+      if (host != null)
+        '$customEmojiName@$host.webp'
+      else
+        '$customEmojiName.webp',
+    ],
+  );
+  if (!rawUrl.isAbsolute) {
+    rawUrl = rawUrl.replace(
+      scheme: 'https',
+      host: account.host,
+    );
+  }
+
+  Uri imageUrl = rawUrl;
   final meta = ref.watch(metaNotifierProvider(account.host)).valueOrNull;
   final mediaProxy = meta?.mediaProxy;
   final proxyUrl = (mediaProxy != null ? Uri.tryParse(mediaProxy) : null) ??
       Uri.https(account.host, 'proxy');
+  if (imageUrl.host == proxyUrl.host) {
+    if (proxyUrl.pathSegments.length <= imageUrl.pathSegments.length &&
+        const ListEquality<String>().equals(
+          imageUrl.pathSegments.sublist(0, proxyUrl.pathSegments.length),
+          proxyUrl.pathSegments,
+        )) {
+      if (imageUrl.queryParameters['url'] case final url?) {
+        if (Uri.tryParse(url) case final url?) {
+          imageUrl = url;
+        }
+      }
+    }
+  } else if (imageUrl.host == account.host) {
+    if (imageUrl.pathSegments.firstOrNull == 'proxy') {
+      if (imageUrl.queryParameters['url'] case final url?) {
+        if (Uri.tryParse(url) case final url?) {
+          imageUrl = url;
+        }
+      }
+    }
+  }
+
   final proxied = proxyUrl.replace(
     pathSegments: [...proxyUrl.pathSegments, 'image.webp'],
     queryParameters: {
-      'url': rawUrl.toString(),
+      'url': imageUrl.toString(),
       if (!useOriginalSize) 'emoji': '1',
     },
   );
-  return (proxied.toString(), rawUrl.toString());
+  return (proxied.toString(), imageUrl.toString());
 }

--- a/lib/provider/emoji_url_provider.g.dart
+++ b/lib/provider/emoji_url_provider.g.dart
@@ -6,7 +6,7 @@ part of 'emoji_url_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$emojiUrlHash() => r'ba66bb47bc5331b32f22e5662e32dd1b638a3699';
+String _$emojiUrlHash() => r'ccc9622002c2c412f0bb6449fa94cd5e87bd9e62';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Extract the original image url if the supplied emoji url is already proxied.
Fixes an issue where remote emojis do not render on some servers.