### PR TITLE
fix: change background color of cancel button

### DIFF
--- a/integration_test/play_test.dart
+++ b/integration_test/play_test.dart
@@ -86,13 +86,7 @@ Ui:render([
       find.byType(TextField),
       'https://misskey.tld/play/testplay',
     );
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.descendant(
-        of: find.byType(AlertDialog),
-        matching: find.byType(ElevatedButton),
-      ),
-    );
+    await tester.testTextInput.receiveAction(TextInputAction.done);
     await tester.pumpAndSettle();
     expect(find.text('Test Play'), findsExactly(2));
     expect(find.text('Test Play summary'), findsOne);

--- a/lib/view/dialog/account_select_dialog.dart
+++ b/lib/view/dialog/account_select_dialog.dart
@@ -37,6 +37,7 @@ class AccountSelectDialog extends HookConsumerWidget {
       );
       return;
     }, []);
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.selectAccount),
@@ -89,7 +90,11 @@ class AccountSelectDialog extends HookConsumerWidget {
           onPressed: () => context.pop(account.value),
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/antenna_settings_dialog.dart
+++ b/lib/view/dialog/antenna_settings_dialog.dart
@@ -47,6 +47,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
         ref
             .watch(endpointParametersProvider(account, 'antennas/create'))
             .valueOrNull;
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(
@@ -62,7 +63,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
                 controller: nameController,
                 decoration: InputDecoration(
                   labelText: t.misskey.name,
-                  enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                  enabledBorder: theme.inputDecorationTheme.border,
                 ),
                 onChanged:
                     (value) =>
@@ -190,7 +191,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
                 decoration: InputDecoration(
                   labelText: t.misskey.antennaKeywords,
                   helperText: t.misskey.antennaKeywordsDescription,
-                  enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                  enabledBorder: theme.inputDecorationTheme.border,
                   alignLabelWithHint: true,
                 ),
                 maxLines: 5,
@@ -207,7 +208,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
                 decoration: InputDecoration(
                   labelText: t.misskey.antennaExcludeKeywords,
                   helperText: t.misskey.antennaKeywordsDescription,
-                  enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                  enabledBorder: theme.inputDecorationTheme.border,
                   alignLabelWithHint: true,
                 ),
                 minLines: 3,
@@ -276,7 +277,11 @@ class AntennaSettingsDialog extends HookConsumerWidget {
               ),
           child: Text(t.misskey.save),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/avatar_decoration_dialog.dart
+++ b/lib/view/dialog/avatar_decoration_dialog.dart
@@ -74,6 +74,7 @@ class AvatarDecorationDialog extends HookConsumerWidget {
       offsetY: offsetY.value,
       flipH: flipH.value,
     );
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.avatarDecorations),
@@ -227,7 +228,12 @@ class AvatarDecorationDialog extends HookConsumerWidget {
                   ),
                 ),
                 if (index != null)
-                  OutlinedButton.icon(
+                  ElevatedButton.icon(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: theme.colorScheme.primary,
+                      backgroundColor: theme.colorScheme.surfaceContainerLowest,
+                      iconColor: theme.colorScheme.primary,
+                    ),
                     onPressed: () => context.pop((null,)),
                     icon: const Icon(Icons.close),
                     label: Text(t.misskey.detach),

--- a/lib/view/dialog/chat_message_send_confirmation_dialog.dart
+++ b/lib/view/dialog/chat_message_send_confirmation_dialog.dart
@@ -42,6 +42,7 @@ class ChatMessageSendConfirmationDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+    final theme = Theme.of(context);
 
     return Dialog(
       child: Container(
@@ -57,7 +58,7 @@ class ChatMessageSendConfirmationDialog extends ConsumerWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
                     t.aria.sendMessageConfirm,
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: theme.textTheme.titleMedium,
                   ),
                 ),
               ),
@@ -81,14 +82,19 @@ class ChatMessageSendConfirmationDialog extends ConsumerWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
+                    spacing: 8.0,
                     children: [
                       ElevatedButton(
                         autofocus: true,
                         onPressed: () => context.pop(true),
                         child: Text(t.misskey.ok),
                       ),
-                      const SizedBox(width: 8.0),
-                      OutlinedButton(
+                      ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          foregroundColor: theme.colorScheme.primary,
+                          backgroundColor:
+                              theme.colorScheme.surfaceContainerLowest,
+                        ),
                         onPressed: () => context.pop(false),
                         child: Text(t.misskey.cancel),
                       ),

--- a/lib/view/dialog/clip_settings_dialog.dart
+++ b/lib/view/dialog/clip_settings_dialog.dart
@@ -18,6 +18,7 @@ class ClipSettingsDialog extends HookWidget {
     final descriptionController = useTextEditingController(
       text: this.settings?.description,
     );
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(this.settings == null ? t.misskey.create : t.misskey.edit),
@@ -31,7 +32,7 @@ class ClipSettingsDialog extends HookWidget {
                 controller: nameController,
                 decoration: InputDecoration(
                   labelText: t.misskey.name,
-                  enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                  enabledBorder: theme.inputDecorationTheme.border,
                 ),
                 onChanged:
                     (value) =>
@@ -49,7 +50,7 @@ class ClipSettingsDialog extends HookWidget {
                 controller: descriptionController,
                 decoration: InputDecoration(
                   labelText: '${t.misskey.description} (${t.misskey.optional})',
-                  enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                  enabledBorder: theme.inputDecorationTheme.border,
                   alignLabelWithHint: true,
                 ),
                 onChanged:
@@ -77,7 +78,11 @@ class ClipSettingsDialog extends HookWidget {
           onPressed: () => context.pop(settings.value),
           child: Text(t.misskey.save),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/confirmation_dialog.dart
+++ b/lib/view/dialog/confirmation_dialog.dart
@@ -43,6 +43,8 @@ class ConfirmationDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return AlertDialog(
       title: title,
       content: content ?? Text(message ?? ''),
@@ -52,7 +54,11 @@ class ConfirmationDialog extends StatelessWidget {
           onPressed: () => context.pop(true),
           child: Text(okText ?? t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(false),
           child: Text(cancelText ?? t.misskey.cancel),
         ),

--- a/lib/view/dialog/confirmation_dialog.dart
+++ b/lib/view/dialog/confirmation_dialog.dart
@@ -46,6 +46,7 @@ class ConfirmationDialog extends StatelessWidget {
     final theme = Theme.of(context);
 
     return AlertDialog(
+      icon: title == null ? const Icon(Icons.help_outline, size: 36.0) : null,
       title: title,
       content: content ?? Text(message ?? ''),
       actions: [

--- a/lib/view/dialog/delete_and_edit_dialog.dart
+++ b/lib/view/dialog/delete_and_edit_dialog.dart
@@ -27,6 +27,7 @@ class DeleteAndEditDialog extends ConsumerWidget {
     final theme = Theme.of(context);
 
     return AlertDialog(
+      icon: const Icon(Icons.help_outline, size: 36.0),
       content: Text(t.misskey.deleteAndEditConfirm),
       actions: [
         ElevatedButton(

--- a/lib/view/dialog/delete_and_edit_dialog.dart
+++ b/lib/view/dialog/delete_and_edit_dialog.dart
@@ -24,6 +24,8 @@ class DeleteAndEditDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
     return AlertDialog(
       content: Text(t.misskey.deleteAndEditConfirm),
       actions: [
@@ -52,7 +54,11 @@ class DeleteAndEditDialog extends ConsumerWidget {
           },
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/duration_picker_dialog.dart
+++ b/lib/view/dialog/duration_picker_dialog.dart
@@ -35,6 +35,7 @@ class DurationPickerDialog extends HookWidget {
     final secondsController = useTextEditingController(
       text: ((initialDuration?.inSeconds ?? 0) % 60).toString(),
     );
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.poll_.duration),
@@ -45,7 +46,7 @@ class DurationPickerDialog extends HookWidget {
             controller: daysController,
             decoration: InputDecoration(
               labelText: t.misskey.time_.day,
-              enabledBorder: Theme.of(context).inputDecorationTheme.border,
+              enabledBorder: theme.inputDecorationTheme.border,
             ),
             keyboardType: TextInputType.number,
             textInputAction: TextInputAction.next,
@@ -57,7 +58,7 @@ class DurationPickerDialog extends HookWidget {
             controller: hoursController,
             decoration: InputDecoration(
               labelText: t.misskey.time_.hour,
-              enabledBorder: Theme.of(context).inputDecorationTheme.border,
+              enabledBorder: theme.inputDecorationTheme.border,
             ),
             keyboardType: TextInputType.number,
             textInputAction: TextInputAction.next,
@@ -69,7 +70,7 @@ class DurationPickerDialog extends HookWidget {
             controller: minutesController,
             decoration: InputDecoration(
               labelText: t.misskey.time_.minute,
-              enabledBorder: Theme.of(context).inputDecorationTheme.border,
+              enabledBorder: theme.inputDecorationTheme.border,
             ),
             keyboardType: TextInputType.number,
             textInputAction: TextInputAction.next,
@@ -81,7 +82,7 @@ class DurationPickerDialog extends HookWidget {
             controller: secondsController,
             decoration: InputDecoration(
               labelText: t.misskey.time_.second,
-              enabledBorder: Theme.of(context).inputDecorationTheme.border,
+              enabledBorder: theme.inputDecorationTheme.border,
             ),
             keyboardType: TextInputType.number,
             textInputAction: TextInputAction.done,
@@ -112,7 +113,11 @@ class DurationPickerDialog extends HookWidget {
               ),
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/field_dialog.dart
+++ b/lib/view/dialog/field_dialog.dart
@@ -15,6 +15,7 @@ class FieldDialog extends HookWidget {
   Widget build(BuildContext context) {
     final nameController = useTextEditingController(text: field?.name);
     final valueController = useTextEditingController(text: field?.value);
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.profile_.metadata),
@@ -27,7 +28,7 @@ class FieldDialog extends HookWidget {
               controller: nameController,
               decoration: InputDecoration(
                 labelText: t.misskey.profile_.metadataLabel,
-                enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                enabledBorder: theme.inputDecorationTheme.border,
               ),
               textInputAction: TextInputAction.next,
               onTapOutside: (_) => primaryFocus?.unfocus(),
@@ -37,7 +38,7 @@ class FieldDialog extends HookWidget {
               controller: valueController,
               decoration: InputDecoration(
                 labelText: t.misskey.profile_.metadataContent,
-                enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                enabledBorder: theme.inputDecorationTheme.border,
               ),
               textInputAction: TextInputAction.done,
               onTapOutside: (_) => primaryFocus?.unfocus(),
@@ -56,7 +57,11 @@ class FieldDialog extends HookWidget {
               ),
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/file_caption_edit_dialog.dart
+++ b/lib/view/dialog/file_caption_edit_dialog.dart
@@ -17,6 +17,7 @@ class FileCaptionEditDialog extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final controller = useTextEditingController(text: file.comment);
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.describeFile),
@@ -77,7 +78,7 @@ class FileCaptionEditDialog extends HookWidget {
               controller: controller,
               decoration: InputDecoration(
                 labelText: t.misskey.caption,
-                enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                enabledBorder: theme.inputDecorationTheme.border,
                 alignLabelWithHint: true,
               ),
               onSubmitted: (value) => context.pop(value),
@@ -93,7 +94,11 @@ class FileCaptionEditDialog extends HookWidget {
           onPressed: () => context.pop(controller.text),
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/list_settings_dialog.dart
+++ b/lib/view/dialog/list_settings_dialog.dart
@@ -15,6 +15,7 @@ class ListSettingsDialog extends HookWidget {
   Widget build(BuildContext context) {
     final settings = useState(this.settings ?? const ListSettings());
     final controller = useTextEditingController(text: this.settings?.name);
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.editList),
@@ -28,7 +29,7 @@ class ListSettingsDialog extends HookWidget {
                 controller: controller,
                 decoration: InputDecoration(
                   labelText: t.misskey.name,
-                  enabledBorder: Theme.of(context).inputDecorationTheme.border,
+                  enabledBorder: theme.inputDecorationTheme.border,
                 ),
                 onChanged:
                     (value) =>
@@ -51,7 +52,11 @@ class ListSettingsDialog extends HookWidget {
           onPressed: () => context.pop(settings.value),
           child: Text(t.misskey.save),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/message_dialog.dart
+++ b/lib/view/dialog/message_dialog.dart
@@ -18,6 +18,7 @@ class MessageDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      icon: const Icon(Icons.error_outline, size: 36.0),
       content: Text(message),
       actions: [
         ElevatedButton(

--- a/lib/view/dialog/mute_dialog.dart
+++ b/lib/view/dialog/mute_dialog.dart
@@ -25,6 +25,7 @@ class MuteDialog extends HookConsumerWidget {
     final period = useState(_MutePeriod.indefinite);
     final expiresAt = useState(DateTime.now());
     final expiresAfter = useState(const Duration(minutes: 10));
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Text(t.misskey.mute),
@@ -33,7 +34,7 @@ class MuteDialog extends HookConsumerWidget {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(6.0),
           ),
-          tileColor: Theme.of(context).colorScheme.surface,
+          tileColor: theme.colorScheme.surface,
         ),
         child: Column(
           children: [
@@ -128,7 +129,11 @@ class MuteDialog extends HookConsumerWidget {
           },
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/post_confirmation_dialog.dart
+++ b/lib/view/dialog/post_confirmation_dialog.dart
@@ -89,9 +89,8 @@ class PostConfirmationDialog extends ConsumerWidget {
     final note = request
         .copyWith(scheduledAt: canScheduleNote ? request.scheduledAt : null)
         .toNote(i: i, channel: channel);
-    final colors = ref.watch(
-      misskeyColorsProvider(Theme.of(context).brightness),
-    );
+    final theme = Theme.of(context);
+    final colors = ref.watch(misskeyColorsProvider(theme.brightness));
 
     return Dialog(
       child: Container(
@@ -109,7 +108,7 @@ class PostConfirmationDialog extends ConsumerWidget {
                     request.isRenote
                         ? t.aria.renoteConfirm
                         : t.aria.postConfirm,
-                    style: Theme.of(context).textTheme.titleMedium,
+                    style: theme.textTheme.titleMedium,
                   ),
                 ),
               ),
@@ -160,14 +159,19 @@ class PostConfirmationDialog extends ConsumerWidget {
                   padding: const EdgeInsets.all(8.0),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
+                    spacing: 8.0,
                     children: [
                       ElevatedButton(
                         autofocus: true,
                         onPressed: () => context.pop(true),
                         child: Text(t.misskey.ok),
                       ),
-                      const SizedBox(width: 8.0),
-                      OutlinedButton(
+                      ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          foregroundColor: theme.colorScheme.primary,
+                          backgroundColor:
+                              theme.colorScheme.surfaceContainerLowest,
+                        ),
                         onPressed: () => context.pop(false),
                         child: Text(t.misskey.cancel),
                       ),

--- a/lib/view/dialog/reaction_confirmation_dialog.dart
+++ b/lib/view/dialog/reaction_confirmation_dialog.dart
@@ -42,6 +42,7 @@ class ReactionConfirmationDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+    final theme = Theme.of(context);
 
     return AlertDialog(
       title: Row(
@@ -85,7 +86,11 @@ class ReactionConfirmationDialog extends ConsumerWidget {
           onPressed: () => context.pop(true),
           child: Text(t.misskey.ok),
         ),
-        OutlinedButton(
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            foregroundColor: theme.colorScheme.primary,
+            backgroundColor: theme.colorScheme.surfaceContainerLowest,
+          ),
           onPressed: () => context.pop(false),
           child: Text(t.misskey.cancel),
         ),

--- a/lib/view/dialog/text_field_dialog.dart
+++ b/lib/view/dialog/text_field_dialog.dart
@@ -104,6 +104,7 @@ class TextFieldDialog extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final controller = useTextEditingController(text: initialText);
+    final theme = Theme.of(context);
 
     return Shortcuts(
       shortcuts: {
@@ -118,7 +119,11 @@ class TextFieldDialog extends HookWidget {
             onPressed: () => context.pop(controller.text),
             child: Text(t.misskey.ok),
           ),
-          OutlinedButton(
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              foregroundColor: theme.colorScheme.primary,
+              backgroundColor: theme.colorScheme.surfaceContainerLowest,
+            ),
             onPressed: () => context.pop(),
             child: Text(t.misskey.cancel),
           ),

--- a/lib/view/page/avatar_decorations_page.dart
+++ b/lib/view/page/avatar_decorations_page.dart
@@ -143,8 +143,8 @@ class AvatarDecorationsPage extends ConsumerWidget {
                 sliver: SliverToBoxAdapter(
                   child: OutlinedButton.icon(
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: Theme.of(context).colorScheme.error,
-                      iconColor: Theme.of(context).colorScheme.error,
+                      foregroundColor: colors.error,
+                      iconColor: colors.error,
                     ),
                     onPressed: () async {
                       final confirmed = await confirm(

--- a/lib/view/widget/follow_button.dart
+++ b/lib/view/widget/follow_button.dart
@@ -67,11 +67,13 @@ class FollowButton extends HookConsumerWidget {
       );
     } else {
       final i = ref.watch(iNotifierProvider(account)).valueOrNull;
+      final theme = Theme.of(context);
 
       return ElevatedButton(
         style: ElevatedButton.styleFrom(
-          foregroundColor: Theme.of(context).colorScheme.primary,
-          backgroundColor: Theme.of(context).colorScheme.surface,
+          foregroundColor: theme.colorScheme.primary,
+          backgroundColor: theme.colorScheme.surface,
+          side: BorderSide(color: theme.colorScheme.primary),
         ),
         onPressed: () async {
           if (ref.read(generalSettingsNotifierProvider).confirmBeforeFollow) {

--- a/lib/view/widget/play_widget.dart
+++ b/lib/view/widget/play_widget.dart
@@ -60,6 +60,7 @@ class PlayWidget extends HookConsumerWidget {
     final aiscript = useState<AiScript?>(null);
     final components = useState(<String, AsUiComponent>{});
     final locale = Localizations.localeOf(context).toLanguageTag();
+    final style = DefaultTextStyle.of(context).style;
     final colors = ref.watch(
       misskeyColorsProvider(Theme.of(context).brightness),
     );
@@ -260,7 +261,7 @@ class PlayWidget extends HookConsumerWidget {
                         children: [
                           Text(
                             play.title,
-                            style: DefaultTextStyle.of(context).style
+                            style: style
                                 .apply(fontSizeFactor: 1.4)
                                 .copyWith(fontWeight: FontWeight.bold),
                           ),
@@ -271,9 +272,7 @@ class PlayWidget extends HookConsumerWidget {
                                     ? account
                                     : Account(host: host),
                             text: play.summary,
-                            style: DefaultTextStyle.of(
-                              context,
-                            ).style.apply(fontSizeFactor: 1.1),
+                            style: style.apply(fontSizeFactor: 1.1),
                           ),
                           const SizedBox(height: 16.0),
                           ElevatedButton(
@@ -515,9 +514,9 @@ class _Dialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final colors = ref.watch(
-      misskeyColorsProvider(Theme.of(context).brightness),
-    );
+    final theme = Theme.of(context);
+    final style = DefaultTextStyle.of(context).style;
+    final colors = ref.watch(misskeyColorsProvider(theme.brightness));
 
     return AlertDialog(
       icon: IconTheme(
@@ -552,9 +551,9 @@ class _Dialog extends ConsumerWidget {
               ? Mfm(account: account, text: title, textAlign: TextAlign.center)
               : null,
       titlePadding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 32.0),
-      titleTextStyle: DefaultTextStyle.of(
-        context,
-      ).style.apply(fontSizeFactor: 1.1).copyWith(fontWeight: FontWeight.bold),
+      titleTextStyle: style
+          .apply(fontSizeFactor: 1.1)
+          .copyWith(fontWeight: FontWeight.bold),
       content: Mfm(account: account, text: text, textAlign: TextAlign.center),
       contentPadding: const EdgeInsets.symmetric(
         vertical: 4.0,
@@ -571,8 +570,10 @@ class _Dialog extends ConsumerWidget {
                   onPressed: () => context.pop(true),
                   child: Text(t.misskey.ok),
                 ),
-                OutlinedButton(
+                ElevatedButton(
                   style: ElevatedButton.styleFrom(
+                    foregroundColor: theme.colorScheme.primary,
+                    backgroundColor: theme.colorScheme.surfaceContainerLowest,
                     minimumSize: const Size(100.0, 40.0),
                     padding: const EdgeInsets.all(8.0),
                   ),


### PR DESCRIPTION
Changed the cancel buttons of dialogs to `ElevatedButton` and made the background color different from the dialog color.

Also added icons to some dialogs without a title.

| Before | After |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/83afb1cf-9305-47d6-996e-0339136987e2) | ![image](https://github.com/user-attachments/assets/2906cfd2-4dbb-4a7a-9453-d9b54a13ee5e) |
| ![image](https://github.com/user-attachments/assets/191d00ed-d0f0-49b4-91cd-511e660249af) | ![image](https://github.com/user-attachments/assets/bb514fa4-2421-494b-8b16-cd1f93ecf19a) |