### PR TITLE
fix: show emoji palette settings url when pasting emojis

### DIFF
--- a/lib/i18n/aria/aria.i18n.yaml
+++ b/lib/i18n/aria/aria.i18n.yaml
@@ -101,7 +101,7 @@ openScratchpadAndRunCode(rich): "Open {scratchpad} in your browser, then enter t
 openSensitiveMediaOnDoubleTap: "Open sensitive media on double tap"
 parameters: "Parameters"
 paste: "Paste"
-pastePinnedEmojisDescription(rich): "Paste JSON format emojis list to pin the emojis.\nYou can copy your pinned emojis for Misskey Web from {url}."
+pastePinnedEmojisDescription(rich): "Paste emoji list to pin the emojis.\nYou can copy your pinned emojis for Misskey Web from {url}."
 pasteResponseBelow: "Paste the response below."
 pinToEmojiPicker: "Pin to emoji picker"
 playAudio: "Play audio"

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -180,7 +180,7 @@ class TranslationsAriaEnUs {
 	String get parameters => 'Parameters';
 	String get paste => 'Paste';
 	TextSpan pastePinnedEmojisDescription({required InlineSpan url}) => TextSpan(children: [
-		const TextSpan(text: 'Paste JSON format emojis list to pin the emojis.\nYou can copy your pinned emojis for Misskey Web from '),
+		const TextSpan(text: 'Paste emoji list to pin the emojis.\nYou can copy your pinned emojis for Misskey Web from '),
 		url,
 		const TextSpan(text: '.'),
 	]);

--- a/lib/view/widget/pinned_emojis_editor.dart
+++ b/lib/view/widget/pinned_emojis_editor.dart
@@ -6,6 +6,7 @@ import 'package:reorderables/reorderables.dart';
 
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
+import '../../provider/api/endpoints_provider.dart';
 import '../../provider/pinned_emojis_notifier_provider.dart';
 import '../../util/copy_text.dart';
 import '../dialog/confirmation_dialog.dart';
@@ -28,6 +29,8 @@ class PinnedEmojisEditor extends HookConsumerWidget {
     final pinnedEmojis = ref.watch(
       pinnedEmojisNotifierProvider(account, reaction: reaction),
     );
+    final endpoints = ref.watch(endpointsProvider(account.host)).valueOrNull;
+    final useEmojiPalette = endpoints?.contains('chat/history') ?? false;
 
     return ExpansionTile(
       leading: Icon(reaction ? Icons.push_pin : Icons.push_pin_outlined),
@@ -105,7 +108,13 @@ class PinnedEmojisEditor extends HookConsumerWidget {
         ListTile(
           leading: const Icon(Icons.copy),
           title: Text(t.misskey.copy),
-          onTap: () => copyToClipboard(context, json5Encode(pinnedEmojis)),
+          onTap:
+              () => copyToClipboard(
+                context,
+                useEmojiPalette
+                    ? pinnedEmojis.join(' ')
+                    : json5Encode(pinnedEmojis),
+              ),
           dense: true,
         ),
         ListTile(


### PR DESCRIPTION
The registry key for emoji pickers has changed in Misskey 2025.4.0, breaking the link in the `PasteEmojiDialog`. This PR changes the link to the emoji palette settings page url, where copy buttons for the palettes exist.

ref: shiosyakeyakini-info/miria#728