### PR TITLE
fix: apply avatar scale to grouped notifications

### DIFF
--- a/lib/view/widget/notification_widget.dart
+++ b/lib/view/widget/notification_widget.dart
@@ -46,6 +46,10 @@ class NotificationWidget extends ConsumerWidget {
                 ?.items ??
             []
         : <FollowRequest>[];
+    final avatarScale = ref.watch(
+      generalSettingsNotifierProvider
+          .select((settings) => settings.avatarScale),
+    );
     final colors =
         ref.watch(misskeyColorsProvider(Theme.of(context).brightness));
 
@@ -399,7 +403,8 @@ class NotificationWidget extends ConsumerWidget {
                         child: UserAvatar(
                           account: account,
                           user: reaction.user,
-                          size: 50.0,
+                          size: DefaultTextStyle.of(context).style.lineHeight *
+                              avatarScale,
                           onTap: () => context
                               .push('/$account/users/${reaction.user.id}'),
                         ),
@@ -498,7 +503,8 @@ class NotificationWidget extends ConsumerWidget {
                     child: UserAvatar(
                       account: account,
                       user: user,
-                      size: 50.0,
+                      size: DefaultTextStyle.of(context).style.lineHeight *
+                          avatarScale,
                       onTap: () => context.push('/$account/users/${user.id}'),
                     ),
                   ),


### PR DESCRIPTION
Changed the size of the user icons in grouped notifications to comply with the avatar scale setting.