### PR TITLE
fix: do not allow duplicate account

### DIFF
--- a/lib/provider/accounts_notifier_provider.dart
+++ b/lib/provider/accounts_notifier_provider.dart
@@ -33,11 +33,9 @@ class AccountsNotifier extends _$AccountsNotifier {
   }
 
   Future<void> login(Account account, String token) async {
-    if (state.contains(account)) {
-      return;
-    }
     await ref.read(tokensNotifierProvider.notifier).add(account, token);
-    state = [...state, account];
+    if (state.contains(account)) return;
+    state = {...state, account}.toList();
     await _save();
   }
 

--- a/lib/provider/accounts_notifier_provider.g.dart
+++ b/lib/provider/accounts_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'accounts_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$accountsNotifierHash() => r'dc094b075969eda4ca721c99b8351f9d51b8ed5e';
+String _$accountsNotifierHash() => r'fe388946c6bfb199a83fac59b97c14c7763c70a5';
 
 /// See also [AccountsNotifier].
 @ProviderFor(AccountsNotifier)


### PR DESCRIPTION
Changed to convert the list of accounts to a set when adding an account.

Fix #393 