### PR TITLE
fix: enable scrolling for announcement dialog

### DIFF
--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -362,11 +362,14 @@ class TimelineWidget extends HookConsumerWidget {
           const ModalBarrier(color: Colors.black54),
         ...?dialogAnnouncements?.map(
           (announcement) => Card(
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: AnnouncementWidget(
-                account: account,
-                announcement: announcement,
+            margin: const EdgeInsets.symmetric(vertical: 80.0, horizontal: 8.0),
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: AnnouncementWidget(
+                  account: account,
+                  announcement: announcement,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Fixed an issue where dialog-style announcements cannot be scrolled when they are long.

ref: `https://github.com/misskey-dev/misskey/pull/15878`