### PR TITLE
fix: show reaction name in notification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -177,9 +177,9 @@ class Aria extends HookConsumerWidget {
               ),
             NotificationType.note => t.misskey.notification_.newNote,
             NotificationType.reaction => [
-                notification.body?.reaction ?? '',
-                notification.body?.user?.nameOrUsername ?? '',
-              ].join(' '),
+                notification.body?.reaction?.split('@')[0].replaceAll(':', ''),
+                notification.body?.user?.nameOrUsername,
+              ].nonNulls.join(' '),
             NotificationType.receiveFollowRequest =>
               t.misskey.notification_.youReceivedFollowRequest,
             NotificationType.followRequestAccepted =>


### PR DESCRIPTION
When showing push notifications, remove colons and the host part from reactions.