### PR TITLE
fix: add icon to account preview in emoji picker page

### DIFF
--- a/lib/view/page/settings/emoji_picker_page.dart
+++ b/lib/view/page/settings/emoji_picker_page.dart
@@ -52,6 +52,7 @@ class EmojiPickerPage extends HookConsumerWidget {
                 tiles: accounts.map(
                   (account) => AccountPreview(
                     account: account,
+                    trailing: const Icon(Icons.navigate_next),
                     onTap: () => context.push(
                       '/settings/accounts/$account/emoji-picker',
                     ),


### PR DESCRIPTION
Added a trailing chevron icon to `AccountPreview` in `EmojiPickerPage` to indicate that the tile is tappable.