### PR TITLE
fix: replace sublist with take

### DIFF
--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -49,7 +49,7 @@ class TimelinesPage extends HookConsumerWidget {
         (settings) =>
             settings.showMenuButtonInTabBar ||
             !settings.timelinesPageButtonTypes
-                .sublist(0, 5)
+                .take(5)
                 .contains(TimelinesPageButtonType.menu),
       ),
     );


### PR DESCRIPTION
Fixed an issue where the timelines page crashes when there are less than 5 buttons at the bottom.