### PR TITLE
feat: add unclip button to note sheet

### DIFF
--- a/lib/provider/api/clip_notes_notifier_provider.dart
+++ b/lib/provider/api/clip_notes_notifier_provider.dart
@@ -42,4 +42,17 @@ class ClipNotesNotifier extends _$ClipNotesNotifier {
       );
     });
   }
+
+  Future<void> removeNote(String noteId) async {
+    await ref
+        .read(misskeyProvider(account))
+        .clips
+        .removeNote(ClipsRemoveNoteRequest(clipId: clipId, noteId: noteId));
+    final value = state.valueOrNull ?? const PaginationState();
+    state = AsyncValue.data(
+      value.copyWith(
+        items: value.items.where((note) => note.id != noteId).toList(),
+      ),
+    );
+  }
 }

--- a/lib/provider/api/clip_notes_notifier_provider.g.dart
+++ b/lib/provider/api/clip_notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'clip_notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$clipNotesNotifierHash() => r'4eb8a45927e8c37b9cd0ee7d799674e105e05ec6';
+String _$clipNotesNotifierHash() => r'93439d458ba64b92f8440ef6c43d885bdd0c81e9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/clips_notifier_provider.dart
+++ b/lib/provider/api/clips_notifier_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -54,6 +56,38 @@ class ClipsNotifier extends _$ClipsNotifier {
     await _misskey.clips.delete(ClipsDeleteRequest(clipId: clipId));
     state = AsyncValue.data([
       ...?state.valueOrNull?.where((clip) => clip.id != clipId),
+    ]);
+  }
+
+  Future<void> addNote(String clipId, String noteId) async {
+    await _misskey.clips.addNote(
+      ClipsAddNoteRequest(clipId: clipId, noteId: noteId),
+    );
+    state = AsyncValue.data([
+      ...?state.valueOrNull?.map(
+        (clip) =>
+            clip.id == clipId
+                ? clip.copyWith(notesCount: (clip.notesCount ?? 0) + 1)
+                : clip,
+      ),
+    ]);
+  }
+
+  Future<void> removeNote(String clipId, String noteId) async {
+    await _misskey.clips.removeNote(
+      ClipsRemoveNoteRequest(clipId: clipId, noteId: noteId),
+    );
+    decrementNotesCount(clipId);
+  }
+
+  void decrementNotesCount(String clipId) {
+    state = AsyncValue.data([
+      ...?state.valueOrNull?.map(
+        (clip) =>
+            clip.id == clipId
+                ? clip.copyWith(notesCount: max(0, (clip.notesCount ?? 1) - 1))
+                : clip,
+      ),
     ]);
   }
 

--- a/lib/provider/api/clips_notifier_provider.g.dart
+++ b/lib/provider/api/clips_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'clips_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$clipsNotifierHash() => r'282be693c3aefc41158e640d01b805f23322d97b';
+String _$clipsNotifierHash() => r'2119d09fe9b04a727993fe2866a6d08595f9b61e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/note_clips_notifier_provider.dart
+++ b/lib/provider/api/note_clips_notifier_provider.dart
@@ -18,17 +18,11 @@ class NoteClipsNotifier extends _$NoteClipsNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Future<void> addClip(Clip clip) async {
-    await _misskey.clips.addNote(
-      ClipsAddNoteRequest(clipId: clip.id, noteId: noteId),
-    );
+  void addClip(Clip clip) {
     state = AsyncValue.data([...?state.valueOrNull, clip]);
   }
 
-  Future<void> removeClip(String clipId) async {
-    await _misskey.clips.removeNote(
-      ClipsRemoveNoteRequest(clipId: clipId, noteId: noteId),
-    );
+  void removeClip(String clipId) {
     state = AsyncValue.data([
       ...?state.valueOrNull?.where((clip) => clip.id != clipId),
     ]);

--- a/lib/provider/api/note_clips_notifier_provider.g.dart
+++ b/lib/provider/api/note_clips_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'note_clips_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$noteClipsNotifierHash() => r'249c0fb33eadcd7aee3353afd9b07507596bf6f2';
+String _$noteClipsNotifierHash() => r'e20fe4047af9dcad769653bd266d381feda9c935';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/util/get_note_action.dart
+++ b/lib/util/get_note_action.dart
@@ -17,6 +17,8 @@ void Function()? getNoteAction(
   required NoteActionType type,
   required Note note,
   required Note appearNote,
+  String? clipId,
+  bool disableHeader = false,
 }) {
   if (note.id.isEmpty) {
     return null;
@@ -30,6 +32,8 @@ void Function()? getNoteAction(
         context: ref.context,
         account: account,
         noteId: note.id,
+        clipId: clipId,
+        disableHeader: disableHeader,
       ),
     NoteActionType.reaction =>
       !account.isGuest

--- a/lib/view/page/clip_page.dart
+++ b/lib/view/page/clip_page.dart
@@ -160,6 +160,7 @@ class ClipPage extends HookConsumerWidget {
             (context, note) => NoteWidget(
               account: account,
               noteId: note.id,
+              clipId: clipId,
               withHardMute: false,
             ),
         onRefresh:

--- a/lib/view/widget/note_detailed_widget.dart
+++ b/lib/view/widget/note_detailed_widget.dart
@@ -119,6 +119,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                 type: tapAction,
                 note: note,
                 appearNote: appearNote,
+                disableHeader: true,
               )
               : null,
       onDoubleTap:
@@ -129,6 +130,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                 type: doubleTapAction,
                 note: note,
                 appearNote: appearNote,
+                disableHeader: true,
               )
               : null,
       onLongPress:
@@ -139,6 +141,7 @@ class NoteDetailedWidget extends HookConsumerWidget {
                 type: longPressAction,
                 note: note,
                 appearNote: appearNote,
+                disableHeader: true,
               )
               : null,
       child: Padding(

--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -38,6 +38,7 @@ class NoteFooter extends HookConsumerWidget {
     super.key,
     required this.account,
     required this.noteId,
+    this.clipId,
     this.disableHeader = false,
     this.focusPostForm,
     this.note,
@@ -45,6 +46,7 @@ class NoteFooter extends HookConsumerWidget {
 
   final Account account;
   final String noteId;
+  final String? clipId;
   final bool disableHeader;
   final void Function()? focusPostForm;
   final Note? note;
@@ -167,12 +169,17 @@ class NoteFooter extends HookConsumerWidget {
                       style: style,
                     ),
                   if (showClipButton)
-                    _ClipButton(account: account, note: appearNote),
+                    _ClipButton(
+                      account: account,
+                      note: appearNote,
+                      clipId: clipId,
+                    ),
                   if (showTranslateButton)
                     _TranslateButton(account: account, note: appearNote),
                   _MenuButton(
                     account: account,
                     note: note,
+                    clipId: clipId,
                     disableHeader: disableHeader,
                     focusPostForm: focusPostForm,
                   ),
@@ -652,10 +659,11 @@ class _RemoveReactionButton extends ConsumerWidget {
 }
 
 class _ClipButton extends ConsumerWidget {
-  const _ClipButton({required this.account, required this.note});
+  const _ClipButton({required this.account, required this.note, this.clipId});
 
   final Account account;
   final Note note;
+  final String? clipId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -668,8 +676,11 @@ class _ClipButton extends ConsumerWidget {
                 showDialog<void>(
                   context: context,
                   builder:
-                      (context) =>
-                          ClipDialog(account: account, noteId: note.id),
+                      (context) => ClipDialog(
+                        account: account,
+                        noteId: note.id,
+                        clipId: clipId,
+                      ),
                 );
               }
               : null,
@@ -722,10 +733,12 @@ class _MenuButton extends ConsumerWidget {
     required this.note,
     this.disableHeader = false,
     this.focusPostForm,
+    this.clipId,
   });
 
   final Account account;
   final Note note;
+  final String? clipId;
   final bool disableHeader;
   final void Function()? focusPostForm;
 
@@ -739,8 +752,8 @@ class _MenuButton extends ConsumerWidget {
           context: context,
           account: account,
           noteId: note.id,
+          clipId: clipId,
           disableHeader: disableHeader,
-          focusPostForm: focusPostForm,
         );
       },
       icon: const Icon(Icons.more_horiz),

--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -42,6 +42,7 @@ class NoteWidget extends HookConsumerWidget {
     super.key,
     required this.account,
     required this.noteId,
+    this.clipId,
     this.withHardMute = true,
     this.focusPostForm,
     this.note,
@@ -53,6 +54,7 @@ class NoteWidget extends HookConsumerWidget {
 
   final Account account;
   final String noteId;
+  final String? clipId;
   final bool withHardMute;
   final void Function()? focusPostForm;
   final Note? note;
@@ -171,8 +173,9 @@ class NoteWidget extends HookConsumerWidget {
               type: tapAction,
               note: note,
               appearNote: appearNote,
+              clipId: clipId,
             ),
-            [account, tapAction, note.id, appearNote.id],
+            [account, tapAction, noteId, clipId],
           ),
           onDoubleTap: useMemoized(
             () => getNoteAction(
@@ -181,8 +184,9 @@ class NoteWidget extends HookConsumerWidget {
               type: doubleTapAction,
               note: note,
               appearNote: appearNote,
+              clipId: clipId,
             ),
-            [account, doubleTapAction, note.id, appearNote.id],
+            [account, doubleTapAction, noteId, clipId],
           ),
           onLongPress: useMemoized(
             () => getNoteAction(
@@ -191,8 +195,9 @@ class NoteWidget extends HookConsumerWidget {
               type: longPressAction,
               note: note,
               appearNote: appearNote,
+              clipId: clipId,
             ),
-            [account, longPressAction, note.id, appearNote.id],
+            [account, longPressAction, noteId, clipId],
           ),
           child: Padding(
             padding: EdgeInsetsDirectional.only(
@@ -315,6 +320,7 @@ class NoteWidget extends HookConsumerWidget {
                             noteId: noteId,
                             note: note,
                             appearNote: appearNote,
+                            clipId: clipId,
                             style: style,
                             showFooter: showFooter,
                             focusPostForm: focusPostForm,
@@ -338,6 +344,7 @@ class _NoteContent extends HookConsumerWidget {
     required this.noteId,
     required this.note,
     required this.appearNote,
+    required this.clipId,
     required this.style,
     required this.showFooter,
     required this.focusPostForm,
@@ -347,6 +354,7 @@ class _NoteContent extends HookConsumerWidget {
   final String noteId;
   final Note note;
   final Note appearNote;
+  final String? clipId;
   final TextStyle style;
   final bool? showFooter;
   final void Function()? focusPostForm;
@@ -577,6 +585,7 @@ class _NoteContent extends HookConsumerWidget {
           NoteFooter(
             account: account,
             noteId: noteId,
+            clipId: clipId,
             focusPostForm: focusPostForm,
             note: note,
           ),


### PR DESCRIPTION
Changed to show the unclip button in the note sheet when the sheet was opened from the clip page.

This fixes an issue where users cannot remove a note from a clip when the clip has reached the notes limit.