### PR TITLE
fix: show like count if reaction acceptance is like only

### DIFF
--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -546,7 +546,9 @@ class _AddReactionButton extends ConsumerWidget {
               const Icon(Icons.favorite_border)
             else
               const Icon(Icons.add),
-            if (showReactionsCount && (note.reactionCount ?? 0) > 0)
+            if ((note.reactionAcceptance == ReactionAcceptance.likeOnly ||
+                    showReactionsCount) &&
+                (note.reactionCount ?? 0) > 0)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 2.0),
                 child: Text(


### PR DESCRIPTION
Fixed an issue where the number of likes is not appearing next to the like button if the note only accepts likes.