### PR TITLE
fix: reload children notes

### DIFF
--- a/lib/view/page/note_page.dart
+++ b/lib/view/page/note_page.dart
@@ -4,9 +4,12 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constant/max_content_width.dart';
+import '../../extension/note_extension.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../model/tab_settings.dart';
+import '../../provider/api/children_notes_notifier_provider.dart';
+import '../../provider/api/conversation_notes_provider.dart';
 import '../../provider/api/i_notifier_provider.dart';
 import '../../provider/api/meta_notifier_provider.dart';
 import '../../provider/api/timeline_notes_after_note_notifier_provider.dart';
@@ -159,6 +162,15 @@ class NotePage extends HookConsumerWidget {
           IconButton(
             tooltip: t.misskey.reload,
             onPressed: () async {
+              final appearNoteId = note.isRenote ? note.renoteId : note.id;
+              if (appearNoteId != null) {
+                ref.invalidate(
+                  conversationNotesProvider(account, appearNoteId),
+                );
+                ref.invalidate(
+                  childrenNotesNotifierProvider(account, appearNoteId),
+                );
+              }
               await futureWithDialog(
                 context,
                 ref.read(notesNotifierProvider(account).notifier).show(noteId),

--- a/lib/view/widget/note_sub_widget.dart
+++ b/lib/view/widget/note_sub_widget.dart
@@ -147,7 +147,8 @@ class NoteSubWidget extends HookConsumerWidget {
               ),
             ],
           ),
-          if (children?.valueOrNull?.items case final children?) ...[
+          if (children?.valueOrNull?.items case final children?
+              when children.isNotEmpty) ...[
             const SizedBox(height: 8.0),
             for (final (index, reply) in children.indexed)
               ChannelColorBarBox(


### PR DESCRIPTION
Changed the behavior of the reload button on the note page to also reload its parent and children notes.