### PR TITLE
fix: set locale before showing notification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -187,6 +187,14 @@ class Aria extends HookConsumerWidget {
                 account;
           }
 
+          final currentLocale = LocaleSettings.currentLocale;
+          if (generalSettings.locale case final locale?
+              when locale != currentLocale) {
+            await LocaleSettings.setLocale(locale);
+          } else if (AppLocaleUtils.findDeviceLocale() != currentLocale) {
+            await LocaleSettings.useDeviceLocale();
+          }
+
           final title = switch (notification.body?.type) {
             NotificationType.follow => t.misskey.notification_.youWereFollowed,
             NotificationType.mention => t.misskey.notification_.youGotMention(


### PR DESCRIPTION
Fixed an issue where push notifications are sometimes not localized on Android.