### PR TITLE
fix: check scheme when pasting a link

### DIFF
--- a/lib/view/widget/post_form.dart
+++ b/lib/view/widget/post_form.dart
@@ -961,7 +961,8 @@ class PostForm extends HookConsumerWidget {
                           final data =
                               await Clipboard.getData(Clipboard.kTextPlain);
                           if (data case ClipboardData(:final text?)) {
-                            if (Uri.tryParse(text) != null) {
+                            if (Uri.tryParse(text) case final url?
+                                when RegExp(r'^https?$').hasMatch(url.scheme)) {
                               if (!controller.selection.isCollapsed) {
                                 controller.insert('[', ']()');
                                 controller.selection = TextSelection.collapsed(


### PR DESCRIPTION
#375 was intended to work only when pasting a url, but `Uri.tryParse()` actually parses a text without a scheme, making normal text wrapped in a link syntax. This PR fixes the problem by checking if the parsed url has an http or https scheme.