### PR TITLE
fix: show local only in emoji page

### DIFF
--- a/lib/view/page/emoji_page.dart
+++ b/lib/view/page/emoji_page.dart
@@ -112,8 +112,7 @@ class EmojiPage extends ConsumerWidget {
                         padding: const EdgeInsets.all(8.0),
                         child: KeyValueWidget(
                           label: t.misskey.localOnly,
-                          text:
-                              emoji.isSensitive ? t.misskey.yes : t.misskey.no,
+                          text: emoji.localOnly ? t.misskey.yes : t.misskey.no,
                         ),
                       ),
                       Padding(


### PR DESCRIPTION
Fixed an issue where the `localOnly` field in the `EmojiPage` is showing the `isSensitive` flag instead.