### PR TITLE
fix: correct parameter name for token login page

### DIFF
--- a/lib/view/page/login_page.dart
+++ b/lib/view/page/login_page.dart
@@ -109,7 +109,7 @@ class LoginPage extends HookConsumerWidget {
       );
       unawaited(ref.context.push('/login/authenticate'));
     } else {
-      unawaited(ref.context.push('/login/token?host=$trimmed'));
+      unawaited(ref.context.push('/login/token?query=$trimmed'));
     }
   }
 


### PR DESCRIPTION
Follow up for #582