### PR TITLE
fix: use onTapEmoji in Mfm widget

### DIFF
--- a/lib/view/page/user/user_home.dart
+++ b/lib/view/page/user/user_home.dart
@@ -22,6 +22,7 @@ import '../../../util/open_as_guest.dart';
 import '../../../util/punycode.dart';
 import '../../dialog/image_dialog.dart';
 import '../../dialog/text_field_dialog.dart';
+import '../../widget/emoji_sheet.dart';
 import '../../widget/error_message.dart';
 import '../../widget/image_widget.dart';
 import '../../widget/mfm.dart';
@@ -425,6 +426,14 @@ class _UserHome extends ConsumerWidget {
                               emojis: user.emojis,
                               author: user,
                               isUserDescription: true,
+                              selectable: true,
+                              onTapEmoji: (emoji) => showModalBottomSheet<void>(
+                                context: context,
+                                builder: (context) => EmojiSheet(
+                                  account: account,
+                                  emoji: emoji,
+                                ),
+                              ),
                               textAlign: TextAlign.center,
                             )
                           : Text(

--- a/lib/view/widget/custom_emoji.dart
+++ b/lib/view/widget/custom_emoji.dart
@@ -70,7 +70,7 @@ class CustomEmoji extends ConsumerWidget {
       child: TooltipVisibility(
         visible: !disableTooltip,
         child: Tooltip(
-          message: emoji,
+          message: emoji.replaceAll('@.', ''),
           child: ImageWidget(
             url: disableShowingAnimatedImages
                 ? ref

--- a/lib/view/widget/emoji_sheet.dart
+++ b/lib/view/widget/emoji_sheet.dart
@@ -67,7 +67,7 @@ class EmojiSheet extends ConsumerWidget {
                     ?.reactionEmojis[emoji.substring(1, emoji.length - 1)],
               ),
             ),
-            subtitle: Text(emoji),
+            subtitle: Text(emoji.replaceAll('@.', '')),
           )
         else
           ListTile(title: Text(emoji)),

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -148,6 +148,17 @@ class Mfm extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final mfmSettings = ref.watch(
+      generalSettingsNotifierProvider.select(
+        (settings) => (
+          settings.advancedMfm,
+          settings.animatedMfm,
+          settings.fontFamily,
+          settings.fontSize,
+          settings.lineHeight,
+        ),
+      ),
+    );
     final colors =
         ref.watch(misskeyColorsProvider(Theme.of(context).brightness));
     final span = useMemoized(
@@ -163,6 +174,7 @@ class Mfm extends HookConsumerWidget {
           author: author,
           nyaize: nyaize,
           isUserDescription: isUserDescription,
+          onTapEmoji: onTapEmoji,
           onClickEv: onClickEv,
           textAlign: textAlign,
           overflow: overflow,
@@ -170,7 +182,17 @@ class Mfm extends HookConsumerWidget {
           enableEmojiFadeIn: enableEmojiFadeIn,
         ),
       ),
-      [account, text, nodes, simple, style, author, colors, emojis],
+      [
+        account,
+        text,
+        nodes,
+        simple,
+        style,
+        author,
+        colors,
+        emojis,
+        mfmSettings,
+      ],
     );
 
     if (selectable) {


### PR DESCRIPTION
Fixed an issue where emojis on the cw text and other widgets cannot detect tap.