### PR TITLE
ci: replace deprecated option of reviewdog/action-suggester

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@v1
         with:
-          fail_on_error: true
+          fail_level: error
 
       - name: Check diff
         if: github.event_name != 'pull_request'
@@ -173,7 +173,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@v1
         with:
-          fail_on_error: true
+          fail_level: error
 
       - name: Check diff
         if: github.event_name != 'pull_request'
@@ -201,7 +201,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@v1
         with:
-          fail_on_error: true
+          fail_level: error
 
       - name: Check diff
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Replaced `fail_error` key of `reviewdog/action-suggester` action with `fail_level`.