### PR TITLE
fix: remove duplicate notification

### DIFF
--- a/lib/provider/api/notifications_notifier_provider.dart
+++ b/lib/provider/api/notifications_notifier_provider.dart
@@ -149,7 +149,7 @@ class NotificationsNotifier extends _$NotificationsNotifier {
     ref.read(notesNotifierProvider(account).notifier).addAll(
           notifications.map((notification) => notification.note).nonNulls,
         );
-    return notifications;
+    return notifications.where((notification) => notification.id != untilId);
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/notifications_notifier_provider.g.dart
+++ b/lib/provider/api/notifications_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'notifications_notifier_provider.dart';
 // **************************************************************************
 
 String _$notificationsNotifierHash() =>
-    r'fc5677a1a6366835cb145027398178c2ff0dfded';
+    r'5bf979e724bb93f85bf308b65d7b7e9fceff6add';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
If a notification with the same id as the specified `untilId` exists in the fetched notifications, remove it.

Fix #395 