### PR TITLE
fix: remove Material around PopupMenuButton

### DIFF
--- a/lib/view/dialog/image_dialog.dart
+++ b/lib/view/dialog/image_dialog.dart
@@ -90,31 +90,32 @@ class ImageDialog extends HookConsumerWidget {
           duration: const Duration(milliseconds: 100),
           curve: Curves.easeInOut,
           child: SafeArea(
-            child: Stack(
-              children: [
-                Align(
-                  alignment: AlignmentDirectional.topStart,
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: IconButton(
-                      tooltip:
-                          MaterialLocalizations.of(context).closeButtonTooltip,
-                      style: IconButton.styleFrom(
-                        backgroundColor: Colors.white54,
-                      ),
-                      onPressed: () => context.pop(),
-                      icon: const Icon(Icons.close),
-                    ),
-                  ),
-                ),
-                if (url case final url?)
+            child: IconButtonTheme(
+              data: IconButtonThemeData(
+                style: IconButton.styleFrom(backgroundColor: Colors.white54),
+              ),
+              child: Stack(
+                children: [
                   Align(
-                    alignment: AlignmentDirectional.topEnd,
+                    alignment: AlignmentDirectional.topStart,
                     child: Padding(
                       padding: const EdgeInsets.all(16.0),
-                      child: Material(
-                        color: Colors.white54,
-                        shape: const OvalBorder(),
+                      child: IconButton(
+                        tooltip:
+                            MaterialLocalizations.of(
+                              context,
+                            ).closeButtonTooltip,
+
+                        onPressed: () => context.pop(),
+                        icon: const Icon(Icons.close),
+                      ),
+                    ),
+                  ),
+                  if (url case final url?)
+                    Align(
+                      alignment: AlignmentDirectional.topEnd,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
                         child: PopupMenuButton<void>(
                           itemBuilder:
                               (context) => [
@@ -156,8 +157,8 @@ class ImageDialog extends HookConsumerWidget {
                         ),
                       ),
                     ),
-                  ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/view/dialog/image_gallery_dialog.dart
+++ b/lib/view/dialog/image_gallery_dialog.dart
@@ -183,30 +183,31 @@ class ImageGalleryDialog extends HookConsumerWidget {
           duration: const Duration(milliseconds: 100),
           curve: Curves.easeInOut,
           child: SafeArea(
-            child: Stack(
-              children: [
-                Align(
-                  alignment: AlignmentDirectional.topStart,
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: IconButton(
-                      tooltip:
-                          MaterialLocalizations.of(context).closeButtonTooltip,
-                      style: IconButton.styleFrom(
-                        backgroundColor: Colors.white54,
+            child: IconButtonTheme(
+              data: IconButtonThemeData(
+                style: IconButton.styleFrom(backgroundColor: Colors.white54),
+              ),
+              child: Stack(
+                children: [
+                  Align(
+                    alignment: AlignmentDirectional.topStart,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: IconButton(
+                        tooltip:
+                            MaterialLocalizations.of(
+                              context,
+                            ).closeButtonTooltip,
+
+                        onPressed: () => context.pop(),
+                        icon: const Icon(Icons.close),
                       ),
-                      onPressed: () => context.pop(),
-                      icon: const Icon(Icons.close),
                     ),
                   ),
-                ),
-                Align(
-                  alignment: AlignmentDirectional.topEnd,
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Material(
-                      color: Colors.white54,
-                      shape: const OvalBorder(),
+                  Align(
+                    alignment: AlignmentDirectional.topEnd,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
                       child: PopupMenuButton<void>(
                         itemBuilder:
                             (context) => [
@@ -254,80 +255,79 @@ class ImageGalleryDialog extends HookConsumerWidget {
                       ),
                     ),
                   ),
-                ),
-                if (index.value > 0)
-                  Align(
-                    alignment: AlignmentDirectional.centerStart,
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: IconButton(
-                        style: IconButton.styleFrom(
-                          backgroundColor: Colors.white54,
+                  if (index.value > 0)
+                    Align(
+                      alignment: AlignmentDirectional.centerStart,
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: IconButton(
+                          onPressed:
+                              () => controller.previousPage(
+                                duration: const Duration(milliseconds: 300),
+                                curve: Curves.easeIn,
+                              ),
+                          icon: const Icon(Icons.navigate_before),
                         ),
-                        onPressed:
-                            () => controller.previousPage(
-                              duration: const Duration(milliseconds: 300),
-                              curve: Curves.easeIn,
-                            ),
-                        icon: const Icon(Icons.navigate_before),
                       ),
                     ),
-                  ),
-                if (index.value < files.length - 1)
-                  Align(
-                    alignment: AlignmentDirectional.centerEnd,
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: IconButton(
-                        style: IconButton.styleFrom(
-                          backgroundColor: Colors.white54,
-                        ),
-                        onPressed:
-                            () => controller.nextPage(
-                              duration: const Duration(milliseconds: 300),
-                              curve: Curves.easeIn,
-                            ),
-                        icon: const Icon(Icons.navigate_next),
-                      ),
-                    ),
-                  ),
-                Align(
-                  alignment: Alignment.bottomCenter,
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: GestureDetector(
-                      onLongPress:
-                          () => copyToClipboard(
-                            context,
-                            comment != null && comment.isNotEmpty
-                                ? comment
-                                : files[index.value].name,
+                  if (index.value < files.length - 1)
+                    Align(
+                      alignment: AlignmentDirectional.centerEnd,
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: IconButton(
+                          style: IconButton.styleFrom(
+                            backgroundColor: Colors.white54,
                           ),
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          color: Colors.white38,
-                          borderRadius: BorderRadius.circular(8.0),
+                          onPressed:
+                              () => controller.nextPage(
+                                duration: const Duration(milliseconds: 300),
+                                curve: Curves.easeIn,
+                              ),
+                          icon: const Icon(Icons.navigate_next),
                         ),
-                        child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxHeight: 100.0),
-                            child: SingleChildScrollView(
-                              child: Text(
-                                comment != null && comment.isNotEmpty
-                                    ? comment
-                                    : files[index.value].name,
-                                style: TextStyle(
-                                  shadows: [
-                                    Shadow(
-                                      blurRadius: 2.0,
-                                      color: Theme.of(context).canvasColor,
-                                    ),
-                                    Shadow(
-                                      blurRadius: 2.0,
-                                      color: Theme.of(context).canvasColor,
-                                    ),
-                                  ],
+                      ),
+                    ),
+                  Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: GestureDetector(
+                        onLongPress:
+                            () => copyToClipboard(
+                              context,
+                              comment != null && comment.isNotEmpty
+                                  ? comment
+                                  : files[index.value].name,
+                            ),
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: Colors.white38,
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                maxHeight: 100.0,
+                              ),
+                              child: SingleChildScrollView(
+                                child: Text(
+                                  comment != null && comment.isNotEmpty
+                                      ? comment
+                                      : files[index.value].name,
+                                  style: TextStyle(
+                                    shadows: [
+                                      Shadow(
+                                        blurRadius: 2.0,
+                                        color: Theme.of(context).canvasColor,
+                                      ),
+                                      Shadow(
+                                        blurRadius: 2.0,
+                                        color: Theme.of(context).canvasColor,
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ),
@@ -336,8 +336,8 @@ class ImageGalleryDialog extends HookConsumerWidget {
                       ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/view/dialog/video_dialog.dart
+++ b/lib/view/dialog/video_dialog.dart
@@ -22,34 +22,34 @@ class VideoDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Stack(
-      children: [
-        Dismissible(
-          key: const ValueKey(0),
-          onDismissed: (_) => context.pop(),
-          direction: DismissDirection.vertical,
-          child: Center(child: _VideoWidget(url: url, file: file)),
-        ),
-        Align(
-          alignment: AlignmentDirectional.topStart,
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: IconButton(
-              tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
-              style: IconButton.styleFrom(backgroundColor: Colors.white54),
-              onPressed: () => context.pop(),
-              icon: const Icon(Icons.close),
-            ),
+    return IconButtonTheme(
+      data: IconButtonThemeData(
+        style: IconButton.styleFrom(backgroundColor: Colors.white54),
+      ),
+      child: Stack(
+        children: [
+          Dismissible(
+            key: const ValueKey(0),
+            onDismissed: (_) => context.pop(),
+            direction: DismissDirection.vertical,
+            child: Center(child: _VideoWidget(url: url, file: file)),
           ),
-        ),
-        if (url case final url?)
           Align(
-            alignment: AlignmentDirectional.topEnd,
+            alignment: AlignmentDirectional.topStart,
             child: Padding(
               padding: const EdgeInsets.all(16.0),
-              child: Material(
-                color: Colors.white54,
-                shape: const OvalBorder(),
+              child: IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                onPressed: () => context.pop(),
+                icon: const Icon(Icons.close),
+              ),
+            ),
+          ),
+          if (url case final url?)
+            Align(
+              alignment: AlignmentDirectional.topEnd,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
                 child: PopupMenuButton<void>(
                   itemBuilder:
                       (context) => [
@@ -91,8 +91,8 @@ class VideoDialog extends ConsumerWidget {
                 ),
               ),
             ),
-          ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
Fixed an issue where the size of the menu button and the close button is different in `ImageDialog`, `ImageGalleryDialog`, and `VideoDialog`.