### PR TITLE
feat: show all reactions in ReactionUsersSheet

### DIFF
--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -161,6 +161,7 @@ class NoteFooter extends HookConsumerWidget {
                                   account: account,
                                   noteId: appearNote.id,
                                 ),
+                                clipBehavior: Clip.antiAlias,
                                 isScrollControlled: true,
                               );
                             }
@@ -358,7 +359,7 @@ class NoteFooter extends HookConsumerWidget {
                                 builder: (context) => ReactionUsersSheet(
                                   account: account,
                                   noteId: appearNote.id,
-                                  reaction: '❤',
+                                  initialReaction: '❤',
                                 ),
                                 isScrollControlled: true,
                               )
@@ -444,7 +445,7 @@ class NoteFooter extends HookConsumerWidget {
                                 builder: (context) => ReactionUsersSheet(
                                   account: account,
                                   noteId: appearNote.id,
-                                  reaction: '❤',
+                                  initialReaction: '❤',
                                 ),
                                 isScrollControlled: true,
                               );

--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -60,7 +60,6 @@ class NoteFooter extends HookConsumerWidget {
       return const SizedBox.shrink();
     }
     final i = ref.watch(iNotifierProvider(account)).valueOrNull;
-    final meta = ref.watch(metaNotifierProvider(account.host)).valueOrNull;
     final showQuoteButton = ref.watch(
       generalSettingsNotifierProvider
           .select((settings) => settings.showQuoteButtonInNoteFooter),
@@ -81,19 +80,12 @@ class NoteFooter extends HookConsumerWidget {
       generalSettingsNotifierProvider
           .select((settings) => settings.noteFooterScale),
     );
-    final showReactionsCount = ref.watch(
-      generalSettingsNotifierProvider
-          .select((settings) => settings.showReactionsCount),
-    );
     final isMyNote = i != null && appearNote.userId == i.id;
     final canRenote = switch (appearNote.visibility) {
       NoteVisibility.public || NoteVisibility.home => true,
       NoteVisibility.followers => isMyNote,
       _ => false,
     };
-    final myRenotingNoteId = useState(
-      note.isRenote && i != null && note.userId == i.id ? noteId : null,
-    );
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -117,191 +109,28 @@ class NoteFooter extends HookConsumerWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
-                  IconButton(
-                    tooltip: t.misskey.reply,
-                    onPressed: !account.isGuest
-                        ? () {
-                            if (appearNote.id.isEmpty) return;
-                            ref
-                                .read(postNotifierProvider(account).notifier)
-                                .setReply(appearNote);
-                            if (focusPostForm case final focusPostForm?) {
-                              focusPostForm();
-                            } else {
-                              context.push('/$account/post');
-                            }
-                          }
-                        : null,
-                    icon: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Icon(Icons.reply),
-                        if (appearNote.repliesCount > 0)
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 2.0,
-                            ),
-                            child: Text(
-                              NumberFormat().format(appearNote.repliesCount),
-                              style: style,
-                            ),
-                          ),
-                      ],
-                    ),
+                  _ReplyButton(
+                    account: account,
+                    note: appearNote,
+                    focusPostForm: focusPostForm,
+                    style: style,
                   ),
                   if (canRenote) ...[
-                    GestureDetector(
-                      onLongPress: appearNote.renoteCount > 0
-                          ? () {
-                              if (appearNote.id.isEmpty) return;
-                              HapticFeedback.lightImpact();
-                              showModalBottomSheet<void>(
-                                context: context,
-                                builder: (context) => RenoteUsersSheet(
-                                  account: account,
-                                  noteId: appearNote.id,
-                                ),
-                                clipBehavior: Clip.antiAlias,
-                                isScrollControlled: true,
-                              );
-                            }
+                    _RenoteButton(
+                      account: account,
+                      note: appearNote,
+                      myRenotingNoteId: note.isRenote && note.userId == i?.id
+                          ? note.id
                           : null,
-                      child: IconButton(
-                        tooltip: appearNote.renoteCount <= 0
-                            ? t.misskey.renote
-                            : null,
-                        onPressed: !account.isGuest
-                            ? () async {
-                                if (appearNote.id.isEmpty) return;
-                                if (myRenotingNoteId.value case final noteId?) {
-                                  final unrenote =
-                                      await showModalBottomSheet<bool>(
-                                    context: context,
-                                    builder: (context) => ListView(
-                                      shrinkWrap: true,
-                                      children: [
-                                        ListTile(
-                                          leading:
-                                              const Icon(Icons.repeat_rounded),
-                                          title: Text(t.misskey.renote),
-                                          onTap: () => context.pop(false),
-                                        ),
-                                        ListTile(
-                                          leading: const Icon(Icons.delete),
-                                          title: Text(t.misskey.unrenote),
-                                          onTap: () => context.pop(true),
-                                          iconColor: Theme.of(context)
-                                              .colorScheme
-                                              .error,
-                                          textColor: Theme.of(context)
-                                              .colorScheme
-                                              .error,
-                                        ),
-                                      ],
-                                    ),
-                                  );
-                                  if (!context.mounted) return;
-                                  if (unrenote == null) return;
-                                  if (unrenote) {
-                                    final result = await futureWithDialog(
-                                      context,
-                                      ref
-                                          .read(misskeyProvider(account))
-                                          .notes
-                                          .delete(
-                                            NotesDeleteRequest(noteId: noteId),
-                                          )
-                                          .then((_) => true),
-                                    );
-                                    if (!context.mounted) return;
-                                    if (result != null) {
-                                      ref
-                                          .read(
-                                            notesNotifierProvider(account)
-                                                .notifier,
-                                          )
-                                          .remove(noteId);
-                                      myRenotingNoteId.value = null;
-                                    }
-                                    return;
-                                  }
-                                }
-                                if (showQuoteButton) {
-                                  final result =
-                                      await showModalBottomSheet<Note>(
-                                    context: context,
-                                    builder: (context) => RenoteSheet(
-                                      account: account,
-                                      note: appearNote,
-                                    ),
-                                    clipBehavior: Clip.hardEdge,
-                                  );
-                                  if (result != null) {
-                                    myRenotingNoteId.value = result.id;
-                                  }
-                                } else {
-                                  ref
-                                      .read(
-                                        postNotifierProvider(account).notifier,
-                                      )
-                                      .setRenote(appearNote);
-                                  if (focusPostForm case final focusPostForm?) {
-                                    focusPostForm();
-                                  } else {
-                                    await context.push('/$account/post');
-                                  }
-                                }
-                              }
-                            : null,
-                        icon: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.repeat_rounded,
-                              color: myRenotingNoteId.value != null
-                                  ? Theme.of(context).colorScheme.primary
-                                  : null,
-                            ),
-                            if (appearNote.renoteCount > 0)
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 2.0,
-                                ),
-                                child: Text(
-                                  NumberFormat().format(appearNote.renoteCount),
-                                  style: style.apply(
-                                    color: myRenotingNoteId.value != null
-                                        ? Theme.of(context)
-                                            .colorScheme
-                                            .primary
-                                            .withOpacity(0.6)
-                                        : null,
-                                  ),
-                                ),
-                              ),
-                          ],
-                        ),
-                      ),
+                      showQuoteButton: showQuoteButton,
+                      focusPostForm: focusPostForm,
+                      style: style,
                     ),
                     if (showQuoteButton)
-                      IconButton(
-                        tooltip: t.misskey.quote,
-                        onPressed: !account.isGuest
-                            ? () {
-                                if (appearNote.id.isEmpty) return;
-                                ref
-                                    .read(
-                                      postNotifierProvider(account).notifier,
-                                    )
-                                    .setRenote(appearNote);
-                                if (focusPostForm case final focusPostForm?) {
-                                  focusPostForm();
-                                } else {
-                                  context.push('/$account/post');
-                                }
-                              }
-                            : null,
-                        icon: const Icon(Icons.format_quote_outlined),
+                      _QuoteButton(
+                        account: account,
+                        note: appearNote,
+                        focusPostForm: focusPostForm,
                       ),
                   ] else
                     IconButton(
@@ -313,259 +142,37 @@ class NoteFooter extends HookConsumerWidget {
                       appearNote.reactionAcceptance !=
                           ReactionAcceptance.likeOnly &&
                       appearNote.myReaction == null)
-                    IconButton(
-                      tooltip: t.misskey.like,
-                      onPressed: !account.isGuest
-                          ? () async {
-                              if (appearNote.id.isEmpty) return;
-                              final defaultReaction = ref
-                                  .read(
-                                    accountSettingsNotifierProvider(account),
-                                  )
-                                  .defaultReaction;
-                              final emoji = defaultReaction ?? '❤';
-                              if (ref
-                                  .read(generalSettingsNotifierProvider)
-                                  .confirmBeforeReact) {
-                                final confirmed = await confirmReaction(
-                                  context,
-                                  account: account,
-                                  emoji: emoji,
-                                  note: appearNote,
-                                );
-                                if (!confirmed) return;
-                              }
-                              if (!context.mounted) return;
-                              await futureWithDialog(
-                                context,
-                                ref
-                                    .read(
-                                      notesNotifierProvider(account).notifier,
-                                    )
-                                    .react(appearNote.id, emoji),
-                                overlay: false,
-                              );
-                            }
-                          : null,
-                      icon: const Icon(Icons.favorite_border),
+                    _LikeButton(
+                      account: account,
+                      note: appearNote,
                     ),
                   if (appearNote.myReaction == null)
-                    GestureDetector(
-                      onLongPress: appearNote.reactionAcceptance ==
-                                  ReactionAcceptance.likeOnly &&
-                              (appearNote.reactionCount ?? 0) > 0
-                          ? () => showModalBottomSheet<void>(
-                                context: context,
-                                builder: (context) => ReactionUsersSheet(
-                                  account: account,
-                                  noteId: appearNote.id,
-                                  initialReaction: '❤',
-                                ),
-                                isScrollControlled: true,
-                              )
-                          : null,
-                      child: IconButton(
-                        tooltip: appearNote.reactionAcceptance !=
-                                ReactionAcceptance.likeOnly
-                            ? t.misskey.reaction
-                            : (appearNote.reactionCount ?? 0) <= 0
-                                ? t.misskey.like
-                                : null,
-                        onPressed: !account.isGuest
-                            ? () async {
-                                if (appearNote.id.isEmpty) return;
-                                final emoji = appearNote.reactionAcceptance ==
-                                        ReactionAcceptance.likeOnly
-                                    ? '❤'
-                                    : await pickEmoji(
-                                        ref,
-                                        account,
-                                        reaction: true,
-                                        targetNote: appearNote,
-                                      );
-                                if (!context.mounted) return;
-                                if (emoji != null) {
-                                  if (ref
-                                      .read(generalSettingsNotifierProvider)
-                                      .confirmBeforeReact) {
-                                    final confirmed = await confirmReaction(
-                                      context,
-                                      account: account,
-                                      emoji: emoji,
-                                      note: appearNote,
-                                    );
-                                    if (!confirmed) return;
-                                  }
-                                  if (!context.mounted) return;
-                                  await futureWithDialog(
-                                    context,
-                                    ref
-                                        .read(
-                                          notesNotifierProvider(account)
-                                              .notifier,
-                                        )
-                                        .react(appearNote.id, emoji),
-                                    overlay: false,
-                                  );
-                                }
-                              }
-                            : null,
-                        icon: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (appearNote.reactionAcceptance ==
-                                ReactionAcceptance.likeOnly)
-                              const Icon(Icons.favorite_border)
-                            else
-                              const Icon(Icons.add),
-                            if (showReactionsCount &&
-                                (appearNote.reactionCount ?? 0) > 0)
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 2.0,
-                                ),
-                                child: Text(
-                                  NumberFormat()
-                                      .format(appearNote.reactionCount),
-                                  style: style,
-                                ),
-                              ),
-                          ],
-                        ),
-                      ),
+                    _AddReactionButton(
+                      account: account,
+                      note: appearNote,
+                      style: style,
                     )
                   else
-                    GestureDetector(
-                      onLongPress: appearNote.reactionAcceptance ==
-                              ReactionAcceptance.likeOnly
-                          ? () {
-                              if (appearNote.id.isEmpty) return;
-                              showModalBottomSheet<void>(
-                                context: context,
-                                builder: (context) => ReactionUsersSheet(
-                                  account: account,
-                                  noteId: appearNote.id,
-                                  initialReaction: '❤',
-                                ),
-                                isScrollControlled: true,
-                              );
-                            }
-                          : null,
-                      child: IconButton(
-                        tooltip: appearNote.reactionAcceptance !=
-                                ReactionAcceptance.likeOnly
-                            ? t.misskey.reaction
-                            : null,
-                        onPressed: () async {
-                          if (appearNote.id.isEmpty) return;
-                          final confirmed = await confirm(
-                            context,
-                            message: t.misskey.cancelReactionConfirm,
-                          );
-                          if (!confirmed) return;
-                          if (!context.mounted) return;
-                          await futureWithDialog(
-                            context,
-                            ref
-                                .read(notesNotifierProvider(account).notifier)
-                                .unreact(appearNote.id),
-                            overlay: false,
-                          );
-                        },
-                        icon: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (appearNote.reactionAcceptance ==
-                                ReactionAcceptance.likeOnly)
-                              const Icon(
-                                Icons.favorite,
-                                color: eventReactionHeart,
-                              )
-                            else
-                              Icon(
-                                Icons.remove,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                            if ((appearNote.reactionAcceptance ==
-                                        ReactionAcceptance.likeOnly ||
-                                    showReactionsCount) &&
-                                (appearNote.reactionCount ?? 0) > 0)
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 2.0,
-                                ),
-                                child: Text(
-                                  NumberFormat()
-                                      .format(appearNote.reactionCount),
-                                  style: style,
-                                ),
-                              ),
-                          ],
-                        ),
-                      ),
+                    _RemoveReactionButton(
+                      account: account,
+                      note: appearNote,
+                      style: style,
                     ),
                   if (showClipButton)
-                    IconButton(
-                      tooltip: t.misskey.clip,
-                      onPressed: !account.isGuest
-                          ? () {
-                              if (appearNote.id.isEmpty) return;
-                              showDialog<void>(
-                                context: context,
-                                builder: (context) => ClipDialog(
-                                  account: account,
-                                  noteId: appearNote.id,
-                                ),
-                              );
-                            }
-                          : null,
-                      icon: const Icon(Icons.attach_file),
+                    _ClipButton(
+                      account: account,
+                      note: appearNote,
                     ),
                   if (showTranslateButton)
-                    IconButton(
-                      tooltip: t.misskey.translate,
-                      onPressed: () {
-                        if ((i?.policies?.canUseTranslator ?? false) &&
-                            (meta?.translatorAvailable ?? false)) {
-                          showModalBottomSheet<void>(
-                            context: context,
-                            builder: (context) => TranslatedNoteSheet(
-                              account: account,
-                              note: appearNote,
-                            ),
-                            clipBehavior: Clip.antiAlias,
-                            scrollControlDisabledMaxHeightRatio: 0.8,
-                          );
-                        } else {
-                          launchUrl(
-                            ref,
-                            Uri.https(
-                              'translate.google.com',
-                              '',
-                              {
-                                'text': [appearNote.cw, appearNote.text]
-                                    .nonNulls
-                                    .join('\n'),
-                              },
-                            ),
-                          );
-                        }
-                      },
-                      icon: const Icon(Icons.translate),
+                    _TranslateButton(
+                      account: account,
+                      note: appearNote,
                     ),
-                  IconButton(
-                    tooltip: t.misskey.menu,
-                    onPressed: () {
-                      if (note.id.isEmpty) return;
-                      showNoteSheet(
-                        context: context,
-                        account: account,
-                        noteId: noteId,
-                        disableHeader: disableHeader,
-                        focusPostForm: focusPostForm,
-                      );
-                    },
-                    icon: const Icon(Icons.more_horiz),
+                  _MenuButton(
+                    account: account,
+                    note: appearNote,
+                    disableHeader: disableHeader,
+                    focusPostForm: focusPostForm,
                   ),
                 ],
               ),
@@ -573,6 +180,553 @@ class NoteFooter extends HookConsumerWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _ReplyButton extends ConsumerWidget {
+  const _ReplyButton({
+    required this.account,
+    required this.note,
+    this.focusPostForm,
+    this.style,
+  });
+
+  final Account account;
+  final Note note;
+  final void Function()? focusPostForm;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      tooltip: t.misskey.reply,
+      onPressed: !account.isGuest
+          ? () {
+              if (note.id.isEmpty) return;
+              ref.read(postNotifierProvider(account).notifier).setReply(note);
+              if (focusPostForm case final focusPostForm?) {
+                focusPostForm();
+              } else {
+                context.push('/$account/post');
+              }
+            }
+          : null,
+      icon: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.reply),
+          if (note.repliesCount > 0)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2.0),
+              child: Text(
+                NumberFormat().format(note.repliesCount),
+                style: style,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RenoteButton extends HookConsumerWidget {
+  const _RenoteButton({
+    required this.account,
+    required this.note,
+    this.myRenotingNoteId,
+    this.showQuoteButton = false,
+    this.focusPostForm,
+    this.style,
+  });
+
+  final Account account;
+  final Note note;
+  final String? myRenotingNoteId;
+  final bool showQuoteButton;
+  final void Function()? focusPostForm;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final myRenotingNoteId = useState(this.myRenotingNoteId);
+
+    return GestureDetector(
+      onLongPress: note.renoteCount > 0
+          ? () {
+              if (note.id.isEmpty) return;
+              HapticFeedback.lightImpact();
+              showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => RenoteUsersSheet(
+                  account: account,
+                  noteId: note.id,
+                ),
+                isScrollControlled: true,
+              );
+            }
+          : null,
+      child: IconButton(
+        tooltip: note.renoteCount <= 0 ? t.misskey.renote : null,
+        onPressed: !account.isGuest
+            ? () async {
+                if (note.id.isEmpty) return;
+                if (myRenotingNoteId.value case final noteId?) {
+                  final unrenote = await showModalBottomSheet<bool>(
+                    context: context,
+                    builder: (context) => ListView(
+                      shrinkWrap: true,
+                      children: [
+                        ListTile(
+                          leading: const Icon(Icons.repeat_rounded),
+                          title: Text(t.misskey.renote),
+                          onTap: () => context.pop(false),
+                        ),
+                        ListTile(
+                          leading: const Icon(Icons.delete),
+                          title: Text(t.misskey.unrenote),
+                          onTap: () => context.pop(true),
+                          iconColor: Theme.of(context).colorScheme.error,
+                          textColor: Theme.of(context).colorScheme.error,
+                        ),
+                      ],
+                    ),
+                  );
+                  if (!context.mounted) return;
+                  if (unrenote == null) return;
+                  if (unrenote) {
+                    final result = await futureWithDialog(
+                      context,
+                      ref
+                          .read(misskeyProvider(account))
+                          .notes
+                          .delete(NotesDeleteRequest(noteId: noteId))
+                          .then((_) => true),
+                    );
+                    if (!context.mounted) return;
+                    if (result != null) {
+                      ref
+                          .read(notesNotifierProvider(account).notifier)
+                          .remove(noteId);
+                      myRenotingNoteId.value = null;
+                    }
+                    return;
+                  }
+                }
+                if (showQuoteButton) {
+                  final result = await showModalBottomSheet<Note>(
+                    context: context,
+                    builder: (context) => RenoteSheet(
+                      account: account,
+                      note: note,
+                    ),
+                    clipBehavior: Clip.hardEdge,
+                  );
+                  if (result != null) {
+                    myRenotingNoteId.value = result.id;
+                  }
+                } else {
+                  ref
+                      .read(postNotifierProvider(account).notifier)
+                      .setRenote(note);
+                  if (focusPostForm case final focusPostForm?) {
+                    focusPostForm();
+                  } else {
+                    await context.push('/$account/post');
+                  }
+                }
+              }
+            : null,
+        icon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.repeat_rounded,
+              color: myRenotingNoteId.value != null
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+            ),
+            if (note.renoteCount > 0)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2.0),
+                child: Text(
+                  NumberFormat().format(note.renoteCount),
+                  style: style?.apply(
+                    color: myRenotingNoteId.value != null
+                        ? Theme.of(context).colorScheme.primary.withOpacity(0.6)
+                        : null,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QuoteButton extends ConsumerWidget {
+  const _QuoteButton({
+    required this.account,
+    required this.note,
+    this.focusPostForm,
+  });
+
+  final Account account;
+  final Note note;
+  final void Function()? focusPostForm;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      tooltip: t.misskey.quote,
+      onPressed: !account.isGuest
+          ? () {
+              if (note.id.isEmpty) return;
+              ref.read(postNotifierProvider(account).notifier).setRenote(note);
+              if (focusPostForm case final focusPostForm?) {
+                focusPostForm();
+              } else {
+                context.push('/$account/post');
+              }
+            }
+          : null,
+      icon: const Icon(Icons.format_quote_outlined),
+    );
+  }
+}
+
+class _LikeButton extends ConsumerWidget {
+  const _LikeButton({
+    required this.account,
+    required this.note,
+  });
+
+  final Account account;
+  final Note note;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      tooltip: t.misskey.like,
+      onPressed: !account.isGuest
+          ? () async {
+              if (note.id.isEmpty) return;
+              final defaultReaction = ref
+                  .read(accountSettingsNotifierProvider(account))
+                  .defaultReaction;
+              final emoji = defaultReaction ?? '❤';
+              if (ref
+                  .read(generalSettingsNotifierProvider)
+                  .confirmBeforeReact) {
+                final confirmed = await confirmReaction(
+                  context,
+                  account: account,
+                  emoji: emoji,
+                  note: note,
+                );
+                if (!confirmed) return;
+              }
+              if (!context.mounted) return;
+              await futureWithDialog(
+                context,
+                ref
+                    .read(notesNotifierProvider(account).notifier)
+                    .react(note.id, emoji),
+                overlay: false,
+              );
+            }
+          : null,
+      icon: const Icon(Icons.favorite_border),
+    );
+  }
+}
+
+class _AddReactionButton extends ConsumerWidget {
+  const _AddReactionButton({
+    required this.account,
+    required this.note,
+    this.style,
+  });
+
+  final Account account;
+  final Note note;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final showReactionsCount = ref.watch(
+      generalSettingsNotifierProvider
+          .select((settings) => settings.showReactionsCount),
+    );
+
+    return GestureDetector(
+      onLongPress: note.reactionAcceptance == ReactionAcceptance.likeOnly &&
+              (note.reactionCount ?? 0) > 0
+          ? () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => ReactionUsersSheet(
+                  account: account,
+                  noteId: note.id,
+                  initialReaction: '❤',
+                ),
+                clipBehavior: Clip.antiAlias,
+                isScrollControlled: true,
+              )
+          : null,
+      child: IconButton(
+        tooltip: note.reactionAcceptance != ReactionAcceptance.likeOnly
+            ? t.misskey.reaction
+            : (note.reactionCount ?? 0) <= 0
+                ? t.misskey.like
+                : null,
+        onPressed: !account.isGuest
+            ? () async {
+                if (note.id.isEmpty) return;
+                final emoji =
+                    note.reactionAcceptance == ReactionAcceptance.likeOnly
+                        ? '❤'
+                        : await pickEmoji(
+                            ref,
+                            account,
+                            reaction: true,
+                            targetNote: note,
+                          );
+                if (!context.mounted) return;
+                if (emoji != null) {
+                  if (ref
+                      .read(generalSettingsNotifierProvider)
+                      .confirmBeforeReact) {
+                    final confirmed = await confirmReaction(
+                      context,
+                      account: account,
+                      emoji: emoji,
+                      note: note,
+                    );
+                    if (!confirmed) return;
+                  }
+                  if (!context.mounted) return;
+                  await futureWithDialog(
+                    context,
+                    ref
+                        .read(notesNotifierProvider(account).notifier)
+                        .react(note.id, emoji),
+                    overlay: false,
+                  );
+                }
+              }
+            : null,
+        icon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (note.reactionAcceptance == ReactionAcceptance.likeOnly)
+              const Icon(Icons.favorite_border)
+            else
+              const Icon(Icons.add),
+            if (showReactionsCount && (note.reactionCount ?? 0) > 0)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 2.0),
+                child: Text(
+                  NumberFormat().format(note.reactionCount),
+                  style: style,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RemoveReactionButton extends ConsumerWidget {
+  const _RemoveReactionButton({
+    required this.account,
+    required this.note,
+    this.style,
+  });
+
+  final Account account;
+  final Note note;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final showReactionsCount = ref.watch(
+      generalSettingsNotifierProvider
+          .select((settings) => settings.showReactionsCount),
+    );
+
+    return GestureDetector(
+      onLongPress: note.reactionAcceptance == ReactionAcceptance.likeOnly
+          ? () {
+              if (note.id.isEmpty) return;
+              showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => ReactionUsersSheet(
+                  account: account,
+                  noteId: note.id,
+                  initialReaction: '❤',
+                ),
+                clipBehavior: Clip.antiAlias,
+                isScrollControlled: true,
+              );
+            }
+          : null,
+      child: IconButton(
+        tooltip: note.reactionAcceptance != ReactionAcceptance.likeOnly
+            ? t.misskey.reaction
+            : null,
+        onPressed: () async {
+          if (note.id.isEmpty) return;
+          final confirmed = await confirm(
+            context,
+            message: t.misskey.cancelReactionConfirm,
+          );
+          if (!confirmed) return;
+          if (!context.mounted) return;
+          await futureWithDialog(
+            context,
+            ref.read(notesNotifierProvider(account).notifier).unreact(note.id),
+            overlay: false,
+          );
+        },
+        icon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (note.reactionAcceptance == ReactionAcceptance.likeOnly)
+              const Icon(
+                Icons.favorite,
+                color: eventReactionHeart,
+              )
+            else
+              Icon(
+                Icons.remove,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            if ((note.reactionAcceptance == ReactionAcceptance.likeOnly ||
+                    showReactionsCount) &&
+                (note.reactionCount ?? 0) > 0)
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 2.0,
+                ),
+                child: Text(
+                  NumberFormat().format(note.reactionCount),
+                  style: style,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ClipButton extends ConsumerWidget {
+  const _ClipButton({
+    required this.account,
+    required this.note,
+  });
+
+  final Account account;
+  final Note note;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      tooltip: t.misskey.clip,
+      onPressed: !account.isGuest
+          ? () {
+              if (note.id.isEmpty) return;
+              showDialog<void>(
+                context: context,
+                builder: (context) => ClipDialog(
+                  account: account,
+                  noteId: note.id,
+                ),
+              );
+            }
+          : null,
+      icon: const Icon(Icons.attach_file),
+    );
+  }
+}
+
+class _TranslateButton extends ConsumerWidget {
+  const _TranslateButton({
+    required this.account,
+    required this.note,
+  });
+
+  final Account account;
+  final Note note;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+    final meta = ref.watch(metaNotifierProvider(account.host)).valueOrNull;
+
+    return IconButton(
+      tooltip: t.misskey.translate,
+      onPressed: () {
+        if (note.id.isEmpty) return;
+        if ((i?.policies?.canUseTranslator ?? false) &&
+            (meta?.translatorAvailable ?? false)) {
+          showModalBottomSheet<void>(
+            context: context,
+            builder: (context) => TranslatedNoteSheet(
+              account: account,
+              note: note,
+            ),
+            clipBehavior: Clip.antiAlias,
+            scrollControlDisabledMaxHeightRatio: 0.8,
+          );
+        } else {
+          launchUrl(
+            ref,
+            Uri.https(
+              'translate.google.com',
+              '',
+              {
+                'text': [note.cw, note.text].nonNulls.join('\n'),
+              },
+            ),
+          );
+        }
+      },
+      icon: const Icon(Icons.translate),
+    );
+  }
+}
+
+class _MenuButton extends ConsumerWidget {
+  const _MenuButton({
+    required this.account,
+    required this.note,
+    this.disableHeader = false,
+    this.focusPostForm,
+  });
+
+  final Account account;
+  final Note note;
+  final bool disableHeader;
+  final void Function()? focusPostForm;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return IconButton(
+      tooltip: t.misskey.menu,
+      onPressed: () {
+        if (note.id.isEmpty) return;
+        showNoteSheet(
+          context: context,
+          account: account,
+          noteId: note.id,
+          disableHeader: disableHeader,
+          focusPostForm: focusPostForm,
+        );
+      },
+      icon: const Icon(Icons.more_horiz),
     );
   }
 }

--- a/lib/view/widget/reaction_button.dart
+++ b/lib/view/widget/reaction_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:misskey_dart/misskey_dart.dart';
+import 'package:misskey_dart/misskey_dart.dart' hide Clip;
 
 import '../../extension/text_style_extension.dart';
 import '../../i18n/strings.g.dart';
@@ -136,8 +136,9 @@ class ReactionButton extends ConsumerWidget {
                 builder: (context) => ReactionUsersSheet(
                   account: account,
                   noteId: note.id,
-                  reaction: emoji,
+                  initialReaction: emoji,
                 ),
+                clipBehavior: Clip.antiAlias,
                 isScrollControlled: true,
               )
           : null,

--- a/test/view/widget/note_footer_test.dart
+++ b/test/view/widget/note_footer_test.dart
@@ -1,0 +1,1173 @@
+import 'package:aria/i18n/strings.g.dart';
+import 'package:aria/model/account.dart';
+import 'package:aria/provider/api/i_notifier_provider.dart';
+import 'package:aria/provider/general_settings_notifier_provider.dart';
+import 'package:aria/provider/notes_notifier_provider.dart';
+import 'package:aria/provider/post_notifier_provider.dart';
+import 'package:aria/view/dialog/clip_dialog.dart';
+import 'package:aria/view/dialog/reaction_confirmation_dialog.dart';
+import 'package:aria/view/widget/emoji_picker.dart';
+import 'package:aria/view/widget/note_footer.dart';
+import 'package:aria/view/widget/note_sheet.dart';
+import 'package:aria/view/widget/reaction_users_sheet.dart';
+import 'package:aria/view/widget/renote_sheet.dart';
+import 'package:aria/view/widget/renote_users_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+import '../../../test_util/create_overrides.dart';
+import '../../../test_util/dummy_me_detailed.dart';
+import '../../../test_util/dummy_note.dart';
+
+Future<ProviderContainer> setupWidget(
+  WidgetTester tester, {
+  required Account account,
+  required String noteId,
+  void Function()? focusPostForm,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: createOverrides(
+        account,
+        i: dummyMeDetailed.copyWith(id: 'testuser'),
+      ),
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (_, __) => NoteFooter(
+                account: account,
+                noteId: noteId,
+                focusPostForm: focusPostForm,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  final container =
+      ProviderScope.containerOf(tester.element(find.byType(NoteFooter)));
+  await tester
+      .runAsync(() => container.read(iNotifierProvider(account).future));
+  return container;
+}
+
+void main() {
+  group('basic', () {
+    testWidgets('should show 5 buttons for a public note', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: dummyNote.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(dummyNote);
+      await tester.pumpAndSettle();
+      expect(find.byType(Icon), findsExactly(5));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show 4 buttons for a private note', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(visibility: NoteVisibility.followers);
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: dummyNote.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byType(Icon), findsExactly(4));
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('reply', () {
+    testWidgets('should not show a replies count if not replied',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        repliesCount: 0,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.text('0'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a replies count if replied', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        repliesCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsOne);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not open a post page on tap for a guest',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.reply));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('/$account/post'), findsNothing);
+      expect(container.read(postNotifierProvider(account)).replyId, isNull);
+    });
+
+    testWidgets('should open a post page on tap', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.reply));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('/$account/post'), findsOne);
+      expect(
+        container.read(postNotifierProvider(account)).replyId,
+        same(note.id),
+      );
+    });
+
+    testWidgets('should call a callback on tap', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      bool tapped = false;
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () => tapped = true,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.reply));
+      await tester.pumpAndSettle();
+      expect(tapped, isTrue);
+      expect(
+        container.read(postNotifierProvider(account)).replyId,
+        same(note.id),
+      );
+    });
+
+    testWidgets('should reply to a renoted note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () {},
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.reply));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(postNotifierProvider(account)).replyId,
+        same(renote.id),
+      );
+    });
+
+    testWidgets('should reply to a quote note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        text: 'quote',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () {},
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.reply));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(postNotifierProvider(account)).replyId,
+        same(note.id),
+      );
+    });
+  });
+
+  group('renote', () {
+    testWidgets('should not show a renote count if not renoted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteCount: 0,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.text('0'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a renote count if renoted', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsOne);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a renote sheet on tap for a guest',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(RenoteSheet), findsNothing);
+    });
+
+    testWidgets('should show a renote sheet on tap', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(RenoteSheet), findsOne);
+    });
+
+    testWidgets('should show a block icon for a private note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        visibility: NoteVisibility.followers,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.repeat_rounded), findsNothing);
+      await tester.tap(find.byIcon(Icons.block));
+      await tester.pumpAndSettle();
+      expect(find.byType(RenoteSheet), findsNothing);
+    });
+
+    testWidgets(
+        'should show a renote sheet on tap for a private note created by me',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        userId: 'testuser',
+        visibility: NoteVisibility.followers,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.block), findsNothing);
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(RenoteSheet), findsOne);
+    });
+
+    testWidgets('should show a modal bottom sheet on tap if already renoted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        userId: 'testuser',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.delete), findsOne);
+    });
+
+    testWidgets('should open a post page on tap if a quote button is hidden',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowQuoteButtonInNoteFooter(false);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('/$account/post'), findsOne);
+    });
+
+    testWidgets('should call a callback on tap if a quote button is hidden',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      bool tapped = false;
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () => tapped = true,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowQuoteButtonInNoteFooter(false);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(tapped, isTrue);
+      expect(
+        container.read(postNotifierProvider(account)).renoteId,
+        same(note.id),
+      );
+    });
+
+    testWidgets('should renote a renoted note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () {},
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowQuoteButtonInNoteFooter(false);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(postNotifierProvider(account)).renoteId,
+        same(renote.id),
+      );
+    });
+
+    testWidgets('should renote a quote note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        text: 'quote',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () {},
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowQuoteButtonInNoteFooter(false);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(postNotifierProvider(account)).renoteId,
+        same(note.id),
+      );
+    });
+
+    testWidgets('should not show renoted users on long press if not renoted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteCount: 0,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(RenoteUsersSheet), findsNothing);
+    });
+
+    testWidgets('should show renoted users on long press if renoted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.repeat_rounded));
+      await tester.pumpAndSettle();
+      expect(find.byType(RenoteUsersSheet), findsOne);
+    });
+  });
+
+  group('quote', () {
+    testWidgets('should not show a quote button if disabled', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowQuoteButtonInNoteFooter(false);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.format_quote_outlined), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a quote button for a private note',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        visibility: NoteVisibility.followers,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.format_quote_outlined), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not open a post page on tap for a guest',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.format_quote_outlined));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('/$account/post'), findsNothing);
+      expect(container.read(postNotifierProvider(account)).renoteId, isNull);
+    });
+
+    testWidgets('should show nothing on tap a quote button', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.format_quote_outlined));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('/$account/post'), findsOne);
+      expect(
+        container.read(postNotifierProvider(account)).renoteId,
+        same(note.id),
+      );
+    });
+
+    testWidgets('should quote a renoted note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () {},
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.format_quote_outlined));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(postNotifierProvider(account)).renoteId,
+        same(renote.id),
+      );
+    });
+
+    testWidgets('should quote a quote note', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final renote = dummyNote.copyWith(id: 'renote');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        text: 'quote',
+        renoteId: renote.id,
+        renote: renote,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+        focusPostForm: () {},
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.format_quote_outlined));
+      await tester.pumpAndSettle();
+      expect(
+        container.read(postNotifierProvider(account)).renoteId,
+        same(note.id),
+      );
+    });
+  });
+
+  group('like', () {
+    testWidgets('should not show a like button', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.favorite_border), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a like button if enabled and like-only',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionAcceptance: ReactionAcceptance.likeOnly,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowLikeButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.favorite_border), findsOne);
+      expect(find.byIcon(Icons.add), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a like button if enabled and reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowLikeButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.favorite_border), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets(
+        'should not show a reaction confirmation on tap for a guest if enabled',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowLikeButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.favorite_border));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionConfirmationDialog), findsNothing);
+    });
+
+    testWidgets('should show a reaction confirmation on tap if enabled',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowLikeButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.favorite_border));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionConfirmationDialog), findsOne);
+    });
+  });
+
+  group('add reaction', () {
+    testWidgets('should not show an add reaction button if reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.add), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a heart icon if like-only', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionAcceptance: ReactionAcceptance.likeOnly,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.add), findsNothing);
+      expect(find.byIcon(Icons.favorite_border), findsOne);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a reaction count', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a reaction count if enabled and not reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 0,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowReactionsCount(true);
+      await tester.pumpAndSettle();
+      expect(find.text('0'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a reaction count if enabled and reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowReactionsCount(true);
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsOne);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show an emoji picker on tap for a guest',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      expect(find.byType(EmojiPicker), findsNothing);
+    });
+
+    testWidgets('should show an emoji picker on tap', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      expect(find.byType(EmojiPicker), findsOne);
+    });
+
+    testWidgets('should not show reacted users on long press if not reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 0,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionUsersSheet), findsNothing);
+    });
+
+    testWidgets(
+        'should not show reacted users on long press if reacted and not like-only',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionUsersSheet), findsNothing);
+    });
+
+    testWidgets(
+        'should show reacted users on long press if reacted and like-only',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 1,
+        reactionAcceptance: ReactionAcceptance.likeOnly,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.favorite_border));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionUsersSheet), findsOne);
+    });
+  });
+
+  group('remove reaction', () {
+    testWidgets('should not show an remove reaction button if not reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.remove), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a heart icon if like-only', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+        reactionAcceptance: ReactionAcceptance.likeOnly,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.remove), findsNothing);
+      expect(find.byIcon(Icons.favorite), findsOne);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a reaction count', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+        reactionCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a reaction count if enabled and not reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+        reactionCount: 0,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowReactionsCount(true);
+      await tester.pumpAndSettle();
+      expect(find.text('0'), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a reaction count if enabled and reacted',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+        reactionCount: 1,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowReactionsCount(true);
+      await tester.pumpAndSettle();
+      expect(find.text('1'), findsOne);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should show a confirmation on tap', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        myReaction: '❤',
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.remove));
+      await tester.pumpAndSettle();
+      expect(find.text(t.misskey.cancelReactionConfirm), findsOne);
+    });
+
+    testWidgets(
+        'should not show reacted users on long press if reacted and not like-only',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 1,
+        myReaction: '❤',
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.remove));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionUsersSheet), findsNothing);
+    });
+
+    testWidgets(
+        'should show reacted users on long press if reacted and like-only',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(
+        id: 'test',
+        reactionCount: 1,
+        myReaction: '❤',
+        reactionAcceptance: ReactionAcceptance.likeOnly,
+      );
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.longPress(find.byIcon(Icons.favorite));
+      await tester.pumpAndSettle();
+      expect(find.byType(ReactionUsersSheet), findsOne);
+    });
+  });
+
+  group('clip', () {
+    testWidgets('should not show a clip button', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.attach_file), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a clip dialog on tap if enabled and guest',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowClipButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.attach_file));
+      await tester.pumpAndSettle();
+      expect(find.byType(ClipDialog), findsNothing);
+    });
+
+    testWidgets('should not show a clip dialog on tap if enabled',
+        (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowClipButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.attach_file));
+      await tester.pumpAndSettle();
+      expect(find.byType(ClipDialog), findsOne);
+    });
+  });
+
+  group('translate', () {
+    testWidgets('should not show a translate button', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.translate), findsNothing);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should not show a translate button if enabled',
+        (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await container
+          .read(generalSettingsNotifierProvider.notifier)
+          .setShowTranslateButtonInNoteFooter(true);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.translate), findsOne);
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('menu', () {
+    testWidgets('should show a menu on tap a menu button', (tester) async {
+      const account = Account(host: 'misskey.tld');
+      final note = dummyNote.copyWith(id: 'test');
+      final container = await setupWidget(
+        tester,
+        account: account,
+        noteId: note.id,
+      );
+      container.read(notesNotifierProvider(account).notifier).add(note);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+      expect(find.byType(NoteSheet), findsOne);
+    });
+  });
+}

--- a/test/view/widget/note_footer_test.dart
+++ b/test/view/widget/note_footer_test.dart
@@ -865,8 +865,7 @@ void main() {
       expect(find.byType(ReactionUsersSheet), findsNothing);
     });
 
-    testWidgets(
-        'should not show reacted users on long press if reacted and not like-only',
+    testWidgets('should show reacted users on long press if reacted',
         (tester) async {
       const account = Account(host: 'misskey.tld', username: 'testuser');
       final note = dummyNote.copyWith(
@@ -881,27 +880,6 @@ void main() {
       container.read(notesNotifierProvider(account).notifier).add(note);
       await tester.pumpAndSettle();
       await tester.longPress(find.byIcon(Icons.add));
-      await tester.pumpAndSettle();
-      expect(find.byType(ReactionUsersSheet), findsNothing);
-    });
-
-    testWidgets(
-        'should show reacted users on long press if reacted and like-only',
-        (tester) async {
-      const account = Account(host: 'misskey.tld', username: 'testuser');
-      final note = dummyNote.copyWith(
-        id: 'test',
-        reactionCount: 1,
-        reactionAcceptance: ReactionAcceptance.likeOnly,
-      );
-      final container = await setupWidget(
-        tester,
-        account: account,
-        noteId: note.id,
-      );
-      container.read(notesNotifierProvider(account).notifier).add(note);
-      await tester.pumpAndSettle();
-      await tester.longPress(find.byIcon(Icons.favorite_border));
       await tester.pumpAndSettle();
       expect(find.byType(ReactionUsersSheet), findsOne);
     });
@@ -1022,8 +1000,7 @@ void main() {
       expect(find.text(t.misskey.cancelReactionConfirm), findsOne);
     });
 
-    testWidgets(
-        'should not show reacted users on long press if reacted and not like-only',
+    testWidgets('should show reacted users on long press if reacted',
         (tester) async {
       const account = Account(host: 'misskey.tld', username: 'testuser');
       final note = dummyNote.copyWith(
@@ -1039,28 +1016,6 @@ void main() {
       container.read(notesNotifierProvider(account).notifier).add(note);
       await tester.pumpAndSettle();
       await tester.longPress(find.byIcon(Icons.remove));
-      await tester.pumpAndSettle();
-      expect(find.byType(ReactionUsersSheet), findsNothing);
-    });
-
-    testWidgets(
-        'should show reacted users on long press if reacted and like-only',
-        (tester) async {
-      const account = Account(host: 'misskey.tld', username: 'testuser');
-      final note = dummyNote.copyWith(
-        id: 'test',
-        reactionCount: 1,
-        myReaction: '❤',
-        reactionAcceptance: ReactionAcceptance.likeOnly,
-      );
-      final container = await setupWidget(
-        tester,
-        account: account,
-        noteId: note.id,
-      );
-      container.read(notesNotifierProvider(account).notifier).add(note);
-      await tester.pumpAndSettle();
-      await tester.longPress(find.byIcon(Icons.favorite));
       await tester.pumpAndSettle();
       expect(find.byType(ReactionUsersSheet), findsOne);
     });

--- a/test_util/create_container.dart
+++ b/test_util/create_container.dart
@@ -1,18 +1,11 @@
-import 'package:aria/extension/emoji_extension.dart';
 import 'package:aria/model/account.dart';
 import 'package:aria/provider/api/i_notifier_provider.dart';
 import 'package:aria/provider/api/meta_notifier_provider.dart';
-import 'package:aria/provider/api/misskey_provider.dart';
-import 'package:aria/provider/cache_manager_provider.dart';
-import 'package:aria/provider/emoji_provider.dart';
-import 'package:aria/provider/note_provider.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
-import 'fake_cache_manager.dart';
+import 'create_overrides.dart';
 
 Future<ProviderContainer> createContainer(
   Account account, {
@@ -21,31 +14,14 @@ Future<ProviderContainer> createContainer(
   Note? note,
   List<Emoji>? emojis,
 }) async {
-  final dio = Dio();
-  final dioAdapter = DioAdapter(dio: dio, matcher: const UrlRequestMatcher());
-  final misskey = Misskey(host: account.host, dio: dio);
-  if (i != null) {
-    dioAdapter.onPost(
-      'i',
-      (server) => server.reply(200, i.toJson()),
-    );
-  }
-  if (meta != null) {
-    dioAdapter.onPost(
-      'meta',
-      (server) => server.reply(200, meta.toJson()),
-    );
-  }
   final container = ProviderContainer(
-    overrides: [
-      cacheManagerProvider.overrideWithValue(FakeCacheManager()),
-      misskeyProvider(account).overrideWithValue(misskey),
-      if (note != null) noteProvider(account, note.id).overrideWithValue(note),
-      ...?emojis?.map(
-        (emoji) =>
-            emojiProvider(account.host, emoji.emoji).overrideWithValue(emoji),
-      ),
-    ],
+    overrides: createOverrides(
+      account,
+      i: i,
+      meta: meta,
+      note: note,
+      emojis: emojis,
+    ),
   );
   if (i != null) {
     await container.read(iNotifierProvider(account).future);

--- a/test_util/create_overrides.dart
+++ b/test_util/create_overrides.dart
@@ -1,0 +1,51 @@
+import 'package:aria/extension/emoji_extension.dart';
+import 'package:aria/model/account.dart';
+import 'package:aria/provider/api/misskey_provider.dart';
+import 'package:aria/provider/cache_manager_provider.dart';
+import 'package:aria/provider/dio_provider.dart';
+import 'package:aria/provider/emoji_provider.dart';
+import 'package:aria/provider/note_provider.dart';
+import 'package:aria/provider/shared_preferences_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:misskey_dart/misskey_dart.dart';
+
+import 'fake_cache_manager.dart';
+import 'fake_shared_preferences.dart';
+
+List<Override> createOverrides(
+  Account account, {
+  MeDetailed? i,
+  MetaResponse? meta,
+  Note? note,
+  List<Emoji>? emojis,
+}) {
+  final dio = Dio();
+  final dioAdapter = DioAdapter(dio: dio, matcher: const UrlRequestMatcher());
+  final misskey = Misskey(host: account.host, dio: dio);
+  if (i != null) {
+    dioAdapter.onPost(
+      'i',
+      (server) => server.reply(200, i.toJson()),
+    );
+  }
+  if (meta != null) {
+    dioAdapter.onPost(
+      'meta',
+      (server) => server.reply(200, meta.toJson()),
+    );
+  }
+  return [
+    cacheManagerProvider.overrideWithValue(FakeCacheManager()),
+    // ignore: prefer_const_constructors
+    sharedPreferencesProvider.overrideWithValue(FakeSharedPreferences({})),
+    dioProvider.overrideWithValue(dio),
+    misskeyProvider(account).overrideWithValue(misskey),
+    if (note != null) noteProvider(account, note.id).overrideWithValue(note),
+    ...?emojis?.map(
+      (emoji) =>
+          emojiProvider(account.host, emoji.emoji).overrideWithValue(emoji),
+    ),
+  ];
+}

--- a/test_util/dummy_note.dart
+++ b/test_util/dummy_note.dart
@@ -7,6 +7,7 @@ final dummyNote = Note(
   createdAt: DateTime(0),
   user: dummyUserLite,
   userId: '',
+  visibility: NoteVisibility.public,
   reactions: {},
   fileIds: [],
   files: [],


### PR DESCRIPTION
Added a horizontal bar on top of the `ReactionUsersSheet` so that the user can see users who added another reaction without closing the sheet.