### PR TITLE
fix: remove height of sheet headers

### DIFF
--- a/lib/view/widget/drive_folder_sheet.dart
+++ b/lib/view/widget/drive_folder_sheet.dart
@@ -100,7 +100,7 @@ class DriveFolderSheet extends ConsumerWidget {
           title: Text(folder.name),
           subtitle: TimeWidget(time: folder.createdAt),
         ),
-        const Divider(),
+        const Divider(height: 0.0),
         ListTile(
           leading: const Icon(Icons.settings),
           title: Text(t.misskey.renameFolder),

--- a/lib/view/widget/url_sheet.dart
+++ b/lib/view/widget/url_sheet.dart
@@ -16,7 +16,7 @@ class UrlSheet extends StatelessWidget {
       shrinkWrap: true,
       children: [
         ListTile(title: Text(url)),
-        const Divider(),
+        const Divider(height: 0.0),
         ListTile(
           leading: const Icon(Icons.open_in_browser),
           title: Text(t.aria.openInInternalBrowser),


### PR DESCRIPTION
Changed the height of dividers between the header and the content of sheets to zero.