### PR TITLE
feat: change layout of MediaList with 3 files

### DIFF
--- a/lib/view/widget/media_card.dart
+++ b/lib/view/widget/media_card.dart
@@ -34,7 +34,7 @@ class MediaCard extends HookConsumerWidget {
     super.key,
     required this.account,
     required this.files,
-    this.index = 0,
+    required this.index,
     this.user,
     this.fit = BoxFit.contain,
   });
@@ -47,7 +47,10 @@ class MediaCard extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final file = files[index];
+    final file = files.elementAtOrNull(index);
+    if (file == null) {
+      return const SizedBox.shrink();
+    }
     final (highlightSensitiveMedia, sensitive, openMediaOnDoubleTap) = ref
         .watch(
           generalSettingsNotifierProvider.select(

--- a/lib/view/widget/media_list.dart
+++ b/lib/view/widget/media_list.dart
@@ -59,9 +59,82 @@ class MediaList extends ConsumerWidget {
             child: MediaCard(
               account: account,
               files: files,
+              index: 0,
               user: user,
               fit: fit,
             ),
+          ),
+        );
+      case 2:
+        return AspectRatio(
+          aspectRatio: 16 / 9,
+          child: Row(
+            children: [
+              Expanded(
+                child: MediaCard(
+                  account: account,
+                  files: files,
+                  index: 0,
+                  user: user,
+                  fit: fit,
+                ),
+              ),
+              const SizedBox(width: 4.0),
+              Expanded(
+                child: MediaCard(
+                  account: account,
+                  files: files,
+                  index: 1,
+                  user: user,
+                  fit: fit,
+                ),
+              ),
+            ],
+          ),
+        );
+      case 3:
+        return AspectRatio(
+          aspectRatio: 16 / 9,
+          child: Row(
+            children: [
+              Expanded(
+                flex: 3,
+                child: MediaCard(
+                  account: account,
+                  files: files,
+                  index: 0,
+                  user: user,
+                  fit: fit,
+                ),
+              ),
+              const SizedBox(width: 4.0),
+              Expanded(
+                flex: 2,
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: MediaCard(
+                        account: account,
+                        files: files,
+                        index: 1,
+                        user: user,
+                        fit: fit,
+                      ),
+                    ),
+                    const SizedBox(height: 4.0),
+                    Expanded(
+                      child: MediaCard(
+                        account: account,
+                        files: files,
+                        index: 2,
+                        user: user,
+                        fit: fit,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
         );
       default:


### PR DESCRIPTION
Changed the layout of images in notes.

This prevents having empty space at the bottom right when 3 files are attached to a note.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/20cdb4dc-8e20-44fc-88b1-f833361e8efd) | ![image](https://github.com/user-attachments/assets/f0319885-ceff-48a2-a1d6-40a97ffc991d) |
