### PR TITLE
ci: use iPhone 15 for integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Start simulator
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
 
       - name: Pre-build the app
         uses: nick-fields/retry@v3


### PR DESCRIPTION
iPhone 14 was removed from available devices.

ref: https://github.com/futureware-tech/simulator-action/wiki/Devices-macos-latest/_compare/1ba16ab52702384ef1769863d8e0580f79e7e18c...8d67e209458b6eb7d777d1a9942d72f3f3cf7903