### PR TITLE
fix: hide duplicate notes from streaming

### DIFF
--- a/lib/view/widget/notifications_list_view.dart
+++ b/lib/view/widget/notifications_list_view.dart
@@ -177,7 +177,7 @@ class NotificationsListView extends HookConsumerWidget {
                         child: Container(
                           margin: const EdgeInsets.symmetric(horizontal: 8.0),
                           width: maxContentWidth,
-                          child: const Divider(height: 0.0),
+                          child: const Divider(height: 1.0),
                         ),
                       ),
                   itemCount: nextNotifications.value.length,

--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -133,8 +133,9 @@ class TimelineListView extends HookConsumerWidget {
     final previousNotes = ref.watch(
       timelineNotesNotifierProvider(tabSettings, untilId: centerId),
     );
-    final hasPreviousNote =
-        previousNotes.valueOrNull?.items.isNotEmpty ?? false;
+    final partialPreviousNoteIds =
+        previousNotes.valueOrNull?.items.take(5).map((note) => note.id) ?? [];
+    final hasPreviousNote = partialPreviousNoteIds.isNotEmpty;
     final (showGap, showPopup, vibrateOnNote) = ref.watch(
       generalSettingsNotifierProvider.select(
         (settings) => (
@@ -401,6 +402,7 @@ class TimelineListView extends HookConsumerWidget {
                                             ? const Radius.circular(8.0)
                                             : Radius.zero,
                                   ),
+                          hide: partialPreviousNoteIds.contains(note.id),
                         ),
                       ),
                     );

--- a/lib/view/widget/timeline_note.dart
+++ b/lib/view/widget/timeline_note.dart
@@ -26,6 +26,7 @@ class TimelineNote extends HookConsumerWidget {
     this.focusPostForm,
     this.margin = EdgeInsets.zero,
     this.borderRadius,
+    this.hide = false,
   });
 
   final TabSettings tabSettings;
@@ -33,6 +34,7 @@ class TimelineNote extends HookConsumerWidget {
   final void Function()? focusPostForm;
   final EdgeInsetsGeometry margin;
   final BorderRadiusGeometry? borderRadius;
+  final bool hide;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -56,7 +58,7 @@ class TimelineNote extends HookConsumerWidget {
         ),
       );
     }
-    if (tabSettings.withFiles && appearNote.fileIds.isEmpty) {
+    if ((tabSettings.withFiles && appearNote.fileIds.isEmpty) || hide) {
       return HardMutedNoteWidget(borderRadius: borderRadius);
     }
     if (note.isRenote) {


### PR DESCRIPTION
Changed to hide a new note if it is a duplicate of a previous note.