### PR TITLE
feat: add crop function for MFM

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -32,6 +32,7 @@ import 'mfm/blur.dart';
 import 'mfm/border.dart';
 import 'mfm/bounce.dart';
 import 'mfm/code.dart';
+import 'mfm/crop.dart';
 import 'mfm/jelly.dart';
 import 'mfm/jump.dart';
 import 'mfm/rainbow.dart';
@@ -1164,6 +1165,23 @@ class _Mfm extends StatelessWidget {
                 textScaler: TextScaler.noScaling,
                 maxLines: maxLines,
               ),
+            ),
+          ),
+        );
+      case 'crop':
+        return WidgetSpan(
+          alignment: children.any(_containsNewLine)
+              ? PlaceholderAlignment.bottom
+              : PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Crop(
+            args: args,
+            child: Text.rich(
+              TextSpan(children: _buildNodes(context, config, children)),
+              textAlign: config.align,
+              overflow: overflow,
+              textScaler: TextScaler.noScaling,
+              maxLines: maxLines,
             ),
           ),
         );

--- a/lib/view/widget/mfm/crop.dart
+++ b/lib/view/widget/mfm/crop.dart
@@ -1,0 +1,62 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../../../util/safe_parse_double.dart';
+
+class Crop extends StatelessWidget {
+  const Crop({super.key, required this.args, required this.child});
+
+  final Map<String, dynamic> args;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final top = safeParseDouble(args['top']) ?? 0.0;
+    final right = safeParseDouble(args['right']) ?? 0.0;
+    final bottom = safeParseDouble(args['bottom']) ?? 0.0;
+    final left = safeParseDouble(args['left']) ?? 0.0;
+
+    return ClipRect(
+      clipper: _InsetClipper(
+        left: left * 0.01,
+        top: top * 0.01,
+        right: right * 0.01,
+        bottom: bottom * 0.01,
+      ),
+      child: child,
+    );
+  }
+}
+
+class _InsetClipper extends CustomClipper<Rect> {
+  const _InsetClipper({
+    required this.left,
+    required this.top,
+    required this.right,
+    required this.bottom,
+  });
+
+  final double left;
+  final double top;
+  final double right;
+  final double bottom;
+
+  @override
+  Rect getClip(Size size) {
+    final left = size.width * this.left;
+    final top = size.height * this.top;
+    final right = size.width * (1 - this.right);
+    final bottom = size.height * (1 - this.bottom);
+
+    return Rect.fromLTRB(left, top, max(left, right), max(top, bottom));
+  }
+
+  @override
+  bool shouldReclip(_InsetClipper oldClipper) {
+    return left != oldClipper.left ||
+        top != oldClipper.top ||
+        right != oldClipper.right ||
+        bottom != oldClipper.bottom;
+  }
+}


### PR DESCRIPTION
Added support for the `crop` function for MFM.

This function is from Firefish and is not supported in Misskey Web.

ref: https://codeberg.org/firefish/firefish/src/commit/02c31e0a2804de48c9d73028df525e197d8df622/packages/client/src/components/mfm.ts#L301-L316

Fix #635