### PR TITLE
refactor: organize media proxy

### DIFF
--- a/lib/provider/emoji_url_provider.g.dart
+++ b/lib/provider/emoji_url_provider.g.dart
@@ -6,7 +6,7 @@ part of 'emoji_url_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$emojiUrlHash() => r'e4f2a5d346910b25bf84f9b62024c3b068b91880';
+String _$emojiUrlHash() => r'4c429ddc2a72872df8e63f08d245cf6cdd78bf54';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/proxied_image_url_provider.dart
+++ b/lib/provider/proxied_image_url_provider.dart
@@ -1,0 +1,72 @@
+import 'package:collection/collection.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'api/meta_notifier_provider.dart';
+
+part 'proxied_image_url_provider.g.dart';
+
+@riverpod
+Uri? proxiedImageUrl(
+  Ref ref,
+  String host,
+  String baseUrl, {
+  bool emoji = false,
+  bool preview = false,
+  bool static = false,
+}) {
+  if (host.isEmpty) {
+    return Uri.tryParse(baseUrl);
+  }
+  final url = Uri.tryParse(baseUrl);
+  if (url == null) {
+    return null;
+  }
+
+  Uri imageUrl =
+      url.isAbsolute ? url : url.replace(scheme: 'https', host: host);
+  final mediaProxy =
+      ref.watch(metaNotifierProvider(host)).valueOrNull?.mediaProxy;
+  final mediaProxyUrl =
+      (mediaProxy != null ? Uri.tryParse(mediaProxy) : null) ??
+          Uri.https(host, 'proxy');
+  if (imageUrl.host == mediaProxyUrl.host) {
+    if (mediaProxyUrl.pathSegments.length <= imageUrl.pathSegments.length &&
+        const ListEquality<String>().equals(
+          imageUrl.pathSegments.sublist(0, mediaProxyUrl.pathSegments.length),
+          mediaProxyUrl.pathSegments,
+        )) {
+      if (imageUrl.queryParameters['url'] case final url?) {
+        if (Uri.tryParse(url) case final url?) {
+          imageUrl = url;
+        }
+      }
+    }
+  } else if (imageUrl.host == host) {
+    if (imageUrl.pathSegments.firstOrNull == 'proxy') {
+      if (imageUrl.queryParameters['url'] case final url?) {
+        if (Uri.tryParse(url) case final url?) {
+          imageUrl = url;
+        }
+      }
+    }
+  }
+
+  return mediaProxyUrl.replace(
+    pathSegments: [
+      ...mediaProxyUrl.pathSegments,
+      if (preview)
+        'preview.webp'
+      else if (static)
+        'static.webp'
+      else
+        'image.webp',
+    ],
+    queryParameters: {
+      'url': imageUrl.toString(),
+      if (emoji) 'emoji': '1',
+      if (preview) 'preview': '1',
+      if (static) 'static': '1',
+    },
+  );
+}

--- a/lib/provider/proxied_image_url_provider.g.dart
+++ b/lib/provider/proxied_image_url_provider.g.dart
@@ -1,0 +1,225 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'proxied_image_url_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$proxiedImageUrlHash() => r'd2662e4631925c1a828c126d9efe36463b5a7751';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [proxiedImageUrl].
+@ProviderFor(proxiedImageUrl)
+const proxiedImageUrlProvider = ProxiedImageUrlFamily();
+
+/// See also [proxiedImageUrl].
+class ProxiedImageUrlFamily extends Family<Uri?> {
+  /// See also [proxiedImageUrl].
+  const ProxiedImageUrlFamily();
+
+  /// See also [proxiedImageUrl].
+  ProxiedImageUrlProvider call(
+    String host,
+    String baseUrl, {
+    bool emoji = false,
+    bool preview = false,
+    bool static = false,
+  }) {
+    return ProxiedImageUrlProvider(
+      host,
+      baseUrl,
+      emoji: emoji,
+      preview: preview,
+      static: static,
+    );
+  }
+
+  @override
+  ProxiedImageUrlProvider getProviderOverride(
+    covariant ProxiedImageUrlProvider provider,
+  ) {
+    return call(
+      provider.host,
+      provider.baseUrl,
+      emoji: provider.emoji,
+      preview: provider.preview,
+      static: provider.static,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'proxiedImageUrlProvider';
+}
+
+/// See also [proxiedImageUrl].
+class ProxiedImageUrlProvider extends AutoDisposeProvider<Uri?> {
+  /// See also [proxiedImageUrl].
+  ProxiedImageUrlProvider(
+    String host,
+    String baseUrl, {
+    bool emoji = false,
+    bool preview = false,
+    bool static = false,
+  }) : this._internal(
+          (ref) => proxiedImageUrl(
+            ref as ProxiedImageUrlRef,
+            host,
+            baseUrl,
+            emoji: emoji,
+            preview: preview,
+            static: static,
+          ),
+          from: proxiedImageUrlProvider,
+          name: r'proxiedImageUrlProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$proxiedImageUrlHash,
+          dependencies: ProxiedImageUrlFamily._dependencies,
+          allTransitiveDependencies:
+              ProxiedImageUrlFamily._allTransitiveDependencies,
+          host: host,
+          baseUrl: baseUrl,
+          emoji: emoji,
+          preview: preview,
+          static: static,
+        );
+
+  ProxiedImageUrlProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.host,
+    required this.baseUrl,
+    required this.emoji,
+    required this.preview,
+    required this.static,
+  }) : super.internal();
+
+  final String host;
+  final String baseUrl;
+  final bool emoji;
+  final bool preview;
+  final bool static;
+
+  @override
+  Override overrideWith(
+    Uri? Function(ProxiedImageUrlRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: ProxiedImageUrlProvider._internal(
+        (ref) => create(ref as ProxiedImageUrlRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        host: host,
+        baseUrl: baseUrl,
+        emoji: emoji,
+        preview: preview,
+        static: static,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeProviderElement<Uri?> createElement() {
+    return _ProxiedImageUrlProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ProxiedImageUrlProvider &&
+        other.host == host &&
+        other.baseUrl == baseUrl &&
+        other.emoji == emoji &&
+        other.preview == preview &&
+        other.static == static;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, host.hashCode);
+    hash = _SystemHash.combine(hash, baseUrl.hashCode);
+    hash = _SystemHash.combine(hash, emoji.hashCode);
+    hash = _SystemHash.combine(hash, preview.hashCode);
+    hash = _SystemHash.combine(hash, static.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin ProxiedImageUrlRef on AutoDisposeProviderRef<Uri?> {
+  /// The parameter `host` of this provider.
+  String get host;
+
+  /// The parameter `baseUrl` of this provider.
+  String get baseUrl;
+
+  /// The parameter `emoji` of this provider.
+  bool get emoji;
+
+  /// The parameter `preview` of this provider.
+  bool get preview;
+
+  /// The parameter `static` of this provider.
+  bool get static;
+}
+
+class _ProxiedImageUrlProviderElement extends AutoDisposeProviderElement<Uri?>
+    with ProxiedImageUrlRef {
+  _ProxiedImageUrlProviderElement(super.provider);
+
+  @override
+  String get host => (origin as ProxiedImageUrlProvider).host;
+  @override
+  String get baseUrl => (origin as ProxiedImageUrlProvider).baseUrl;
+  @override
+  bool get emoji => (origin as ProxiedImageUrlProvider).emoji;
+  @override
+  bool get preview => (origin as ProxiedImageUrlProvider).preview;
+  @override
+  bool get static => (origin as ProxiedImageUrlProvider).static;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/provider/static_image_url_provider.dart
+++ b/lib/provider/static_image_url_provider.dart
@@ -1,7 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import 'api/meta_notifier_provider.dart';
+import 'proxied_image_url_provider.dart';
 
 part 'static_image_url_provider.g.dart';
 
@@ -18,27 +18,12 @@ Uri? staticImageUrl(Ref ref, String host, String baseUrl) {
   if (url == null) {
     return null;
   }
+
   final urlString = url.toString();
   if (urlString.startsWith('https://$host/emoji/')) {
     return url
         .replace(queryParameters: {...url.queryParameters, 'static': '1'});
   }
-  final mediaProxy =
-      ref.watch(metaNotifierProvider(host)).valueOrNull?.mediaProxy ??
-          'https://$host/proxy';
-  if (urlString.startsWith('$mediaProxy/')) {
-    return url
-        .replace(queryParameters: {...url.queryParameters, 'static': '1'});
-  }
-  final mediaProxyUrl = Uri.tryParse(mediaProxy);
-  if (mediaProxyUrl == null) {
-    return null;
-  }
-  return mediaProxyUrl.replace(
-    pathSegments: [...mediaProxyUrl.pathSegments, 'static.webp'],
-    queryParameters: {
-      'url': urlString,
-      'static': '1',
-    },
-  );
+
+  return ref.watch(proxiedImageUrlProvider(host, urlString, static: true));
 }

--- a/lib/provider/static_image_url_provider.g.dart
+++ b/lib/provider/static_image_url_provider.g.dart
@@ -6,7 +6,7 @@ part of 'static_image_url_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$staticImageUrlHash() => r'ae34acc65548bf2164cc0c7c958682f7a251522d';
+String _$staticImageUrlHash() => r'f3e1d77a57b6762ef35f0b67edda9934ed942db1';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/widget/instance_ticker_widget.dart
+++ b/lib/view/widget/instance_ticker_widget.dart
@@ -6,6 +6,7 @@ import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../model/account.dart';
 import '../../provider/api/meta_notifier_provider.dart';
+import '../../provider/proxied_image_url_provider.dart';
 import '../../util/safe_parse_color.dart';
 import 'image_widget.dart';
 
@@ -29,15 +30,14 @@ class InstanceTickerWidget extends ConsumerWidget {
         ) ??
         const Color(0xff777777);
     final faviconUrl = instance?.faviconUrl;
-    final mediaProxy = meta?.mediaProxy;
-    final mediaProxyUrl =
-        (mediaProxy != null ? Uri.tryParse(mediaProxy) : null) ??
-            Uri.https(account.host, 'proxy');
     final proxiedUrl =
         instance != null && faviconUrl != null && account.host.isNotEmpty
-            ? mediaProxyUrl.replace(
-                pathSegments: [...mediaProxyUrl.pathSegments, 'preview.webp'],
-                queryParameters: {'url': faviconUrl.toString()},
+            ? ref.watch(
+                proxiedImageUrlProvider(
+                  account.host,
+                  faviconUrl.toString(),
+                  preview: true,
+                ),
               )
             : faviconUrl;
     final style = DefaultTextStyle.of(context).style;


### PR DESCRIPTION
Added `proxiedImageUrlProvider` to remove duplicate process for getting proxied images.