### PR TITLE
fix: load locales when opening languages page

### DIFF
--- a/lib/view/page/settings/languages_page.dart
+++ b/lib/view/page/settings/languages_page.dart
@@ -100,9 +100,7 @@ class LanguagesPage extends ConsumerWidget {
                   groupValue: locale,
                   onChanged: (_) {
                     ref
-                        .read(
-                          generalSettingsNotifierProvider.notifier,
-                        )
+                        .read(generalSettingsNotifierProvider.notifier)
                         .setLocale(null);
                     LocaleSettings.useDeviceLocale();
                   },
@@ -117,17 +115,17 @@ class LanguagesPage extends ConsumerWidget {
                     )
                     .map(
                       (appLocale) => RadioListTile(
-                        title: Text(
-                          appLocale.translations.misskey.lang__,
+                        title: FutureBuilder(
+                          future: LocaleSettings.instance.loadLocale(appLocale),
+                          builder: (context, snapshot) =>
+                              Text(appLocale.translations.misskey.lang__),
                         ),
                         subtitle: Text(appLocale.languageTag),
                         value: appLocale,
                         groupValue: locale,
                         onChanged: (locale) {
                           ref
-                              .read(
-                                generalSettingsNotifierProvider.notifier,
-                              )
+                              .read(generalSettingsNotifierProvider.notifier)
                               .setLocale(locale);
                           if (locale == null) {
                             LocaleSettings.useDeviceLocale();


### PR DESCRIPTION
Fixed an issue where all language names are displayed as "English" after lazy loading of translations was introduced in [slang 4.0.0](https://pub.dev/packages/slang/changelog#400).