### PR TITLE
feat: expand translated note sheet

### DIFF
--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -532,6 +532,8 @@ class NoteFooter extends HookConsumerWidget {
                               account: account,
                               note: appearNote,
                             ),
+                            clipBehavior: Clip.antiAlias,
+                            scrollControlDisabledMaxHeightRatio: 0.8,
                           );
                         } else {
                           launchUrl(

--- a/lib/view/widget/note_sheet.dart
+++ b/lib/view/widget/note_sheet.dart
@@ -269,6 +269,8 @@ class NoteSheet extends ConsumerWidget {
                       account: account,
                       note: appearNote,
                     ),
+                    clipBehavior: Clip.antiAlias,
+                    scrollControlDisabledMaxHeightRatio: 0.8,
                   );
                 } else {
                   launchUrl(

--- a/lib/view/widget/translated_note_sheet.dart
+++ b/lib/view/widget/translated_note_sheet.dart
@@ -29,10 +29,11 @@ class TranslatedNoteSheet extends ConsumerWidget {
       ),
     );
 
-    return switch (translatedNote) {
-      AsyncValue(valueOrNull: final translatedNote?) => SingleChildScrollView(
-          child: Column(
-            children: [
+    return ListView(
+      shrinkWrap: true,
+      children: [
+        ...switch (translatedNote) {
+          AsyncValue(valueOrNull: final translatedNote?) => [
               ListTile(
                 title: Text(
                   t.misskey.translatedFrom(x: translatedNote.sourceLang),
@@ -58,11 +59,18 @@ class TranslatedNoteSheet extends ConsumerWidget {
                 ),
               ),
             ],
-          ),
-        ),
-      AsyncValue(:final error?, :final stackTrace) =>
-        ErrorMessage(error: error, stackTrace: stackTrace),
-      _ => const Center(child: CircularProgressIndicator()),
-    };
+          AsyncValue(:final error?, :final stackTrace) => [
+              ErrorMessage(error: error, stackTrace: stackTrace),
+            ],
+          _ => [
+              const SizedBox(
+                width: double.infinity,
+                height: 100.0,
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ],
+        },
+      ],
+    );
   }
 }


### PR DESCRIPTION
Changed to allow `TranslatedNoteSheet` to occupy at most 80% of the screen height.