### PR TITLE
fix: add paddings around children of page sections

### DIFF
--- a/lib/view/page/page/page_page.dart
+++ b/lib/view/page/page/page_page.dart
@@ -103,7 +103,10 @@ class PagePage extends ConsumerWidget {
             ),
             const SizedBox(height: 8.0),
             ...?children?.map(
-              (child) => _buildBlock(context, page, child, topLevel: false),
+              (child) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
+                child: _buildBlock(context, page, child, topLevel: false),
+              ),
             ),
           ],
         );


### PR DESCRIPTION
Fixed an issue where children of page sections do not have paddings.