### PR TITLE
fix: add keys to note preview

### DIFF
--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -204,10 +204,12 @@ class PostPage extends HookConsumerWidget {
                           clipBehavior: Clip.antiAlias,
                           child: request.isRenote
                               ? NoteWidget(
+                                  key: const ValueKey('renote'),
                                   account: account.value,
                                   noteId: request.renoteId!,
                                 )
                               : NoteWidget(
+                                  key: const ValueKey('note'),
                                   account: account.value,
                                   noteId: '',
                                   note: note,


### PR DESCRIPTION
Added keys for `NoteWidget` used for preview in the post page. 
Using different keys prevents widgets from being reused when switching between quote and renote.

Fix #392
