### PR TITLE
fix: always make pull-to-refresh triggerable

### DIFF
--- a/lib/view/page/drive_page.dart
+++ b/lib/view/page/drive_page.dart
@@ -280,6 +280,7 @@ class DrivePage extends HookConsumerWidget {
           ]),
           child: CustomScrollView(
             controller: controller,
+            physics: const AlwaysScrollableScrollPhysics(),
             slivers: [
               if (folders
                   case AsyncValue(

--- a/lib/view/widget/drive_folder_sheet.dart
+++ b/lib/view/widget/drive_folder_sheet.dart
@@ -6,6 +6,7 @@ import 'package:misskey_dart/misskey_dart.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/api/drive_folders_notifier_provider.dart';
+import '../../provider/selected_drive_files_notifier_provider.dart';
 import '../../util/future_with_dialog.dart';
 import '../dialog/confirmation_dialog.dart';
 import '../dialog/text_field_dialog.dart';
@@ -83,6 +84,7 @@ class DriveFolderSheet extends ConsumerWidget {
             .delete(folder.id),
         message: t.misskey.removed,
       );
+      ref.read(selectedDriveFilesNotifierProvider.notifier).removeAll();
       if (!ref.context.mounted) return;
       ref.context.pop();
     }

--- a/lib/view/widget/paginated_list_view.dart
+++ b/lib/view/widget/paginated_list_view.dart
@@ -63,6 +63,7 @@ class PaginatedListView<T> extends HookConsumerWidget {
           margin: const EdgeInsets.symmetric(horizontal: 8.0),
           child: CustomScrollView(
             controller: controller,
+            physics: const AlwaysScrollableScrollPhysics(),
             slivers: [
               if (header case final header?) header,
               if (paginationState != null) ...[


### PR DESCRIPTION
Applied `AlwaysScrollableScrollPhysics` to `PagenatedListView` to make pull-to-refresh work even if the list has no elements.