### PR TITLE
fix: clear children of cache directory

### DIFF
--- a/lib/view/page/settings/behavior_page.dart
+++ b/lib/view/page/settings/behavior_page.dart
@@ -251,8 +251,11 @@ class BehaviorPage extends ConsumerWidget {
             onTap: () async {
               await futureWithDialog(
                 context,
-                getApplicationCacheDirectory()
-                    .then((cacheDir) => cacheDir.delete(recursive: true)),
+                getApplicationCacheDirectory().then(
+                  (cacheDir) => Future.wait(
+                    cacheDir.listSync().map((e) => e.delete(recursive: true)),
+                  ),
+                ),
               );
               ref.invalidate(cacheSizeProvider);
             },


### PR DESCRIPTION
Changed to delete the children of the cache directory instead of the directory itself.