### PR TITLE
fix: apply text style for unicode emoji

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -66,6 +66,7 @@ List<InlineSpan> buildMfm(
     unicodeEmojiBuilder: (emoji, style) => UnicodeEmoji(
       account: account,
       emoji: emoji,
+      style: style,
       onTap: onTapEmoji != null ? () => onTapEmoji.call(emoji) : null,
       inline: true,
     ),


### PR DESCRIPTION
Fixed an issue where the style is not applied to unicode emojis in MFM after #445.

Fix #463 