### PR TITLE
fix: use original url if already proxied

### DIFF
--- a/lib/provider/proxied_image_url_provider.dart
+++ b/lib/provider/proxied_image_url_provider.dart
@@ -36,11 +36,14 @@ Uri? proxiedImageUrl(
           imageUrl.pathSegments.sublist(0, mediaProxyUrl.pathSegments.length),
           mediaProxyUrl.pathSegments,
         )) {
-      if (imageUrl.queryParameters['url'] case final url?) {
-        if (Uri.tryParse(url) case final url?) {
-          imageUrl = url;
-        }
-      }
+      return imageUrl.replace(
+        queryParameters: {
+          ...imageUrl.queryParameters,
+          if (emoji) 'emoji': '1',
+          if (preview) 'preview': '1',
+          if (static) 'static': '1',
+        },
+      );
     }
   } else if (imageUrl.host == host) {
     if (imageUrl.pathSegments.firstOrNull == 'proxy') {
@@ -53,15 +56,7 @@ Uri? proxiedImageUrl(
   }
 
   return mediaProxyUrl.replace(
-    pathSegments: [
-      ...mediaProxyUrl.pathSegments,
-      if (preview)
-        'preview.webp'
-      else if (static)
-        'static.webp'
-      else
-        'image.webp',
-    ],
+    pathSegments: [...mediaProxyUrl.pathSegments, 'image.webp'],
     queryParameters: {
       'url': imageUrl.toString(),
       if (emoji) 'emoji': '1',

--- a/lib/provider/proxied_image_url_provider.g.dart
+++ b/lib/provider/proxied_image_url_provider.g.dart
@@ -6,7 +6,7 @@ part of 'proxied_image_url_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$proxiedImageUrlHash() => r'd2662e4631925c1a828c126d9efe36463b5a7751';
+String _$proxiedImageUrlHash() => r'273f773eeb4b38bbb2c5d61d1460de6f8c872cda';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Changed to add query parameters to the original url if it is from a media proxy.