### PR TITLE
feat: expand emoji picker if auto focus is enabled

### DIFF
--- a/lib/view/widget/emoji_picker.dart
+++ b/lib/view/widget/emoji_picker.dart
@@ -63,9 +63,8 @@ Future<String?> pickEmoji(
     }
   }
 
-  final useDialog =
-      ref.read(generalSettingsNotifierProvider).emojiPickerUseDialog;
-  if (useDialog) {
+  final settings = ref.read(generalSettingsNotifierProvider);
+  if (settings.emojiPickerUseDialog) {
     return showDialog<String>(
       context: ref.context,
       builder: (context) => Dialog(
@@ -82,6 +81,7 @@ Future<String?> pickEmoji(
     return showModalBottomSheet<String>(
       context: ref.context,
       builder: (context) => DraggableScrollableSheet(
+        initialChildSize: settings.emojiPickerAutofocus ? 0.8 : 0.5,
         minChildSize: 0.5,
         maxChildSize: 0.8,
         expand: false,


### PR DESCRIPTION
When opening an emoji picker in a modal bottom sheet, if the setting for automatically focusing the search field is enabled, expand the sheet to 80% to the top.
This makes search results to be less hidden by the software keyboard.