### PR TITLE
fix: limit scale of nested x* mfm functions

### DIFF
--- a/lib/model/mfm_config.dart
+++ b/lib/model/mfm_config.dart
@@ -11,5 +11,6 @@ abstract class MfmConfig with _$MfmConfig {
     @Default(1.0) double scale,
     @Default(1.0) double opacity,
     TextAlign? align,
+    @Default(0) int xNest,
   }) = _MfmConfig;
 }

--- a/lib/model/mfm_config.freezed.dart
+++ b/lib/model/mfm_config.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MfmConfig {
 
- TextStyle get style; bool get disableNyaize; double get scale; double get opacity; TextAlign? get align;
+ TextStyle get style; bool get disableNyaize; double get scale; double get opacity; TextAlign? get align; int get xNest;
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $MfmConfigCopyWith<MfmConfig> get copyWith => _$MfmConfigCopyWithImpl<MfmConfig>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align)&&(identical(other.xNest, xNest) || other.xNest == xNest));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align);
+int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align,xNest);
 
 @override
 String toString() {
-  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align)';
+  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align, xNest: $xNest)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $MfmConfigCopyWith<$Res>  {
   factory $MfmConfigCopyWith(MfmConfig value, $Res Function(MfmConfig) _then) = _$MfmConfigCopyWithImpl;
 @useResult
 $Res call({
- TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align
+ TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align, int xNest
 });
 
 
@@ -63,14 +63,15 @@ class _$MfmConfigCopyWithImpl<$Res>
 
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,Object? xNest = null,}) {
   return _then(_self.copyWith(
 style: null == style ? _self.style : style // ignore: cast_nullable_to_non_nullable
 as TextStyle,disableNyaize: null == disableNyaize ? _self.disableNyaize : disableNyaize // ignore: cast_nullable_to_non_nullable
 as bool,scale: null == scale ? _self.scale : scale // ignore: cast_nullable_to_non_nullable
 as double,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
 as double,align: freezed == align ? _self.align : align // ignore: cast_nullable_to_non_nullable
-as TextAlign?,
+as TextAlign?,xNest: null == xNest ? _self.xNest : xNest // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 
@@ -81,7 +82,7 @@ as TextAlign?,
 
 
 class _MfmConfig implements MfmConfig {
-  const _MfmConfig({required this.style, this.disableNyaize = false, this.scale = 1.0, this.opacity = 1.0, this.align});
+  const _MfmConfig({required this.style, this.disableNyaize = false, this.scale = 1.0, this.opacity = 1.0, this.align, this.xNest = 0});
   
 
 @override final  TextStyle style;
@@ -89,6 +90,7 @@ class _MfmConfig implements MfmConfig {
 @override@JsonKey() final  double scale;
 @override@JsonKey() final  double opacity;
 @override final  TextAlign? align;
+@override@JsonKey() final  int xNest;
 
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
@@ -100,16 +102,16 @@ _$MfmConfigCopyWith<_MfmConfig> get copyWith => __$MfmConfigCopyWithImpl<_MfmCon
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align)&&(identical(other.xNest, xNest) || other.xNest == xNest));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align);
+int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align,xNest);
 
 @override
 String toString() {
-  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align)';
+  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align, xNest: $xNest)';
 }
 
 
@@ -120,7 +122,7 @@ abstract mixin class _$MfmConfigCopyWith<$Res> implements $MfmConfigCopyWith<$Re
   factory _$MfmConfigCopyWith(_MfmConfig value, $Res Function(_MfmConfig) _then) = __$MfmConfigCopyWithImpl;
 @override @useResult
 $Res call({
- TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align
+ TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align, int xNest
 });
 
 
@@ -137,14 +139,15 @@ class __$MfmConfigCopyWithImpl<$Res>
 
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,Object? xNest = null,}) {
   return _then(_MfmConfig(
 style: null == style ? _self.style : style // ignore: cast_nullable_to_non_nullable
 as TextStyle,disableNyaize: null == disableNyaize ? _self.disableNyaize : disableNyaize // ignore: cast_nullable_to_non_nullable
 as bool,scale: null == scale ? _self.scale : scale // ignore: cast_nullable_to_non_nullable
 as double,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
 as double,align: freezed == align ? _self.align : align // ignore: cast_nullable_to_non_nullable
-as TextAlign?,
+as TextAlign?,xNest: null == xNest ? _self.xNest : xNest // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/lib/view/widget/custom_emoji.dart
+++ b/lib/view/widget/custom_emoji.dart
@@ -20,6 +20,8 @@ class CustomEmoji extends ConsumerWidget {
     this.useOriginalSize = false,
     this.height,
     this.opacity = 1.0,
+    this.fit = BoxFit.contain,
+    this.alignment = Alignment.center,
     this.onTap,
     this.disableTooltip = false,
     this.fallbackTextStyle,
@@ -34,6 +36,8 @@ class CustomEmoji extends ConsumerWidget {
   final bool useOriginalSize;
   final double? height;
   final double opacity;
+  final BoxFit fit;
+  final Alignment alignment;
   final void Function()? onTap;
   final bool disableTooltip;
   final TextStyle? fallbackTextStyle;
@@ -68,7 +72,8 @@ class CustomEmoji extends ConsumerWidget {
             child: Assets.misskey.packages.frontend.assets.dummy.image(
               height: height,
               opacity: AlwaysStoppedAnimation(opacity),
-              fit: BoxFit.contain,
+              fit: fit,
+              alignment: alignment,
             ),
           ),
         ),
@@ -112,13 +117,15 @@ class CustomEmoji extends ConsumerWidget {
                       : proxiedUrl,
               height: height,
               opacity: opacity,
-              fit: BoxFit.contain,
+              fit: fit,
+              alignment: alignment,
               errorBuilder:
                   (_, _, _) => ImageWidget(
                     url: rawUrl,
                     height: height,
                     opacity: opacity,
-                    fit: BoxFit.contain,
+                    fit: fit,
+                    alignment: alignment,
                     errorBuilder:
                         (_, _, _) =>
                             fallbackToImage
@@ -126,7 +133,8 @@ class CustomEmoji extends ConsumerWidget {
                                     .image(
                                       height: height,
                                       opacity: AlwaysStoppedAnimation(opacity),
-                                      fit: BoxFit.contain,
+                                      fit: fit,
+                                      alignment: alignment,
                                     )
                                 : height > fallbackTextStyle.lineHeight
                                 ? Column(

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -505,6 +505,8 @@ class _Mfm extends StatelessWidget {
           useOriginalSize: config.scale >= 2.5,
           height: config.style.fontSize! * config.scale * (simple ? 1.0 : 2.0),
           opacity: config.opacity,
+          fit: BoxFit.cover,
+          alignment: Alignment.centerLeft,
           onTap:
               !simple
                   ? () => showModalBottomSheet<void>(
@@ -550,6 +552,8 @@ class _Mfm extends StatelessWidget {
                   )
                   : null,
           inline: true,
+          fit: BoxFit.cover,
+          alignment: Alignment.centerLeft,
         ),
       ),
       MfmMathInline(:final formula) => WidgetSpan(
@@ -784,7 +788,16 @@ class _Mfm extends StatelessWidget {
         return TextSpan(
           children: _buildNodes(
             context,
-            config.copyWith(scale: config.scale * 2),
+            config.copyWith(
+              scale:
+                  config.scale *
+                  switch (config.xNest) {
+                    0 => 2,
+                    1 => 1.5,
+                    _ => 1.0,
+                  },
+              xNest: config.xNest + 1,
+            ),
             children,
           ),
         );
@@ -793,7 +806,16 @@ class _Mfm extends StatelessWidget {
         return TextSpan(
           children: _buildNodes(
             context,
-            config.copyWith(scale: config.scale * 4),
+            config.copyWith(
+              scale:
+                  config.scale *
+                  switch (config.xNest) {
+                    0 => 4,
+                    1 => 2.5,
+                    _ => 1.0,
+                  },
+              xNest: config.xNest + 1,
+            ),
             children,
           ),
         );
@@ -802,7 +824,16 @@ class _Mfm extends StatelessWidget {
         return TextSpan(
           children: _buildNodes(
             context,
-            config.copyWith(scale: config.scale * 6),
+            config.copyWith(
+              scale:
+                  config.scale *
+                  switch (config.xNest) {
+                    0 => 6,
+                    1 => 3.5,
+                    _ => 1.0,
+                  },
+              xNest: config.xNest + 1,
+            ),
             children,
           ),
         );

--- a/lib/view/widget/unicode_emoji.dart
+++ b/lib/view/widget/unicode_emoji.dart
@@ -29,6 +29,8 @@ class UnicodeEmoji extends ConsumerWidget {
     this.account,
     required this.emoji,
     this.style,
+    this.fit = BoxFit.contain,
+    this.alignment = Alignment.center,
     this.onTap,
     this.inline = false,
   });
@@ -36,6 +38,8 @@ class UnicodeEmoji extends ConsumerWidget {
   final Account? account;
   final String emoji;
   final TextStyle? style;
+  final BoxFit fit;
+  final Alignment alignment;
   final void Function()? onTap;
   final bool inline;
 
@@ -55,7 +59,8 @@ class UnicodeEmoji extends ConsumerWidget {
         child: Assets.misskey.packages.frontend.assets.dummy.image(
           height: style.lineHeight,
           opacity: AlwaysStoppedAnimation(style.color?.a ?? 1.0),
-          fit: BoxFit.contain,
+          fit: fit,
+          alignment: alignment,
         ),
       );
     }
@@ -77,6 +82,8 @@ class UnicodeEmoji extends ConsumerWidget {
               height: style.fontSize,
               width: style.fontSize,
               opacity: style.color?.a,
+              fit: fit,
+              alignment: alignment,
             ),
           ),
         );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1965,8 +1965,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4e9421350c0f6b3c4ca908e79042e6a2ab5d6dfc"
-      resolved-ref: "4e9421350c0f6b3c4ca908e79042e6a2ab5d6dfc"
+      ref: "05d864e84b6d6028d457ee9b03f61836a4c1f316"
+      resolved-ref: "05d864e84b6d6028d457ee9b03f61836a4c1f316"
       url: "https://github.com/poppingmoon/twemoji_v2"
     source: git
     version: "0.5.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,7 +115,7 @@ dependencies:
   twemoji_v2:
     git:
       url: https://github.com/poppingmoon/twemoji_v2
-      ref: 4e9421350c0f6b3c4ca908e79042e6a2ab5d6dfc
+      ref: 05d864e84b6d6028d457ee9b03f61836a4c1f316
   unifiedpush: ^6.0.0-rc3
   unifiedpush_ui: ^0.1.0
   url_launcher: ^6.3.1


### PR DESCRIPTION
Changed scale of nested `$[x2`, `$[x3`, `$[x4` functions.

The outermost function has the normal effect, the second one has about half the effect, and the rest have no effect.

ref: `https://github.com/misskey-dev/misskey/issues/7445#issuecomment-2851275850`
ref: https://github.com/misskey-dev/misskey/blob/2025.5.0/packages/frontend/src/style.scss#L641-L653

Related to #470