### PR TITLE
refactor: remove image_size_getter

### DIFF
--- a/lib/extension/image_extension.dart
+++ b/lib/extension/image_extension.dart
@@ -1,0 +1,5 @@
+import 'dart:ui';
+
+extension ImageExtension on Image {
+  Size get size => Size(width.toDouble(), height.toDouble());
+}

--- a/lib/model/layer.dart
+++ b/lib/model/layer.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:image_size_getter/image_size_getter.dart';
 
 part 'layer.freezed.dart';
 
@@ -17,32 +16,12 @@ sealed class Layer {
 abstract class ImageLayer with _$ImageLayer implements Layer {
   const factory ImageLayer({
     required Uint8List data,
-    required Size size,
     @Default(1.0) double opacity,
     @Default(Offset.zero) Offset offset,
     @Default(1.0) double scale,
     @Default(0.0) double angle,
     @Default(false) bool flipX,
   }) = _ImageLayer;
-
-  factory ImageLayer.fromData(
-    Uint8List data, {
-    double opacity = 1.0,
-    Offset offset = Offset.zero,
-    double scale = 1.0,
-    double angle = 0.0,
-    bool flipX = false,
-  }) {
-    return ImageLayer(
-      data: data,
-      size: ImageSizeGetter.getSizeResult(MemoryInput(data)).size,
-      opacity: opacity,
-      offset: offset,
-      scale: scale,
-      angle: angle,
-      flipX: flipX,
-    );
-  }
 }
 
 @freezed

--- a/lib/model/layer.freezed.dart
+++ b/lib/model/layer.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ImageLayer {
 
- Uint8List get data; Size get size; double get opacity; Offset get offset; double get scale; double get angle; bool get flipX;
+ Uint8List get data; double get opacity; Offset get offset; double get scale; double get angle; bool get flipX;
 /// Create a copy of ImageLayer
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $ImageLayerCopyWith<ImageLayer> get copyWith => _$ImageLayerCopyWithImpl<ImageLa
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ImageLayer&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.size, size) || other.size == size)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.offset, offset) || other.offset == offset)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.angle, angle) || other.angle == angle)&&(identical(other.flipX, flipX) || other.flipX == flipX));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ImageLayer&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.offset, offset) || other.offset == offset)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.angle, angle) || other.angle == angle)&&(identical(other.flipX, flipX) || other.flipX == flipX));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(data),size,opacity,offset,scale,angle,flipX);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(data),opacity,offset,scale,angle,flipX);
 
 @override
 String toString() {
-  return 'ImageLayer(data: $data, size: $size, opacity: $opacity, offset: $offset, scale: $scale, angle: $angle, flipX: $flipX)';
+  return 'ImageLayer(data: $data, opacity: $opacity, offset: $offset, scale: $scale, angle: $angle, flipX: $flipX)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $ImageLayerCopyWith<$Res>  {
   factory $ImageLayerCopyWith(ImageLayer value, $Res Function(ImageLayer) _then) = _$ImageLayerCopyWithImpl;
 @useResult
 $Res call({
- Uint8List data, Size size, double opacity, Offset offset, double scale, double angle, bool flipX
+ Uint8List data, double opacity, Offset offset, double scale, double angle, bool flipX
 });
 
 
@@ -63,11 +63,10 @@ class _$ImageLayerCopyWithImpl<$Res>
 
 /// Create a copy of ImageLayer
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? data = null,Object? size = null,Object? opacity = null,Object? offset = null,Object? scale = null,Object? angle = null,Object? flipX = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? data = null,Object? opacity = null,Object? offset = null,Object? scale = null,Object? angle = null,Object? flipX = null,}) {
   return _then(_self.copyWith(
 data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
-as Uint8List,size: null == size ? _self.size : size // ignore: cast_nullable_to_non_nullable
-as Size,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
+as Uint8List,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
 as double,offset: null == offset ? _self.offset : offset // ignore: cast_nullable_to_non_nullable
 as Offset,scale: null == scale ? _self.scale : scale // ignore: cast_nullable_to_non_nullable
 as double,angle: null == angle ? _self.angle : angle // ignore: cast_nullable_to_non_nullable
@@ -83,11 +82,10 @@ as bool,
 
 
 class _ImageLayer implements ImageLayer {
-  const _ImageLayer({required this.data, required this.size, this.opacity = 1.0, this.offset = Offset.zero, this.scale = 1.0, this.angle = 0.0, this.flipX = false});
+  const _ImageLayer({required this.data, this.opacity = 1.0, this.offset = Offset.zero, this.scale = 1.0, this.angle = 0.0, this.flipX = false});
   
 
 @override final  Uint8List data;
-@override final  Size size;
 @override@JsonKey() final  double opacity;
 @override@JsonKey() final  Offset offset;
 @override@JsonKey() final  double scale;
@@ -104,16 +102,16 @@ _$ImageLayerCopyWith<_ImageLayer> get copyWith => __$ImageLayerCopyWithImpl<_Ima
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ImageLayer&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.size, size) || other.size == size)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.offset, offset) || other.offset == offset)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.angle, angle) || other.angle == angle)&&(identical(other.flipX, flipX) || other.flipX == flipX));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ImageLayer&&const DeepCollectionEquality().equals(other.data, data)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.offset, offset) || other.offset == offset)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.angle, angle) || other.angle == angle)&&(identical(other.flipX, flipX) || other.flipX == flipX));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(data),size,opacity,offset,scale,angle,flipX);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(data),opacity,offset,scale,angle,flipX);
 
 @override
 String toString() {
-  return 'ImageLayer(data: $data, size: $size, opacity: $opacity, offset: $offset, scale: $scale, angle: $angle, flipX: $flipX)';
+  return 'ImageLayer(data: $data, opacity: $opacity, offset: $offset, scale: $scale, angle: $angle, flipX: $flipX)';
 }
 
 
@@ -124,7 +122,7 @@ abstract mixin class _$ImageLayerCopyWith<$Res> implements $ImageLayerCopyWith<$
   factory _$ImageLayerCopyWith(_ImageLayer value, $Res Function(_ImageLayer) _then) = __$ImageLayerCopyWithImpl;
 @override @useResult
 $Res call({
- Uint8List data, Size size, double opacity, Offset offset, double scale, double angle, bool flipX
+ Uint8List data, double opacity, Offset offset, double scale, double angle, bool flipX
 });
 
 
@@ -141,11 +139,10 @@ class __$ImageLayerCopyWithImpl<$Res>
 
 /// Create a copy of ImageLayer
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? data = null,Object? size = null,Object? opacity = null,Object? offset = null,Object? scale = null,Object? angle = null,Object? flipX = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? data = null,Object? opacity = null,Object? offset = null,Object? scale = null,Object? angle = null,Object? flipX = null,}) {
   return _then(_ImageLayer(
 data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
-as Uint8List,size: null == size ? _self.size : size // ignore: cast_nullable_to_non_nullable
-as Size,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
+as Uint8List,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
 as double,offset: null == offset ? _self.offset : offset // ignore: cast_nullable_to_non_nullable
 as Offset,scale: null == scale ? _self.scale : scale // ignore: cast_nullable_to_non_nullable
 as double,angle: null == angle ? _self.angle : angle // ignore: cast_nullable_to_non_nullable

--- a/lib/view/widget/layers_sheet.dart
+++ b/lib/view/widget/layers_sheet.dart
@@ -1,9 +1,10 @@
 import 'dart:math';
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:extended_image/extended_image.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Image;
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -13,9 +14,14 @@ import '../../provider/overlay_layers_notifier_provider.dart';
 import 'reorderable_drag_start_listener_wrapper.dart';
 
 class LayersSheet extends ConsumerWidget {
-  const LayersSheet({super.key, required this.backgroundLayer});
+  const LayersSheet({
+    super.key,
+    required this.backgroundLayer,
+    required this.images,
+  });
 
   final ImageLayer backgroundLayer;
+  final Map<Uint8List, Image> images;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -68,7 +74,10 @@ class LayersSheet extends ConsumerWidget {
                     builder:
                         (context) => _LayerSheet(
                           backgroundLayer: backgroundLayer,
+                          backgroundImage: images[backgroundLayer.data]!,
                           index: index,
+                          image:
+                              layer is ImageLayer ? images[layer.data] : null,
                         ),
                   ),
             ),
@@ -102,10 +111,17 @@ class LayersSheet extends ConsumerWidget {
 }
 
 class _LayerSheet extends HookConsumerWidget {
-  const _LayerSheet({required this.backgroundLayer, required this.index});
+  const _LayerSheet({
+    required this.backgroundLayer,
+    required this.backgroundImage,
+    required this.index,
+    this.image,
+  });
 
   final ImageLayer backgroundLayer;
+  final Image backgroundImage;
   final int index;
+  final Image? image;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -114,11 +130,10 @@ class _LayerSheet extends HookConsumerWidget {
     );
     const minAngle = -pi;
     const maxAngle = pi;
-    final minOffsetX = layer is ImageLayer ? -layer.size.width.toDouble() : 0.0;
-    final maxOffsetX = backgroundLayer.size.width.toDouble();
-    final minOffsetY =
-        layer is ImageLayer ? -layer.size.height.toDouble() : 0.0;
-    final maxOffsetY = backgroundLayer.size.height.toDouble();
+    final minOffsetX = image?.width.toDouble() ?? 0.0;
+    final maxOffsetX = backgroundImage.width.toDouble();
+    final minOffsetY = -(image?.height.toDouble() ?? 0.0);
+    final maxOffsetY = backgroundImage.height.toDouble();
     const minScale = 0.0;
     const maxScale = 10.0;
     const minStrokeWidthFactor = 0.0;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1076,7 +1076,7 @@ packages:
     source: hosted
     version: "1.1.0"
   image_size_getter:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: image_size_getter
       sha256: "9a299e3af2ebbcfd1baf21456c3c884037ff524316c97d8e56035ea8fdf35653"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,6 @@ dependencies:
       url: https://github.com/poppingmoon/image_compression
       ref: 37b78624635c42f51524cdfc001ae9073ec468ee
   image_editor: ^1.6.0
-  image_size_getter: ^2.4.0
   intl: ^0.19.0
   json5: ^0.8.2
   json_annotation: ^4.9.0


### PR DESCRIPTION
Removed use of `image_size_getter` in the `ImagePage` and get size from [`Image`](https://api.flutter.dev/flutter/dart-ui/Image-class.html) instead.

This prevents UI crash caused by errors from `image_size_getter` not being handled correctly.