### PR TITLE
feat: mark notifications as read on tap

### DIFF
--- a/lib/provider/message_opened_app_notifier_provider.dart
+++ b/lib/provider/message_opened_app_notifier_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'api/i_notifier_provider.dart';
 import 'notes_notifier_provider.dart';
 import 'push_notification_notifier_provider.dart';
 import 'user_ids_notifier_provider.dart';
@@ -42,16 +43,13 @@ class MessageOpenedAppNotifier extends _$MessageOpenedAppNotifier {
       return null;
     }
 
-    try {
-      if (notification.body?.note?.id case final noteId?) {
-        unawaited(
-          ref.read(notesNotifierProvider(account).notifier).show(noteId),
-        );
-        return '/$account/notes/$noteId';
-      } else if (notification.body?.userId case final userId?) {
-        return '/$account/users/$userId';
-      }
-    } catch (_) {}
+    ref.read(iNotifierProvider(account).notifier).readNotifications().ignore();
+    if (notification.body?.note?.id case final noteId?) {
+      ref.read(notesNotifierProvider(account).notifier).show(noteId).ignore();
+      return '/$account/notes/$noteId';
+    } else if (notification.body?.userId case final userId?) {
+      return '/$account/users/$userId';
+    }
     return '/$account/notifications';
   }
 }

--- a/lib/provider/message_opened_app_notifier_provider.g.dart
+++ b/lib/provider/message_opened_app_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'message_opened_app_notifier_provider.dart';
 // **************************************************************************
 
 String _$messageOpenedAppNotifierHash() =>
-    r'aee58f16c19afc51abade9aac101f17c46769a0e';
+    r'f2a053ae7c9c7f1cd227930913631a6c7fe58c1a';
 
 /// See also [MessageOpenedAppNotifier].
 @ProviderFor(MessageOpenedAppNotifier)


### PR DESCRIPTION
Changed to mark notifications as read when a push notification is tapped in order to hide the dot indicator on the notification icon.