### PR TITLE
ci: install Flutter for format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,17 @@ jobs:
   format:
     runs-on: ubuntu-latest
 
+    needs: get-flutter-version
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Dart
-        uses: dart-lang/setup-dart@v1
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: ${{ needs.get-flutter-version.outputs.flutter-version }}
+          cache: true
 
       - name: Format
         run: >


### PR DESCRIPTION
Instead of installing the default version of Dart, install Flutter with the version specified in `.fvmrc` when checking the format. 

This will avoid inconsistent formatting caused by different Dart versions introduced by FVM and the latest stable channel.