### PR TITLE
fix: use LineSplitter to split lines

### DIFF
--- a/lib/view/page/settings/mute_block_page.dart
+++ b/lib/view/page/settings/mute_block_page.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -163,9 +165,7 @@ class _MutedEmojisEditor extends HookConsumerWidget {
             child: ElevatedButton.icon(
               onPressed: isChanged.value
                   ? () async {
-                      final mutes = controller.text
-                          .trim()
-                          .split('\n')
+                      final mutes = LineSplitter.split(controller.text.trim())
                           .map((emoji) => emoji.trim())
                           .where((emoji) => emoji.isNotEmpty);
                       await ref
@@ -259,9 +259,7 @@ class _InstanceMuteEditor extends HookConsumerWidget {
           child: ElevatedButton.icon(
             onPressed: isChanged.value
                 ? () async {
-                    final mutes = controller.text
-                        .trim()
-                        .split('\n')
+                    final mutes = LineSplitter.split(controller.text.trim())
                         .map((server) => server.trim())
                         .where((server) => server.isNotEmpty)
                         .toList();

--- a/lib/view/widget/muted_words_editor.dart
+++ b/lib/view/widget/muted_words_editor.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -22,9 +24,7 @@ class MutedWordsEditor extends HookConsumerWidget {
   final bool hardMute;
 
   List<MuteWord> _parseMutes(BuildContext context, String mutes) {
-    return mutes
-        .trim()
-        .split('\n')
+    return LineSplitter.split(mutes.trim())
         .map((line) => line.trim())
         .mapIndexed((index, line) {
           if (line.isEmpty) {


### PR DESCRIPTION
Changed to use [`LineSplitter`](https://api.dart.dev/dart-convert/LineSplitter-class.html) instead of `text.split('\n')`.