### PR TITLE
fix: avoid updating PostNotifier state if text is not changed

### DIFF
--- a/lib/provider/post_notifier_provider.dart
+++ b/lib/provider/post_notifier_provider.dart
@@ -282,7 +282,13 @@ class PostNotifier extends _$PostNotifier {
   }
 
   void setCw(String? cw) {
-    state = state.copyWith(cw: cw?.isNotEmpty ?? false ? cw : null);
+    if ((cw == null || cw.isEmpty) && state.cw != null) {
+      state = state.copyWith(cw: null);
+    } else if (cw != state.cw) {
+      state = state.copyWith(cw: cw);
+    } else {
+      return;
+    }
     _scheduleSave();
   }
 
@@ -462,7 +468,13 @@ class PostNotifier extends _$PostNotifier {
   }
 
   void setText(String? text) {
-    state = state.copyWith(text: text?.isNotEmpty ?? false ? text : null);
+    if ((text == null || text.isEmpty) && state.text != null) {
+      state = state.copyWith(text: null);
+    } else if (text != state.text) {
+      state = state.copyWith(text: text);
+    } else {
+      return;
+    }
     _scheduleSave();
   }
 

--- a/lib/provider/post_notifier_provider.g.dart
+++ b/lib/provider/post_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'post_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$postNotifierHash() => r'eccd6311d739a6daeb2e8b704714b15d648f3145';
+String _$postNotifierHash() => r'fc224bbd9a943ee7a09a4c5a6bcee70bf4e72895';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Removed unnecessary update process which was called when `TextEditingController` was updated.

Fix #457