### PR TITLE
feat: add ability to configure syntax highlight

### DIFF
--- a/lib/model/misskey_theme.dart
+++ b/lib/model/misskey_theme.dart
@@ -12,6 +12,7 @@ abstract class MisskeyTheme with _$MisskeyTheme {
     String? desc,
     String? base,
     required Map<String, String> props,
+    Map<String, dynamic>? codeHighlighter,
   }) = _MisskeyTheme;
 
   factory MisskeyTheme.fromJson(Map<String, dynamic> json) =>

--- a/lib/model/misskey_theme.freezed.dart
+++ b/lib/model/misskey_theme.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MisskeyTheme {
 
- String get id; String get name; String? get author; String? get desc; String? get base; Map<String, String> get props;
+ String get id; String get name; String? get author; String? get desc; String? get base; Map<String, String> get props; Map<String, dynamic>? get codeHighlighter;
 /// Create a copy of MisskeyTheme
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $MisskeyThemeCopyWith<MisskeyTheme> get copyWith => _$MisskeyThemeCopyWithImpl<M
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyTheme&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.author, author) || other.author == author)&&(identical(other.desc, desc) || other.desc == desc)&&(identical(other.base, base) || other.base == base)&&const DeepCollectionEquality().equals(other.props, props));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MisskeyTheme&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.author, author) || other.author == author)&&(identical(other.desc, desc) || other.desc == desc)&&(identical(other.base, base) || other.base == base)&&const DeepCollectionEquality().equals(other.props, props)&&const DeepCollectionEquality().equals(other.codeHighlighter, codeHighlighter));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,author,desc,base,const DeepCollectionEquality().hash(props));
+int get hashCode => Object.hash(runtimeType,id,name,author,desc,base,const DeepCollectionEquality().hash(props),const DeepCollectionEquality().hash(codeHighlighter));
 
 @override
 String toString() {
-  return 'MisskeyTheme(id: $id, name: $name, author: $author, desc: $desc, base: $base, props: $props)';
+  return 'MisskeyTheme(id: $id, name: $name, author: $author, desc: $desc, base: $base, props: $props, codeHighlighter: $codeHighlighter)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $MisskeyThemeCopyWith<$Res>  {
   factory $MisskeyThemeCopyWith(MisskeyTheme value, $Res Function(MisskeyTheme) _then) = _$MisskeyThemeCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, String? author, String? desc, String? base, Map<String, String> props
+ String id, String name, String? author, String? desc, String? base, Map<String, String> props, Map<String, dynamic>? codeHighlighter
 });
 
 
@@ -64,7 +64,7 @@ class _$MisskeyThemeCopyWithImpl<$Res>
 
 /// Create a copy of MisskeyTheme
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? author = freezed,Object? desc = freezed,Object? base = freezed,Object? props = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? author = freezed,Object? desc = freezed,Object? base = freezed,Object? props = null,Object? codeHighlighter = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -72,7 +72,8 @@ as String,author: freezed == author ? _self.author : author // ignore: cast_null
 as String?,desc: freezed == desc ? _self.desc : desc // ignore: cast_nullable_to_non_nullable
 as String?,base: freezed == base ? _self.base : base // ignore: cast_nullable_to_non_nullable
 as String?,props: null == props ? _self.props : props // ignore: cast_nullable_to_non_nullable
-as Map<String, String>,
+as Map<String, String>,codeHighlighter: freezed == codeHighlighter ? _self.codeHighlighter : codeHighlighter // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
   ));
 }
 
@@ -83,7 +84,7 @@ as Map<String, String>,
 @JsonSerializable(createToJson: false)
 
 class _MisskeyTheme implements MisskeyTheme {
-  const _MisskeyTheme({required this.id, required this.name, this.author, this.desc, this.base, required final  Map<String, String> props}): _props = props;
+  const _MisskeyTheme({required this.id, required this.name, this.author, this.desc, this.base, required final  Map<String, String> props, final  Map<String, dynamic>? codeHighlighter}): _props = props,_codeHighlighter = codeHighlighter;
   factory _MisskeyTheme.fromJson(Map<String, dynamic> json) => _$MisskeyThemeFromJson(json);
 
 @override final  String id;
@@ -98,6 +99,15 @@ class _MisskeyTheme implements MisskeyTheme {
   return EqualUnmodifiableMapView(_props);
 }
 
+ final  Map<String, dynamic>? _codeHighlighter;
+@override Map<String, dynamic>? get codeHighlighter {
+  final value = _codeHighlighter;
+  if (value == null) return null;
+  if (_codeHighlighter is EqualUnmodifiableMapView) return _codeHighlighter;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
 
 /// Create a copy of MisskeyTheme
 /// with the given fields replaced by the non-null parameter values.
@@ -109,16 +119,16 @@ _$MisskeyThemeCopyWith<_MisskeyTheme> get copyWith => __$MisskeyThemeCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MisskeyTheme&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.author, author) || other.author == author)&&(identical(other.desc, desc) || other.desc == desc)&&(identical(other.base, base) || other.base == base)&&const DeepCollectionEquality().equals(other._props, _props));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MisskeyTheme&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.author, author) || other.author == author)&&(identical(other.desc, desc) || other.desc == desc)&&(identical(other.base, base) || other.base == base)&&const DeepCollectionEquality().equals(other._props, _props)&&const DeepCollectionEquality().equals(other._codeHighlighter, _codeHighlighter));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,author,desc,base,const DeepCollectionEquality().hash(_props));
+int get hashCode => Object.hash(runtimeType,id,name,author,desc,base,const DeepCollectionEquality().hash(_props),const DeepCollectionEquality().hash(_codeHighlighter));
 
 @override
 String toString() {
-  return 'MisskeyTheme(id: $id, name: $name, author: $author, desc: $desc, base: $base, props: $props)';
+  return 'MisskeyTheme(id: $id, name: $name, author: $author, desc: $desc, base: $base, props: $props, codeHighlighter: $codeHighlighter)';
 }
 
 
@@ -129,7 +139,7 @@ abstract mixin class _$MisskeyThemeCopyWith<$Res> implements $MisskeyThemeCopyWi
   factory _$MisskeyThemeCopyWith(_MisskeyTheme value, $Res Function(_MisskeyTheme) _then) = __$MisskeyThemeCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, String? author, String? desc, String? base, Map<String, String> props
+ String id, String name, String? author, String? desc, String? base, Map<String, String> props, Map<String, dynamic>? codeHighlighter
 });
 
 
@@ -146,7 +156,7 @@ class __$MisskeyThemeCopyWithImpl<$Res>
 
 /// Create a copy of MisskeyTheme
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? author = freezed,Object? desc = freezed,Object? base = freezed,Object? props = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? author = freezed,Object? desc = freezed,Object? base = freezed,Object? props = null,Object? codeHighlighter = freezed,}) {
   return _then(_MisskeyTheme(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -154,7 +164,8 @@ as String,author: freezed == author ? _self.author : author // ignore: cast_null
 as String?,desc: freezed == desc ? _self.desc : desc // ignore: cast_nullable_to_non_nullable
 as String?,base: freezed == base ? _self.base : base // ignore: cast_nullable_to_non_nullable
 as String?,props: null == props ? _self._props : props // ignore: cast_nullable_to_non_nullable
-as Map<String, String>,
+as Map<String, String>,codeHighlighter: freezed == codeHighlighter ? _self._codeHighlighter : codeHighlighter // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
   ));
 }
 

--- a/lib/model/misskey_theme.g.dart
+++ b/lib/model/misskey_theme.g.dart
@@ -14,4 +14,5 @@ _MisskeyTheme _$MisskeyThemeFromJson(Map<String, dynamic> json) =>
       desc: json['desc'] as String?,
       base: json['base'] as String?,
       props: Map<String, String>.from(json['props'] as Map),
+      codeHighlighter: json['codeHighlighter'] as Map<String, dynamic>?,
     );

--- a/lib/view/widget/mfm/code.dart
+++ b/lib/view/widget/mfm/code.dart
@@ -1,15 +1,23 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_highlighting/flutter_highlighting.dart';
-import 'package:flutter_highlighting/themes/atelier-cave-light.dart';
+import 'package:flutter_highlighting/theme_map.dart';
 import 'package:flutter_highlighting/themes/atom-one-dark.dart';
+import 'package:flutter_highlighting/tm_themes/theme_map.dart';
+import 'package:flutter_highlighting/tm_themes/themes/catppuccin-latte.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:highlighting/languages/all.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../constant/fonts.dart';
 import '../../../extension/text_style_extension.dart';
 import '../../../i18n/strings.g.dart';
+import '../../../provider/general_settings_notifier_provider.dart';
+import '../../../provider/misskey_themes_provider.dart';
 import '../../../util/copy_text.dart';
+import '../../../util/safe_parse_color.dart';
 
-class Code extends StatelessWidget {
+class Code extends HookConsumerWidget {
   const Code({
     super.key,
     required this.code,
@@ -26,13 +34,63 @@ class Code extends StatelessWidget {
   final bool copyOnTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final input = code.replaceAll(RegExp(r'\r?\n$'), '');
-    final languageId = allLanguages[language]?.id ?? 'javascript';
-    final theme = switch (Theme.of(context).brightness) {
-      Brightness.light => atelierCaveLightTheme,
-      Brightness.dark => atomOneDarkTheme,
-    };
+    final languageId =
+        allLanguages[language]?.id ??
+        allLanguages[allAliases[language]]?.id ??
+        'javascript';
+    final brightness = Theme.of(context).brightness;
+    final themeId = ref.watch(
+      generalSettingsNotifierProvider.select(
+        (settings) => switch (brightness) {
+          Brightness.light => settings.lightThemeId,
+          Brightness.dark => settings.darkThemeId,
+        },
+      ),
+    );
+    final codeHighlighter = ref.watch(
+      misskeyThemesProvider.select(
+        (themes) => themes
+            .firstWhereOrNull((theme) => theme?.id == themeId)
+            ?.codeHighlighter,
+      ),
+    );
+    final theme = useMemoized(() {
+      final theme = Map.of(
+        tmThemeMap[codeHighlighter?['base']] ??
+            themeMap[codeHighlighter?['base']] ??
+            switch (brightness) {
+              Brightness.light => catppuccinLatteTheme,
+              Brightness.dark => atomOneDarkTheme,
+            },
+      );
+      if (codeHighlighter?['overrides']
+          case final Map<String, dynamic> overrides) {
+        theme['root'] = (theme['root'] ?? const TextStyle()).copyWith(
+          color: safeParseColor(overrides['fg']),
+          backgroundColor: safeParseColor(overrides['bg']),
+        );
+        if (overrides['colorReplacements']
+            case final Map<String, dynamic> colorReplacements) {
+          final colors = colorReplacements.map(
+            (key, value) =>
+                MapEntry(safeParseColor(key), safeParseColor(value)),
+          )..removeWhere((key, value) => key == null || value == null);
+          for (final e in theme.entries) {
+            if (colors[e.value.color] case final color?) {
+              theme[e.key] = (theme[e.key] ?? e.value).copyWith(color: color);
+            }
+            if (colors[e.value.backgroundColor] case final backgroundColor?) {
+              theme[e.key] = (theme[e.key] ?? e.value).copyWith(
+                backgroundColor: backgroundColor,
+              );
+            }
+          }
+        }
+      }
+      return theme;
+    }, [themeId]);
 
     return Stack(
       children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -584,8 +584,8 @@ packages:
     dependency: "direct main"
     description:
       path: flutter_highlighting
-      ref: f8722192d6a92582299a8a0c3756862d31298388
-      resolved-ref: f8722192d6a92582299a8a0c3756862d31298388
+      ref: "0e214d04590ba808d49d3de5d6e1eb520fd69b8c"
+      resolved-ref: "0e214d04590ba808d49d3de5d6e1eb520fd69b8c"
       url: "https://github.com/poppingmoon/dart-highlighting"
     source: git
     version: "0.9.1+11.8.0"
@@ -957,8 +957,8 @@ packages:
     dependency: "direct main"
     description:
       path: highlighting
-      ref: "76d9f984d53de07b445965f13a5e02c3bd3ed83a"
-      resolved-ref: "76d9f984d53de07b445965f13a5e02c3bd3ed83a"
+      ref: cabd93636e331707ad6ff0f548a9c21e07b0e6c7
+      resolved-ref: cabd93636e331707ad6ff0f548a9c21e07b0e6c7
       url: "https://github.com/poppingmoon/dart-highlighting"
     source: git
     version: "0.9.1+11.8.0"
@@ -2262,4 +2262,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   flutter_highlighting:
     git:
       url: https://github.com/poppingmoon/dart-highlighting
-      ref: f8722192d6a92582299a8a0c3756862d31298388
+      ref: 0e214d04590ba808d49d3de5d6e1eb520fd69b8c
       path: flutter_highlighting
   flutter_hooks: ^0.21.2
   flutter_html: ^3.0.0
@@ -58,7 +58,7 @@ dependencies:
   highlighting:
     git:
       url: https://github.com/poppingmoon/dart-highlighting
-      ref: 76d9f984d53de07b445965f13a5e02c3bd3ed83a
+      ref: cabd93636e331707ad6ff0f548a9c21e07b0e6c7
       path: highlighting
   hooks_riverpod: ^2.6.1
   image: ^4.5.4


### PR DESCRIPTION
Added the ability to change colors in the code block.

The following settings can be configured by installing a custom theme.

```json5
{
  id: '',
  name: '',
  props: {
    // ...
  },
  codeHighlighter: {
    base: 'rose-pine-dawn', // Theme id from Shiki or Highlight.js.
    overrides: {
      fg: '#111111',        // Default foreground color.
      bg: '#ffffff',        // Background color.
      colorReplacements: {  // A map of color names to new color values.
        '#286983': '#86b300', 
      },
    },
  },
}
```

For the list of themes available in Shiki and Highlight.js, see https://shiki.style/themes#bundled-themes and https://github.com/highlightjs/highlight.js/tree/main/src/styles.