### PR TITLE
fix: always use converted image if input is heic

### DIFF
--- a/lib/util/compress_image.dart
+++ b/lib/util/compress_image.dart
@@ -60,6 +60,9 @@ Future<Uint8List?> compressImage(Uint8List image, String? type) async {
         quality: imgConfig.quality,
         format: imgConfig.format,
       );
+      if (fileType case 'image/heic' || 'image/heif') {
+        return resized;
+      }
       if (resized.length < image.length) {
         return resized;
       }
@@ -83,6 +86,9 @@ Future<Uint8List?> compressImage(Uint8List image, String? type) async {
           ),
         ),
       );
+      if (fileType case 'image/heic' || 'image/heif') {
+        return resized.rawBytes;
+      }
       if (resized.rawBytes.length < image.length) {
         return resized.rawBytes;
       }


### PR DESCRIPTION
Changed to return a compressed image from `compressImage()` if the input is heic/heif because those formats are not rendered on the app and the browser.

For the other formats, the function returns compressed one only if the image size was reduced after resizing.