### PR TITLE
fix: show host in instance ticker as a fallback

### DIFF
--- a/lib/view/widget/instance_ticker_widget.dart
+++ b/lib/view/widget/instance_ticker_widget.dart
@@ -78,7 +78,9 @@ class InstanceTickerWidget extends ConsumerWidget {
                   child: Padding(
                     padding: const EdgeInsets.all(1.0),
                     child: Text(
-                      (instance != null ? instance?.name : meta?.name) ?? '',
+                      instance != null
+                          ? instance?.name ?? host ?? ''
+                          : meta?.name ?? account.host,
                       style: style.copyWith(
                         color: Colors.white,
                         height: 1.0,


### PR DESCRIPTION
When a remote note does not contain the server's name, display its host instead in the instance ticker.