### PR TITLE
feat: enable embed for Windows

### DIFF
--- a/lib/view/widget/url_preview.dart
+++ b/lib/view/widget/url_preview.dart
@@ -166,7 +166,8 @@ class UrlPreview extends HookConsumerWidget {
         if (defaultTargetPlatform
             case TargetPlatform.android ||
                 TargetPlatform.iOS ||
-                TargetPlatform.macOS)
+                TargetPlatform.macOS ||
+                TargetPlatform.windows)
           if (playerUrl != null || tweetId != null) ...[
             if (isPlayerOpen.value) ...[
               if (summalyResult case SummalyResult(player: Player(url: _?)))
@@ -178,7 +179,7 @@ class UrlPreview extends HookConsumerWidget {
                   lang: Localizations.localeOf(context).toLanguageTag(),
                 ),
             ],
-            const SizedBox(height: 4.0),
+            const SizedBox(height: 6.0),
             OutlinedButton.icon(
               style: OutlinedButton.styleFrom(
                 foregroundColor: colors.fg,
@@ -189,6 +190,7 @@ class UrlPreview extends HookConsumerWidget {
                     const EdgeInsets.symmetric(vertical: 6.0, horizontal: 12.0),
                 minimumSize: Size.zero,
                 side: BorderSide.none,
+                visualDensity: VisualDensity.standard,
                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
               onPressed: () => isPlayerOpen.value = !isPlayerOpen.value,


### PR DESCRIPTION
Enabled embed of players and tweets for Windows since `flutter_inappwebview` has added support for the platform in [6.1.0](https://pub.dev/packages/flutter_inappwebview/changelog#610).

Currently, a tap event on a web view propagates to the widgets below on Windows. To prevent other widgets from being tapped, the web view is wrapped with an InkWell with an empty `onTap` handler.