### PR TITLE
fix: open hashtags form when post to hashtag

### DIFF
--- a/lib/view/page/tag/tag_page.dart
+++ b/lib/view/page/tag/tag_page.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../i18n/strings.g.dart';
 import '../../../model/account.dart';
+import '../../../provider/account_settings_notifier_provider.dart';
 import '../../../provider/api/tag_notes_notifier_provider.dart';
 import '../../../provider/post_form_hashtags_notifier_provider.dart';
 import 'tag_notes.dart';
@@ -51,11 +52,22 @@ class TagPage extends ConsumerWidget {
                   ref
                       .read(postFormHashtagsNotifierProvider(account).notifier)
                       .updateHashtags([tag]);
+                  final useHashtags = ref
+                      .read(accountSettingsNotifierProvider(account))
+                      .postFormUseHashtags;
+                  await ref
+                      .read(accountSettingsNotifierProvider(account).notifier)
+                      .setPostFormUseHashtags(true);
+                  if (!context.mounted) return;
                   await context.push('/$account/post');
+                  if (!context.mounted) return;
                   ref
                       .read(postFormHashtagsNotifierProvider(account).notifier)
                       .updateHashtags(hashtags);
                   ref.invalidate(tagNotesNotifierProvider(account, tag));
+                  await ref
+                      .read(accountSettingsNotifierProvider(account).notifier)
+                      .setPostFormUseHashtags(useHashtags);
                 },
                 label: Text(t.misskey.postToHashtag),
                 icon: const Icon(Icons.edit),


### PR DESCRIPTION
Set `postFormUseHashtags` to true when the "Post to this hashtag" button is tapped.

Fix #479