### PR TITLE
ci: ignore l10n-main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches-ignore:
+      - l10n-main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
On the branch Crowdin pushes translated files to, ci actions always fail because files generated by slang will not update.