### PR TITLE
fix: collapse long code block

### DIFF
--- a/lib/provider/note_collapse_reason_provider.dart
+++ b/lib/provider/note_collapse_reason_provider.dart
@@ -22,6 +22,9 @@ enum CollapseReason { long, large }
       case MfmCodeBlock(:final code):
         length -= code.length;
         newLines -= '\n'.allMatches(code).length;
+        if (newLines < 0) {
+          return (CollapseReason.large, null);
+        }
       case MfmPlain(:final text):
         length -= text.length;
         newLines -= '\n'.allMatches(text).length;


### PR DESCRIPTION
Changed to collapse code blocks with a lot of newlines.

There is no option for `HighlightView` to limit the lines, so the whole block was displayed even if `maxLine` is specified for `Mfm`. With this change, if a code block has more newlines than the threshold, `Mfm` is clipped by height in the same manner as #623.