### PR TITLE
refactor: use move-bulk if available

### DIFF
--- a/lib/provider/api/drive_files_notifier_provider.g.dart
+++ b/lib/provider/api/drive_files_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'drive_files_notifier_provider.dart';
 // **************************************************************************
 
 String _$driveFilesNotifierHash() =>
-    r'4a1244348b921a2e6dc58f00f0b0233157df46f2';
+    r'3153a37d26fa5103652a5cc1e39c7e556532ff1f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/widget/drive_files_sheet.dart
+++ b/lib/view/widget/drive_files_sheet.dart
@@ -33,13 +33,9 @@ class DriveFilesSheet extends ConsumerWidget {
     if (!ref.context.mounted) return;
     await futureWithDialog(
       ref.context,
-      Future.wait(
-        files.map(
-          (file) => ref
-              .read(driveFilesNotifierProvider(account, file.folderId).notifier)
-              .move(fileId: file.id, folderId: result.$1?.id),
-        ),
-      ),
+      ref
+          .read(driveFilesNotifierProvider(account, result.$1?.id).notifier)
+          .moveBulkFrom(files),
       message: t.aria.moved,
     );
     ref.read(selectedDriveFilesNotifierProvider.notifier).removeAll();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1294,8 +1294,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "3f0f4d71c1947cf42c62df6b367c08fad13a3d9f"
-      resolved-ref: "3f0f4d71c1947cf42c62df6b367c08fad13a3d9f"
+      ref: "96ef86593578327330b9c3c05f967e7a2d28b412"
+      resolved-ref: "96ef86593578327330b9c3c05f967e7a2d28b412"
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,7 +85,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: 3f0f4d71c1947cf42c62df6b367c08fad13a3d9f
+      ref: 96ef86593578327330b9c3c05f967e7a2d28b412
   multi_split_view: ^3.6.0
   package_info_plus: ^8.3.0
   path: ^1.9.1


### PR DESCRIPTION
Changed to use the `drive/files/move-bulk` endpoint for moving multiple drive files.

If the server does not support the endpoint, use the conventional approach, which calls the `drive/files/update` endpoint concurrently.

ref: `https://github.com/misskey-dev/misskey/pull/16011`