### PR TITLE
fix: reset pinned emojis

### DIFF
--- a/lib/view/widget/pinned_emojis_editor.dart
+++ b/lib/view/widget/pinned_emojis_editor.dart
@@ -137,7 +137,7 @@ class PinnedEmojisEditor extends HookConsumerWidget {
                   .read(
                     pinnedEmojisNotifierProvider(
                       account,
-                      reaction: true,
+                      reaction: reaction,
                     ).notifier,
                   )
                   .reset();


### PR DESCRIPTION
This fixes an issue where general pinned emojis do not reset when tapping the reset button.