### PR TITLE
fix: check duplicate notes per timelines

### DIFF
--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
@@ -151,11 +151,13 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
 
   void addNote(Note note) {
     final value = state.valueOrNull;
-    state = AsyncValue.data(
-      PaginationState(
-        items: [note, ...?value?.items],
-        isLastLoaded: value?.isLastLoaded ?? false,
-      ),
-    );
+    if (value?.items.lastOrNull?.id != note.id) {
+      state = AsyncValue.data(
+        PaginationState(
+          items: [note, ...?value?.items],
+          isLastLoaded: value?.isLastLoaded ?? false,
+        ),
+      );
+    }
   }
 }

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_notes_after_note_notifier_provider.dart';
 // **************************************************************************
 
 String _$timelineNotesAfterNoteNotifierHash() =>
-    r'7b53cdf9f544a5f26bf95f9c0a7a2364a1f2b940';
+    r'e29433aff3e0f9cba8dc82e2df1576a93f10529c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -19,7 +19,7 @@ class NotesNotifier extends _$NotesNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Note? add(Note note, {bool detail = true}) {
+  void add(Note note, {bool detail = true}) {
     final renote = note.renote;
     if (renote != null) {
       add(renote);
@@ -41,7 +41,6 @@ class NotesNotifier extends _$NotesNotifier {
         myReaction: detail ? note.myReaction : cachedNote?.myReaction,
       ),
     };
-    return cachedNote;
   }
 
   void addAll(Iterable<Note> notes) {

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'56e736a66b8b319aaf9ad8320152e25028c5d897';
+String _$notesNotifierHash() => r'91f6f264b2e30155a6bbd5cd31aae49efd804f34';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/streaming/timeline_stream_notifier.dart
+++ b/lib/provider/streaming/timeline_stream_notifier.dart
@@ -40,12 +40,10 @@ class TimelineStreamNotifier extends _$TimelineStreamNotifier {
           final event = message.body;
           if (event['type'] == 'note') {
             final note = Note.fromJson(event['body'] as Map<String, dynamic>);
-            final cachedNote = ref
+            ref
                 .read(notesNotifierProvider(tabSettings.account).notifier)
                 .add(note);
-            if (cachedNote == null) {
-              yield note;
-            }
+            yield note;
           }
         }
       case TabType.mention || TabType.direct:

--- a/lib/provider/streaming/timeline_stream_notifier.g.dart
+++ b/lib/provider/streaming/timeline_stream_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_stream_notifier.dart';
 // **************************************************************************
 
 String _$timelineStreamNotifierHash() =>
-    r'4c7b4e28189f2b67ccd3faa7afaf34e078089b0a';
+    r'81967b6a652252409a91af61a32d3e350da5b9c0';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Removed check for the cached note inside `TimelineStreamNotifier`. This was intended to avoid duplicate notes for streaming, but since posting notes also caches them, this was causing the notes posted by the user not to appear in the timelines.
The duplicate notes will now be checked during the `TimelineNotesAfterNoteNotifier.addNote` method.

Fix #336 