### PR TITLE
fix: remove BlurHash from loading image 

### DIFF
--- a/lib/view/dialog/image_dialog.dart
+++ b/lib/view/dialog/image_dialog.dart
@@ -105,7 +105,6 @@ class ImageDialog extends HookConsumerWidget {
                             MaterialLocalizations.of(
                               context,
                             ).closeButtonTooltip,
-
                         onPressed: () => context.pop(),
                         icon: const Icon(Icons.close),
                       ),

--- a/lib/view/dialog/image_gallery_dialog.dart
+++ b/lib/view/dialog/image_gallery_dialog.dart
@@ -139,7 +139,6 @@ class ImageGalleryDialog extends HookConsumerWidget {
                           Positioned.fill(
                             child: ImageWidget(
                               url: thumbnailUrl,
-                              blurHash: thumbnailUrl,
                               fit: BoxFit.contain,
                             ),
                           ),

--- a/lib/view/dialog/image_gallery_dialog.dart
+++ b/lib/view/dialog/image_gallery_dialog.dart
@@ -198,7 +198,6 @@ class ImageGalleryDialog extends HookConsumerWidget {
                             MaterialLocalizations.of(
                               context,
                             ).closeButtonTooltip,
-
                         onPressed: () => context.pop(),
                         icon: const Icon(Icons.close),
                       ),

--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -57,7 +57,6 @@ class TimelinesPage extends HookConsumerWidget {
                   .contains(TimelinesPageButtonType.menu),
           settings.timelinesPageButtonTypes,
           settings.showSmallTimelinesPageButtons,
-
           settings.showSquaredTimelinesPageButtons,
           settings.enableHorizontalSwipe,
         ),


### PR DESCRIPTION
Fixed an issue where `ImageGalleryDialog` flickers during loading because the thumbnail url was passed to the `blurHash` parameter of `ImageDialog` used in `loadingBuilder`.

Follow up for #518