### PR TITLE
fix: truncate long user name in notification

### DIFF
--- a/lib/view/widget/notification_widget.dart
+++ b/lib/view/widget/notification_widget.dart
@@ -924,9 +924,13 @@ class _NotificationTile extends ConsumerWidget {
                                       account: account,
                                       userId: user!.id,
                                     ),
-                                    child: UsernameWidget(
-                                      account: account,
-                                      user: user!,
+                                    child: DefaultTextStyle.merge(
+                                      overflow: TextOverflow.ellipsis,
+                                      maxLines: 1,
+                                      child: UsernameWidget(
+                                        account: account,
+                                        user: user!,
+                                      ),
                                     ),
                                   )
                                 : null),


### PR DESCRIPTION
Changed to show the user name in one line in the `NotificationWidget`.