### PR TITLE
fix: compare new note with the first note

### DIFF
--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
@@ -151,7 +151,7 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
 
   void addNote(Note note) {
     final value = state.valueOrNull;
-    if (value?.items.lastOrNull?.id != note.id) {
+    if (value?.items.firstOrNull?.id != note.id) {
       state = AsyncValue.data(
         PaginationState(
           items: [note, ...?value?.items],

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_notes_after_note_notifier_provider.dart';
 // **************************************************************************
 
 String _$timelineNotesAfterNoteNotifierHash() =>
-    r'e29433aff3e0f9cba8dc82e2df1576a93f10529c';
+    r'807935d681491796690db3ae4b82f8c8fae281e7';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Fixed an issue where the duplicate check added in #418 was comparing the newly received note with the oldest note in the timeline while it should be compared with the newest note.