### PR TITLE
build: fix path of translated files

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
-  - source: lib/i18n/aria/aria.i18n.yaml
-    translation: lib/i18n/aria/aria_%locale%.i18n.yaml
+  - source: /lib/i18n/aria/aria.i18n.yaml
+    translation: /lib/i18n/aria/aria_%locale%.i18n.yaml


### PR DESCRIPTION
Changed paths in crowdin.yml to absolute.