### PR TITLE
fix: enable pull-to-refresh when list is empty

### DIFF
--- a/lib/view/page/antennas_page.dart
+++ b/lib/view/page/antennas_page.dart
@@ -27,7 +27,16 @@ class AntennasPage extends ConsumerWidget {
         child: switch (antennas) {
           AsyncValue(valueOrNull: final antennas?) =>
             antennas.isEmpty
-                ? Center(child: Text(t.misskey.nothing))
+                ? LayoutBuilder(
+                  builder:
+                      (context, constraint) => SingleChildScrollView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        child: SizedBox(
+                          height: constraint.maxHeight,
+                          child: Center(child: Text(t.misskey.nothing)),
+                        ),
+                      ),
+                )
                 : ListTileTheme(
                   tileColor: Theme.of(context).colorScheme.surface,
                   child: ListView.separated(

--- a/lib/view/page/channel/channels_favorites.dart
+++ b/lib/view/page/channel/channels_favorites.dart
@@ -27,7 +27,16 @@ class ChannelsFavorites extends ConsumerWidget {
       child: switch (channels) {
         AsyncValue(valueOrNull: final channels?) =>
           channels.isEmpty
-              ? Center(child: Text(t.misskey.nothing))
+              ? LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.nothing)),
+                      ),
+                    ),
+              )
               : ListView.builder(
                 itemBuilder:
                     (context, index) => Center(

--- a/lib/view/page/channel/channels_featured.dart
+++ b/lib/view/page/channel/channels_featured.dart
@@ -23,7 +23,16 @@ class ChannelsFeatured extends ConsumerWidget {
       child: switch (channels) {
         AsyncValue(valueOrNull: final channels?) =>
           channels.isEmpty
-              ? Center(child: Text(t.misskey.nothing))
+              ? LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.nothing)),
+                      ),
+                    ),
+              )
               : ListView.builder(
                 itemBuilder:
                     (context, index) => Center(

--- a/lib/view/page/clips_page.dart
+++ b/lib/view/page/clips_page.dart
@@ -44,7 +44,16 @@ class ClipsPage extends ConsumerWidget {
               child: switch (clips) {
                 AsyncValue(valueOrNull: final clips?) =>
                   clips.isEmpty
-                      ? Center(child: Text(t.misskey.nothing))
+                      ? LayoutBuilder(
+                        builder:
+                            (context, constraint) => SingleChildScrollView(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              child: SizedBox(
+                                height: constraint.maxHeight,
+                                child: Center(child: Text(t.misskey.nothing)),
+                              ),
+                            ),
+                      )
                       : ListView.separated(
                         itemBuilder:
                             (context, index) => Center(
@@ -120,7 +129,16 @@ class ClipsPage extends ConsumerWidget {
               child: switch (favoriteClips) {
                 AsyncValue(valueOrNull: final clips?) =>
                   clips.isEmpty
-                      ? Center(child: Text(t.misskey.nothing))
+                      ? LayoutBuilder(
+                        builder:
+                            (context, constraint) => SingleChildScrollView(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              child: SizedBox(
+                                height: constraint.maxHeight,
+                                child: Center(child: Text(t.misskey.nothing)),
+                              ),
+                            ),
+                      )
                       : ListView.separated(
                         itemBuilder:
                             (context, index) => Center(

--- a/lib/view/page/explore/explore_roles.dart
+++ b/lib/view/page/explore/explore_roles.dart
@@ -26,7 +26,16 @@ class ExploreRoles extends ConsumerWidget {
             final manualRoles =
                 roles.where((role) => role.target == 'manual').toList();
             return manualRoles.isEmpty
-                ? Center(child: Text(t.misskey.noRole))
+                ? LayoutBuilder(
+                  builder:
+                      (context, constraint) => SingleChildScrollView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        child: SizedBox(
+                          height: constraint.maxHeight,
+                          child: Center(child: Text(t.misskey.noRole)),
+                        ),
+                      ),
+                )
                 : ListView.builder(
                   itemBuilder:
                       (context, index) => Center(

--- a/lib/view/page/gallery/gallery_popular.dart
+++ b/lib/view/page/gallery/gallery_popular.dart
@@ -23,7 +23,16 @@ class GalleryPopular extends ConsumerWidget {
       child: switch (pages) {
         AsyncValue(valueOrNull: final posts?) =>
           posts.isEmpty
-              ? Center(child: Text(t.misskey.nothing))
+              ? LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.nothing)),
+                      ),
+                    ),
+              )
               : ListView.builder(
                 itemBuilder:
                     (context, index) => Center(

--- a/lib/view/page/list/lists_page.dart
+++ b/lib/view/page/list/lists_page.dart
@@ -31,7 +31,16 @@ class ListsPage extends ConsumerWidget {
         child: switch (lists) {
           AsyncValue(valueOrNull: final lists?) =>
             lists.isEmpty
-                ? Center(child: Text(t.misskey.nothing))
+                ? LayoutBuilder(
+                  builder:
+                      (context, constraint) => SingleChildScrollView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        child: SizedBox(
+                          height: constraint.maxHeight,
+                          child: Center(child: Text(t.misskey.nothing)),
+                        ),
+                      ),
+                )
                 : ListView.separated(
                   itemBuilder:
                       (context, index) => Center(

--- a/lib/view/page/page/pages_featured.dart
+++ b/lib/view/page/page/pages_featured.dart
@@ -23,7 +23,16 @@ class PagesFeatured extends ConsumerWidget {
       child: switch (pages) {
         AsyncValue(valueOrNull: final pages?) =>
           pages.isEmpty
-              ? Center(child: Text(t.misskey.nothing))
+              ? LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.nothing)),
+                      ),
+                    ),
+              )
               : ListView.builder(
                 itemBuilder:
                     (context, index) => Center(

--- a/lib/view/page/server/server_ads.dart
+++ b/lib/view/page/server/server_ads.dart
@@ -31,7 +31,16 @@ class ServerAds extends ConsumerWidget {
                     ),
                 itemCount: ads.length,
               )
-              : Center(child: Text(t.misskey.nothing)),
+              : LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.nothing)),
+                      ),
+                    ),
+              ),
         AsyncValue(:final error?, :final stackTrace) => ErrorMessage(
           error: error,
           stackTrace: stackTrace,

--- a/lib/view/page/server/server_emojis.dart
+++ b/lib/view/page/server/server_emojis.dart
@@ -142,7 +142,16 @@ class ServerEmojis extends HookConsumerWidget {
                 },
                 itemCount: groups.length + 1,
               )
-              : Center(child: Text(t.misskey.noCustomEmojis)),
+              : LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.noCustomEmojis)),
+                      ),
+                    ),
+              ),
     );
   }
 }

--- a/lib/view/page/user/user_lists.dart
+++ b/lib/view/page/user/user_lists.dart
@@ -23,7 +23,16 @@ class UserLists extends ConsumerWidget {
       child: switch (lists) {
         AsyncValue(valueOrNull: final lists?) =>
           lists.isEmpty
-              ? Center(child: Text(t.misskey.noLists))
+              ? LayoutBuilder(
+                builder:
+                    (context, constraint) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraint.maxHeight,
+                        child: Center(child: Text(t.misskey.noLists)),
+                      ),
+                    ),
+              )
               : ListView.separated(
                 itemBuilder:
                     (context, index) => Center(


### PR DESCRIPTION
Wrapped labels for empty lists with `SingleChildScrollView` to enable pull-to-refresh.

ref: #473