### PR TITLE
fix: expand background of hidden media

### DIFF
--- a/lib/view/widget/media_card.dart
+++ b/lib/view/widget/media_card.dart
@@ -149,8 +149,9 @@ class MediaCard extends HookConsumerWidget {
                           child: BlurHash(hash: blurhash),
                         )
                       else
-                        const Positioned.fill(
-                          child: ColoredBox(color: Color(0xff888888)),
+                        const ColoredBox(
+                          color: Color(0xff888888),
+                          child: SizedBox.expand(),
                         ),
                       Text.rich(
                         TextSpan(


### PR DESCRIPTION
Fixed an issue where media in a note does not fill the grid if hidden and the file does not contain a BlurHash.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/e4d59868-15ec-4bec-9469-28005797d8d6) | ![image](https://github.com/user-attachments/assets/81281aff-969d-4b7e-b52d-d1870094b56b) |
