### PR TITLE
refactor: filter pagination response

### DIFF
--- a/lib/provider/api/announcements_notifier_provider.dart
+++ b/lib/provider/api/announcements_notifier_provider.dart
@@ -44,22 +44,17 @@ class AnnouncementsNotifier extends _$AnnouncementsNotifier {
     if (value.isLastLoaded) {
       return;
     }
-    bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchAnnouncements(
         untilId: value.items.lastOrNull?.id,
         offset: value.items.length,
       );
-      shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
         items: [...value.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });
-    if (shouldLoadMore) {
-      await loadMore();
-    }
   }
 
   Future<void> readAnnouncement(String announcementId) async {

--- a/lib/provider/api/announcements_notifier_provider.g.dart
+++ b/lib/provider/api/announcements_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'announcements_notifier_provider.dart';
 // **************************************************************************
 
 String _$announcementsNotifierHash() =>
-    r'9fe22e1a301df5e687f725fa7702c374e8c9c2bc';
+    r'8e24f5f4cfd7a8e9e681b8a0930bd9275892b8b7';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/attached_notes_notifier_provider.g.dart
+++ b/lib/provider/api/attached_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'attached_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$attachedNotesNotifierHash() =>
-    r'05a9598fae8a8f0b90fb0292dd49153016acaf18';
+    r'8153805bcef0d6aff4e68662ca9f72c736aa11e8';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/blockings_notifier_provider.dart
+++ b/lib/provider/api/blockings_notifier_provider.dart
@@ -21,7 +21,14 @@ class BlockingsNotifier extends _$BlockingsNotifier {
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
   Future<Iterable<Blocking>> _fetchBlockings({String? untilId}) async {
-    return await _misskey.blocking.list(BlockingListRequest(untilId: untilId));
+    final blockings = await _misskey.blocking.list(
+      BlockingListRequest(untilId: untilId),
+    );
+    if (untilId != null) {
+      return blockings.where((blocking) => blocking.id.compareTo(untilId) < 0);
+    } else {
+      return blockings;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/blockings_notifier_provider.g.dart
+++ b/lib/provider/api/blockings_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'blockings_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$blockingsNotifierHash() => r'7b434f8b5e089cf71a34f0a794df3aeec351b83a';
+String _$blockingsNotifierHash() => r'ecede0be28721cbd9a7b96099b1185b32710f447';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/chat_invitations_notifier_provider.dart
+++ b/lib/provider/api/chat_invitations_notifier_provider.dart
@@ -20,10 +20,17 @@ class ChatInvitationsNotifier extends _$ChatInvitationsNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Future<Iterable<ChatJoining>> _fetchInvitations({String? untilId}) {
-    return _misskey.chat.rooms.invitations.inbox(
+  Future<Iterable<ChatJoining>> _fetchInvitations({String? untilId}) async {
+    final invitations = await _misskey.chat.rooms.invitations.inbox(
       ChatRoomsInvitationsInboxRequest(untilId: untilId),
     );
+    if (untilId != null) {
+      return invitations.where(
+        (invitation) => invitation.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return invitations;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/chat_invitations_notifier_provider.g.dart
+++ b/lib/provider/api/chat_invitations_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_invitations_notifier_provider.dart';
 // **************************************************************************
 
 String _$chatInvitationsNotifierHash() =>
-    r'80619bda877ceb2ba187fdf580d00d557589bc15';
+    r'017908eeee8872177d0aa9aadb152aa2368cc3fb';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/chat_memberships_notifier_provider.dart
+++ b/lib/provider/api/chat_memberships_notifier_provider.dart
@@ -18,12 +18,19 @@ class ChatMembershipsNotifier extends _$ChatMembershipsNotifier {
     }
   }
 
-  Future<Iterable<ChatJoining>> _fetchMemberships({String? untilId}) {
-    return ref
+  Future<Iterable<ChatJoining>> _fetchMemberships({String? untilId}) async {
+    final memberships = await ref
         .read(misskeyProvider(account))
         .chat
         .rooms
         .joining(ChatRoomsJoiningRequest(untilId: untilId));
+    if (untilId != null) {
+      return memberships.where(
+        (membership) => membership.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return memberships;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/chat_memberships_notifier_provider.g.dart
+++ b/lib/provider/api/chat_memberships_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_memberships_notifier_provider.dart';
 // **************************************************************************
 
 String _$chatMembershipsNotifierHash() =>
-    r'91eac011998b70d1f21c880d9a41c9f0d4adc17b';
+    r'923cdcc80e956c935b55b5e56016189acc695205';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/chat_messages_notifier_provider.dart
+++ b/lib/provider/api/chat_messages_notifier_provider.dart
@@ -24,9 +24,10 @@ class ChatMessagesNotifier extends _$ChatMessagesNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Future<Iterable<ChatMessage>> _fetchMessages({String? untilId}) {
+  Future<Iterable<ChatMessage>> _fetchMessages({String? untilId}) async {
+    Iterable<ChatMessage> messages = [];
     if (userId case final userId?) {
-      return _misskey.chat.messages.userTimeline(
+      messages = await _misskey.chat.messages.userTimeline(
         ChatMessagesUserTimelineRequest(
           userId: userId,
           untilId: untilId,
@@ -35,7 +36,7 @@ class ChatMessagesNotifier extends _$ChatMessagesNotifier {
       );
     }
     if (roomId case final roomId?) {
-      return _misskey.chat.messages.roomTimeline(
+      messages = await _misskey.chat.messages.roomTimeline(
         ChatMessagesRoomTimelineRequest(
           roomId: roomId,
           untilId: untilId,
@@ -43,7 +44,11 @@ class ChatMessagesNotifier extends _$ChatMessagesNotifier {
         ),
       );
     }
-    return Future.value([]);
+    if (untilId != null) {
+      return messages.where((message) => message.id.compareTo(untilId) < 0);
+    } else {
+      return messages;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/chat_messages_notifier_provider.g.dart
+++ b/lib/provider/api/chat_messages_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_messages_notifier_provider.dart';
 // **************************************************************************
 
 String _$chatMessagesNotifierHash() =>
-    r'e1da3bffa7afc6b462d39500feb45be938d43fd9';
+    r'2bc79f966b2d8af94e89b0bf1ab04e8704f5b121';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/chat_room_invitations_notifier_provider.dart
+++ b/lib/provider/api/chat_room_invitations_notifier_provider.dart
@@ -23,14 +23,21 @@ class ChatRoomInvitationsNotifier extends _$ChatRoomInvitationsNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Future<Iterable<ChatJoining>> _fetchInvitations({String? untilId}) {
-    return _misskey.chat.rooms.invitations.outbox(
+  Future<Iterable<ChatJoining>> _fetchInvitations({String? untilId}) async {
+    final invitations = await _misskey.chat.rooms.invitations.outbox(
       ChatRoomsInvitationsOutboxRequest(
         roomId: roomId,
         untilId: untilId,
         limit: 20,
       ),
     );
+    if (untilId != null) {
+      return invitations.where(
+        (invitation) => invitation.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return invitations;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/chat_room_invitations_notifier_provider.g.dart
+++ b/lib/provider/api/chat_room_invitations_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_room_invitations_notifier_provider.dart';
 // **************************************************************************
 
 String _$chatRoomInvitationsNotifierHash() =>
-    r'78f17eb6b9a9760f0f62542a38b0ae93045e2c69';
+    r'ba24d298c29b4db0d588b417e2b3e937e53a4b1b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/chat_room_members_notifier_provider.dart
+++ b/lib/provider/api/chat_room_members_notifier_provider.dart
@@ -21,14 +21,21 @@ class ChatRoomMembersNotifier extends _$ChatRoomMembersNotifier {
     }
   }
 
-  Future<Iterable<ChatJoining>> _fetchMemberships({String? untilId}) {
-    return ref
+  Future<Iterable<ChatJoining>> _fetchMemberships({String? untilId}) async {
+    final memberships = await ref
         .read(misskeyProvider(account))
         .chat
         .rooms
         .members(
           ChatRoomsMembersRequest(roomId: roomId, untilId: untilId, limit: 20),
         );
+    if (untilId != null) {
+      return memberships.where(
+        (membership) => membership.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return memberships;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/chat_room_members_notifier_provider.g.dart
+++ b/lib/provider/api/chat_room_members_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_room_members_notifier_provider.dart';
 // **************************************************************************
 
 String _$chatRoomMembersNotifierHash() =>
-    r'c8d62c85da514869b023608bd77c5c4f1480e487';
+    r'6ced7ef1d8cbcd53ee9748d77c07a4fa33d35642';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/children_notes_notifier_provider.dart
+++ b/lib/provider/api/children_notes_notifier_provider.dart
@@ -27,7 +27,11 @@ class ChildrenNotesNotifier extends _$ChildrenNotesNotifier {
           NotesChildrenRequest(noteId: noteId, depth: 1, untilId: untilId),
         );
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/children_notes_notifier_provider.g.dart
+++ b/lib/provider/api/children_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'children_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$childrenNotesNotifierHash() =>
-    r'37a2455b97e7441dea8596704b6d540ef123e027';
+    r'2138578ca535573bd36a3dc7aaf83d07cf958e5f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/clip_notes_notifier_provider.dart
+++ b/lib/provider/api/clip_notes_notifier_provider.dart
@@ -25,7 +25,11 @@ class ClipNotesNotifier extends _$ClipNotesNotifier {
         .clips
         .notes(ClipsNotesRequest(clipId: clipId, untilId: untilId));
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/clip_notes_notifier_provider.g.dart
+++ b/lib/provider/api/clip_notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'clip_notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$clipNotesNotifierHash() => r'1464d7186ff40c8a18e9dac3d4d7f95155049ece';
+String _$clipNotesNotifierHash() => r'9f10f2f3ae18fb49d3cc032290e08ecdcf67fb31';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/drive_files_notifier_provider.dart
+++ b/lib/provider/api/drive_files_notifier_provider.dart
@@ -40,10 +40,15 @@ class DriveFilesNotifier extends _$DriveFilesNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Future<Iterable<DriveFile>> _fetchFiles({String? untilId}) {
-    return _misskey.drive.files.files(
+  Future<Iterable<DriveFile>> _fetchFiles({String? untilId}) async {
+    final files = await _misskey.drive.files.files(
       DriveFilesRequest(folderId: folderId, untilId: untilId, limit: 30),
     );
+    if (untilId != null) {
+      return files.where((file) => file.id.compareTo(untilId) < 0);
+    } else {
+      return files;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/drive_files_notifier_provider.g.dart
+++ b/lib/provider/api/drive_files_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'drive_files_notifier_provider.dart';
 // **************************************************************************
 
 String _$driveFilesNotifierHash() =>
-    r'3152302d3606625ec93a3885d26b54676415e1b4';
+    r'9bbd69500d2673d462d776cbecde49125b76880d';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/drive_folders_notifier_provider.dart
+++ b/lib/provider/api/drive_folders_notifier_provider.dart
@@ -36,11 +36,15 @@ class DriveFoldersNotifier extends _$DriveFoldersNotifier {
 
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
-  Future<List<DriveFolder>> _fetchFolders({String? untilId}) async {
-    final response = await _misskey.drive.folders.folders(
+  Future<Iterable<DriveFolder>> _fetchFolders({String? untilId}) async {
+    final folders = await _misskey.drive.folders.folders(
       DriveFoldersRequest(folderId: folderId, untilId: untilId, limit: 30),
     );
-    return response.toList();
+    if (untilId != null) {
+      return folders.where((folder) => folder.id.compareTo(untilId) < 0);
+    } else {
+      return folders;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/drive_folders_notifier_provider.g.dart
+++ b/lib/provider/api/drive_folders_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'drive_folders_notifier_provider.dart';
 // **************************************************************************
 
 String _$driveFoldersNotifierHash() =>
-    r'83bc84a3be8adf1eb3814aed5564ca6d25b9a19f';
+    r'e844cae17729755a41da6b3e2cb43a60da5123d1';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/favorites_notifier_provider.dart
+++ b/lib/provider/api/favorites_notifier_provider.dart
@@ -29,7 +29,11 @@ class FavoritesNotifier extends _$FavoritesNotifier {
     ref
         .read(notesNotifierProvider(account).notifier)
         .addAll(favorites.map((favorite) => favorite.note));
-    return favorites;
+    if (untilId != null) {
+      return favorites.where((favorite) => favorite.id.compareTo(untilId) < 0);
+    } else {
+      return favorites;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/favorites_notifier_provider.g.dart
+++ b/lib/provider/api/favorites_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'favorites_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$favoritesNotifierHash() => r'6fd50be5bb7eacd486e5ed5d0dbb345d210d77c3';
+String _$favoritesNotifierHash() => r'b8533a6cf6754608c136e11b0b1c641dc586406d';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/featured_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/featured_gallery_posts_notifier_provider.dart
@@ -36,7 +36,11 @@ class FeaturedGalleryPostsNotifier extends _$FeaturedGalleryPostsNotifier {
         .read(misskeyProvider(account))
         .gallery
         .featured(GalleryFeaturedRequest(untilId: untilId));
-    return posts;
+    if (untilId != null) {
+      return posts.where((post) => post.id.compareTo(untilId) < 0);
+    } else {
+      return posts;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/featured_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/featured_gallery_posts_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'featured_gallery_posts_notifier_provider.dart';
 // **************************************************************************
 
 String _$featuredGalleryPostsNotifierHash() =>
-    r'd9492d13baf8a01d97f3ae07ffb55119fa26823c';
+    r'41904d409482f217a44e3163ead80542d3ca3830';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/featured_notes_notifier_provider.dart
+++ b/lib/provider/api/featured_notes_notifier_provider.dart
@@ -28,7 +28,11 @@ class FeaturedNotesNotifier extends _$FeaturedNotesNotifier {
         .notes
         .featured(NotesFeaturedRequest(channelId: channelId, untilId: untilId));
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/featured_notes_notifier_provider.g.dart
+++ b/lib/provider/api/featured_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'featured_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$featuredNotesNotifierHash() =>
-    r'3fce6fd0afbdfefc67d9fbb6a4e100d713a00095';
+    r'0e63bb9be150f1ca59f840139c125d80cb58f353';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/featured_plays_notifier_provider.dart
+++ b/lib/provider/api/featured_plays_notifier_provider.dart
@@ -33,7 +33,6 @@ class FeaturedPlaysNotifier extends _$FeaturedPlaysNotifier {
     if (value.isLastLoaded) {
       return;
     }
-    bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchPlays(offset: value.items.length);
@@ -42,15 +41,11 @@ class FeaturedPlaysNotifier extends _$FeaturedPlaysNotifier {
         // until Misskey 2024.10.0.
         return value.copyWith(isLastLoaded: true);
       } else {
-        shouldLoadMore = response.isNotEmpty && response.length < 5;
         return PaginationState(
           items: [...value.items, ...response],
           isLastLoaded: response.isEmpty,
         );
       }
     });
-    if (shouldLoadMore) {
-      await loadMore();
-    }
   }
 }

--- a/lib/provider/api/featured_plays_notifier_provider.g.dart
+++ b/lib/provider/api/featured_plays_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'featured_plays_notifier_provider.dart';
 // **************************************************************************
 
 String _$featuredPlaysNotifierHash() =>
-    r'cd1acc00bf575c349e58fe4e0e2afbe948e60114';
+    r'1dc000748e7c9fee6463552174ef62b7abdcc942';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/featured_polls_notifier_provider.dart
+++ b/lib/provider/api/featured_polls_notifier_provider.dart
@@ -40,18 +40,13 @@ class FeaturedPollsNotifier extends _$FeaturedPollsNotifier {
     if (value.isLastLoaded) {
       return;
     }
-    bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchNotes(offset: value.items.length);
-      shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
         items: [...value.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });
-    if (shouldLoadMore) {
-      await loadMore();
-    }
   }
 }

--- a/lib/provider/api/featured_polls_notifier_provider.g.dart
+++ b/lib/provider/api/featured_polls_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'featured_polls_notifier_provider.dart';
 // **************************************************************************
 
 String _$featuredPollsNotifierHash() =>
-    r'ccc761d8a7bd02bb1a513bb2e76bc48dc87111ab';
+    r'daf0d0cf4a58398f3a652b7d138acb33b115cb20';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/follow_requests_notifier_provider.dart
+++ b/lib/provider/api/follow_requests_notifier_provider.dart
@@ -24,7 +24,11 @@ class FollowRequestsNotifier extends _$FollowRequestsNotifier {
     final requests = await _misskey.following.requests.list(
       FollowingRequestsListRequest(untilId: untilId),
     );
-    return requests;
+    if (untilId != null) {
+      return requests.where((request) => request.id.compareTo(untilId) < 0);
+    } else {
+      return requests;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/follow_requests_notifier_provider.g.dart
+++ b/lib/provider/api/follow_requests_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'follow_requests_notifier_provider.dart';
 // **************************************************************************
 
 String _$followRequestsNotifierHash() =>
-    r'ab11bba240369467da78cfa4922f2710ff54c10c';
+    r'980c6d1b2200012b988cff1fff2023a33260f0a9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/following_channels_notifier_provider.dart
+++ b/lib/provider/api/following_channels_notifier_provider.dart
@@ -23,7 +23,11 @@ class FollowingChannelsNotifier extends _$FollowingChannelsNotifier {
         .read(misskeyProvider(account))
         .channels
         .followed(ChannelsFollowedRequest(untilId: untilId));
-    return channels;
+    if (untilId != null) {
+      return channels.where((channel) => channel.id.compareTo(untilId) < 0);
+    } else {
+      return channels;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/following_channels_notifier_provider.g.dart
+++ b/lib/provider/api/following_channels_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'following_channels_notifier_provider.dart';
 // **************************************************************************
 
 String _$followingChannelsNotifierHash() =>
-    r'37bf1de0aa0a402f017b39ac8286258a15420493';
+    r'72ebaa497f627bf8ac026b315ae60214d5a882e9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/gallery_posts_notifier_provider.dart
@@ -37,7 +37,11 @@ class GalleryPostsNotifier extends _$GalleryPostsNotifier {
         .gallery
         .posts
         .posts(GalleryPostsRequest(untilId: untilId));
-    return posts;
+    if (untilId != null) {
+      return posts.where((post) => post.id.compareTo(untilId) < 0);
+    } else {
+      return posts;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/gallery_posts_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'gallery_posts_notifier_provider.dart';
 // **************************************************************************
 
 String _$galleryPostsNotifierHash() =>
-    r'55c39a61d69d1f2fbc0327f8ac88e7823bef9acd';
+    r'ebe3b5c4bb4147b1df11926f3c29fe3e9ea81c35';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/liked_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/liked_gallery_posts_notifier_provider.dart
@@ -37,7 +37,11 @@ class LikedGalleryPostsNotifier extends _$LikedGalleryPostsNotifier {
         .i
         .gallery
         .likes(IGalleryLikesRequest(untilId: untilId));
-    return posts;
+    if (untilId != null) {
+      return posts.where((post) => post.id.compareTo(untilId) < 0);
+    } else {
+      return posts;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/liked_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/liked_gallery_posts_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'liked_gallery_posts_notifier_provider.dart';
 // **************************************************************************
 
 String _$likedGalleryPostsNotifierHash() =>
-    r'd0a141660ebfba6c2a67de8d6aec5e392e8c3662';
+    r'6084d8ffb97e7879bb3390e6f87a7e8a23f27982';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/liked_pages_notifier_provider.dart
+++ b/lib/provider/api/liked_pages_notifier_provider.dart
@@ -18,11 +18,16 @@ class LikedPagesNotifier extends _$LikedPagesNotifier {
     }
   }
 
-  Future<Iterable<IPageLikesResponse>> _fetchPages({String? untilId}) {
-    return ref
+  Future<Iterable<IPageLikesResponse>> _fetchPages({String? untilId}) async {
+    final pages = await ref
         .read(misskeyProvider(account))
         .i
         .pageLikes(IPageLikesRequest(untilId: untilId));
+    if (untilId != null) {
+      return pages.where((page) => page.id.compareTo(untilId) < 0);
+    } else {
+      return pages;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/liked_pages_notifier_provider.g.dart
+++ b/lib/provider/api/liked_pages_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'liked_pages_notifier_provider.dart';
 // **************************************************************************
 
 String _$likedPagesNotifierHash() =>
-    r'a3f141dee262d19f4c339818503a512c4b76abde';
+    r'bfcfad309a7f34b0ed6392280c50d1e537360905';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/liked_plays_notifier_provider.dart
+++ b/lib/provider/api/liked_plays_notifier_provider.dart
@@ -18,11 +18,16 @@ class LikedPlaysNotifier extends _$LikedPlaysNotifier {
     }
   }
 
-  Future<Iterable<FlashMyLikesResponse>> _fetchPlays({String? untilId}) {
-    return ref
+  Future<Iterable<FlashMyLikesResponse>> _fetchPlays({String? untilId}) async {
+    final plays = await ref
         .read(misskeyProvider(account))
         .flash
         .myLikes(FlashMyLikesRequest(untilId: untilId));
+    if (untilId != null) {
+      return plays.where((play) => play.id.compareTo(untilId) < 0);
+    } else {
+      return plays;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/liked_plays_notifier_provider.g.dart
+++ b/lib/provider/api/liked_plays_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'liked_plays_notifier_provider.dart';
 // **************************************************************************
 
 String _$likedPlaysNotifierHash() =>
-    r'4a012e0e18eb1724fe32c68095e4481d4d2e9c9f';
+    r'e412312e388b27142bdd6a53b2ceb97e3a29fdef';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/mutings_notifier_provider.dart
+++ b/lib/provider/api/mutings_notifier_provider.dart
@@ -21,7 +21,12 @@ class MutingsNotifier extends _$MutingsNotifier {
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
   Future<Iterable<Muting>> _fetchMutings({String? untilId}) async {
-    return await _misskey.mute.list(MuteListRequest(untilId: untilId));
+    final mutings = await _misskey.mute.list(MuteListRequest(untilId: untilId));
+    if (untilId != null) {
+      return mutings.where((muting) => muting.id.compareTo(untilId) < 0);
+    } else {
+      return mutings;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/mutings_notifier_provider.g.dart
+++ b/lib/provider/api/mutings_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'mutings_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$mutingsNotifierHash() => r'5a178415cadf778585573ee220ae7307ac245115';
+String _$mutingsNotifierHash() => r'8823083a289421c8373b8210eec9555a8c417d8b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/my_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/my_gallery_posts_notifier_provider.dart
@@ -37,7 +37,11 @@ class MyGalleryPostsNotifier extends _$MyGalleryPostsNotifier {
     final posts = await _misskey.i.gallery.posts(
       IGalleryPostsRequest(limit: 100, untilId: untilId),
     );
-    return posts;
+    if (untilId != null) {
+      return posts.where((post) => post.id.compareTo(untilId) < 0);
+    } else {
+      return posts;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/my_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/my_gallery_posts_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'my_gallery_posts_notifier_provider.dart';
 // **************************************************************************
 
 String _$myGalleryPostsNotifierHash() =>
-    r'5936f4760cc284edfaef4ed386bda9561dcadc33';
+    r'c4752462097ee3233a03eab520f0995a02f6afb4';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/notes_after_renotes_notifier_provider.dart
+++ b/lib/provider/api/notes_after_renotes_notifier_provider.dart
@@ -27,13 +27,18 @@ class NotesAfterRenotesNotifier extends _$NotesAfterRenotesNotifier {
   String? _untilId;
 
   Future<Iterable<Note>> _fetchRenotes() async {
+    final untilId = _untilId;
     final notes = await ref
         .read(misskeyProvider(account))
         .notes
-        .renotes(NotesRenoteRequest(noteId: noteId, untilId: _untilId));
+        .renotes(NotesRenoteRequest(noteId: noteId, untilId: untilId));
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
     _untilId = notes.lastOrNull?.id;
-    return notes;
+    if (untilId != null) {
+      return notes.where((post) => post.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<Note?> _fetchNote(Note renote) async {

--- a/lib/provider/api/notes_after_renotes_notifier_provider.g.dart
+++ b/lib/provider/api/notes_after_renotes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'notes_after_renotes_notifier_provider.dart';
 // **************************************************************************
 
 String _$notesAfterRenotesNotifierHash() =>
-    r'efc284c1f1a213389df352a48c5f6261bca08dcb';
+    r'e02d55f4ba7cc91418a176268eddf7452bf8f2b8';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/notifications_notifier_provider.dart
+++ b/lib/provider/api/notifications_notifier_provider.dart
@@ -162,7 +162,13 @@ class NotificationsNotifier extends _$NotificationsNotifier {
         .addAll(
           notifications.map((notification) => notification.note).nonNulls,
         );
-    return notifications.where((notification) => notification.id != untilId);
+    if (untilId != null) {
+      return notifications.where(
+        (notification) => notification.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return notifications;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/notifications_notifier_provider.g.dart
+++ b/lib/provider/api/notifications_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'notifications_notifier_provider.dart';
 // **************************************************************************
 
 String _$notificationsNotifierHash() =>
-    r'5f02d7d2dfc63128a6619f918408cc9eabd9d827';
+    r'7861b4868aeb052d24ef5a5be50cfc66071b8df1';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/owned_channels_notifier_provider.dart
+++ b/lib/provider/api/owned_channels_notifier_provider.dart
@@ -23,7 +23,11 @@ class OwnedChannelsNotifier extends _$OwnedChannelsNotifier {
         .read(misskeyProvider(account))
         .channels
         .owned(ChannelsOwnedRequest(untilId: untilId));
-    return channels;
+    if (untilId != null) {
+      return channels.where((channel) => channel.id.compareTo(untilId) < 0);
+    } else {
+      return channels;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/owned_channels_notifier_provider.g.dart
+++ b/lib/provider/api/owned_channels_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'owned_channels_notifier_provider.dart';
 // **************************************************************************
 
 String _$ownedChannelsNotifierHash() =>
-    r'5b038f996c44a68c4cb3591c44cf98b90d7dbc83';
+    r'cd0113b6070da55811e54a9aa2b1440b8cebd8b6';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/owned_chat_rooms_notifier_provider.dart
+++ b/lib/provider/api/owned_chat_rooms_notifier_provider.dart
@@ -18,12 +18,17 @@ class OwnedChatRoomsNotifier extends _$OwnedChatRoomsNotifier {
     }
   }
 
-  Future<Iterable<ChatRoom>> _fetchRooms({String? untilId}) {
-    return ref
+  Future<Iterable<ChatRoom>> _fetchRooms({String? untilId}) async {
+    final rooms = await ref
         .read(misskeyProvider(account))
         .chat
         .rooms
         .owned(ChatRoomsOwnedRequest(untilId: untilId));
+    if (untilId != null) {
+      return rooms.where((room) => room.id.compareTo(untilId) < 0);
+    } else {
+      return rooms;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/owned_chat_rooms_notifier_provider.g.dart
+++ b/lib/provider/api/owned_chat_rooms_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'owned_chat_rooms_notifier_provider.dart';
 // **************************************************************************
 
 String _$ownedChatRoomsNotifierHash() =>
-    r'f18a82e9cf9131e807455a53b3245e64a9493436';
+    r'b090a8404f77cb1680a0f5de2098ff98b69dcd1e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/pages_notifier_provider.dart
+++ b/lib/provider/api/pages_notifier_provider.dart
@@ -23,7 +23,11 @@ class PagesNotifier extends _$PagesNotifier {
         .read(misskeyProvider(account))
         .i
         .pages(IPagesRequest(untilId: untilId));
-    return pages;
+    if (untilId != null) {
+      return pages.where((page) => page.id.compareTo(untilId) < 0);
+    } else {
+      return pages;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/pages_notifier_provider.g.dart
+++ b/lib/provider/api/pages_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'pages_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$pagesNotifierHash() => r'6ff454e674b794fb243ad58c506a54abaced7259';
+String _$pagesNotifierHash() => r'05a5931a27cf21ab6e367c5698902830f45a3066';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/plays_notifier_provider.dart
+++ b/lib/provider/api/plays_notifier_provider.dart
@@ -23,7 +23,11 @@ class PlaysNotifier extends _$PlaysNotifier {
         .read(misskeyProvider(account))
         .flash
         .my(FlashMyRequest(untilId: untilId));
-    return plays;
+    if (untilId != null) {
+      return plays.where((play) => play.id.compareTo(untilId) < 0);
+    } else {
+      return plays;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/plays_notifier_provider.g.dart
+++ b/lib/provider/api/plays_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'plays_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$playsNotifierHash() => r'f02154d1c6cc58b51b18422d28bb120fa5232b92';
+String _$playsNotifierHash() => r'df062927540cc28111dd6335a3f3a894119007af';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/reactions_notifier_provider.dart
+++ b/lib/provider/api/reactions_notifier_provider.dart
@@ -22,8 +22,10 @@ class ReactionsNotifier extends _$ReactionsNotifier {
     }
   }
 
-  Future<Iterable<NotesReactionsResponse>> _fetchReactions({String? untilId}) {
-    return ref
+  Future<Iterable<NotesReactionsResponse>> _fetchReactions({
+    String? untilId,
+  }) async {
+    final reactions = await ref
         .read(misskeyProvider(account))
         .notes
         .reactions
@@ -35,6 +37,11 @@ class ReactionsNotifier extends _$ReactionsNotifier {
             limit: 20,
           ),
         );
+    if (untilId != null) {
+      return reactions.where((reaction) => reaction.id.compareTo(untilId) < 0);
+    } else {
+      return reactions;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/reactions_notifier_provider.g.dart
+++ b/lib/provider/api/reactions_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'reactions_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$reactionsNotifierHash() => r'1f70e350b36096e60e0d6d5133efff6bfc8e71db';
+String _$reactionsNotifierHash() => r'62aa3850df4059c9edbb14e69f2f9fb40484f01e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/renote_mutings_notifier_provider.dart
+++ b/lib/provider/api/renote_mutings_notifier_provider.dart
@@ -21,10 +21,17 @@ class RenoteMutingsNotifier extends _$RenoteMutingsNotifier {
   Misskey get _misskey => ref.read(misskeyProvider(account));
 
   Future<Iterable<RenoteMuting>> _fetchRenoteMutings({String? untilId}) async {
-    return await ref
+    final renoteMutings = await ref
         .read(misskeyProvider(account))
         .renoteMute
         .list(RenoteMuteListRequest(untilId: untilId));
+    if (untilId != null) {
+      return renoteMutings.where(
+        (renoteMuting) => renoteMuting.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return renoteMutings;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/renote_mutings_notifier_provider.g.dart
+++ b/lib/provider/api/renote_mutings_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'renote_mutings_notifier_provider.dart';
 // **************************************************************************
 
 String _$renoteMutingsNotifierHash() =>
-    r'126c882bbf5bf8902200669b33fe8f8aefd7f717';
+    r'370dc2e750e9af580b7a2a26e01ccd621a410dc1';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/renotes_notifier_provider.dart
+++ b/lib/provider/api/renotes_notifier_provider.dart
@@ -29,7 +29,11 @@ class RenotesNotifier extends _$RenotesNotifier {
           NotesRenoteRequest(noteId: noteId, untilId: untilId, limit: 20),
         );
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/renotes_notifier_provider.g.dart
+++ b/lib/provider/api/renotes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'renotes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$renotesNotifierHash() => r'1e28ba79b23698961b5d0ca11daeace007561782';
+String _$renotesNotifierHash() => r'393beca83a9173756ea293f9eefaf5805b17b3fe';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/role_users_notifier_provider.dart
+++ b/lib/provider/api/role_users_notifier_provider.dart
@@ -21,11 +21,16 @@ class RoleUsersNotifier extends _$RoleUsersNotifier {
     }
   }
 
-  Future<Iterable<RolesUsersResponse>> _fetchUsers({String? untilId}) {
-    return ref
+  Future<Iterable<RolesUsersResponse>> _fetchUsers({String? untilId}) async {
+    final users = await ref
         .read(misskeyProvider(account))
         .roles
         .users(RolesUsersRequest(roleId: roleId, untilId: untilId));
+    if (untilId != null) {
+      return users.where((user) => user.id.compareTo(untilId) < 0);
+    } else {
+      return users;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/role_users_notifier_provider.g.dart
+++ b/lib/provider/api/role_users_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'role_users_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$roleUsersNotifierHash() => r'51c3f9d3b0b4b5f656629c9917b23e362e833ad3';
+String _$roleUsersNotifierHash() => r'40ca4fc4c2b261bc67a90f6f33e82e3f498466ab';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/scheduled_notes_notifier_provider.dart
+++ b/lib/provider/api/scheduled_notes_notifier_provider.dart
@@ -105,22 +105,17 @@ class ScheduledNotesNotifier extends _$ScheduledNotesNotifier {
     if (value.isLastLoaded) {
       return;
     }
-    bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchNotes(
         untilId: value.items.lastOrNull?.id,
         offset: value.items.length,
       );
-      shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
         items: [...value.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });
-    if (shouldLoadMore) {
-      await loadMore();
-    }
   }
 
   Future<void> cancel(String noteId) async {

--- a/lib/provider/api/scheduled_notes_notifier_provider.g.dart
+++ b/lib/provider/api/scheduled_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'scheduled_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$scheduledNotesNotifierHash() =>
-    r'81fb9163fa85d1a694cde4deeaa89e6070465765';
+    r'b15761fbe0a24f5a403fbf7852d7dba2de226559';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/search_channels_notifier_provider.dart
+++ b/lib/provider/api/search_channels_notifier_provider.dart
@@ -35,7 +35,11 @@ class SearchChannelsNotifier extends _$SearchChannelsNotifier {
             untilId: untilId,
           ),
         );
-    return channels;
+    if (untilId != null) {
+      return channels.where((channel) => channel.id.compareTo(untilId) < 0);
+    } else {
+      return channels;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/search_channels_notifier_provider.g.dart
+++ b/lib/provider/api/search_channels_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'search_channels_notifier_provider.dart';
 // **************************************************************************
 
 String _$searchChannelsNotifierHash() =>
-    r'a55746109ac5b62aee0f55e499ae0c872309add7';
+    r'41044bf6ed530505db087e4dea7984a23d1927c4';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/search_notes_notifier_provider.dart
+++ b/lib/provider/api/search_notes_notifier_provider.dart
@@ -55,7 +55,11 @@ class SearchNotesNotifier extends _$SearchNotesNotifier {
           ),
         );
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/search_notes_notifier_provider.g.dart
+++ b/lib/provider/api/search_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'search_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$searchNotesNotifierHash() =>
-    r'b74e64d9f6dcff92572b71ee8658f4490b07d459';
+    r'778e8d621b5a6af8b02f3e425b7c44be22bd50a9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/search_users_notifier_provider.dart
+++ b/lib/provider/api/search_users_notifier_provider.dart
@@ -53,18 +53,13 @@ class SearchUsersNotifier extends _$SearchUsersNotifier {
     if (value.isLastLoaded) {
       return;
     }
-    bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchUsers(offset: value.items.length);
-      shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
         items: [...value.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });
-    if (shouldLoadMore) {
-      await loadMore();
-    }
   }
 }

--- a/lib/provider/api/search_users_notifier_provider.g.dart
+++ b/lib/provider/api/search_users_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'search_users_notifier_provider.dart';
 // **************************************************************************
 
 String _$searchUsersNotifierHash() =>
-    r'cf3b8a789b2b292f6237473713e0db80777cc75e';
+    r'5ce185ef378356d401eb4e4850314601425f44ba';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/tag_notes_notifier_provider.dart
+++ b/lib/provider/api/tag_notes_notifier_provider.dart
@@ -32,7 +32,11 @@ class TagNotesNotifier extends _$TagNotesNotifier {
           NotesSearchByTagRequest(tag: tag, sinceId: sinceId, untilId: untilId),
         );
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/tag_notes_notifier_provider.g.dart
+++ b/lib/provider/api/tag_notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'tag_notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$tagNotesNotifierHash() => r'ab10969bce3eb3c18d328189bbbba609b830023c';
+String _$tagNotesNotifierHash() => r'97d89575f256d3a2de787e7168c95ad9d417e27e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
@@ -166,7 +166,10 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
       TabType.custom => _fetchNotesFromCustomTimeline(sinceId),
     };
     ref.read(notesNotifierProvider(tabSettings.account).notifier).addAll(notes);
-    return notes.sortedBy((note) => note.id).reversed;
+    return (sinceId != null
+            ? notes.where((note) => sinceId.compareTo(note.id) < 0)
+            : notes)
+        .sortedByCompare((note) => note.id, (a, b) => b.compareTo(a));
   }
 
   Future<Iterable<Note>> _fetchNotesEagerly(String sinceId) async {
@@ -192,7 +195,7 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
         _duration ~/= 2;
       }
       if (notes.isNotEmpty) {
-        return notes;
+        return notes.where((note) => sinceId.compareTo(note.id) < 0);
       } else {
         sinceDate = untilDate;
       }

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_notes_after_note_notifier_provider.dart';
 // **************************************************************************
 
 String _$timelineNotesAfterNoteNotifierHash() =>
-    r'f3e31698bc2936f39671e16f5bcf2e34dd333057';
+    r'665aa8c0b115f37dac4b90dde60be83267b9b3ee';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/timeline_notes_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_notifier_provider.dart
@@ -149,7 +149,11 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.custom => _fetchNotesFromCustomTimeline(untilId: untilId),
     };
     ref.read(notesNotifierProvider(tabSettings.account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/timeline_notes_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'timeline_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$timelineNotesNotifierHash() =>
-    r'c2c1510678e2fc6c9575d96f89052e1f495a4bf0';
+    r'09c4e69f9751949249ea7e3d81a5ad2c35d9aa2c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_clips_notifier_provider.dart
+++ b/lib/provider/api/user_clips_notifier_provider.dart
@@ -31,11 +31,16 @@ class UserClipsNotifier extends _$UserClipsNotifier {
     }
   }
 
-  Future<Iterable<Clip>> _fetchClips({String? untilId}) {
-    return ref
+  Future<Iterable<Clip>> _fetchClips({String? untilId}) async {
+    final clips = await ref
         .read(misskeyProvider(account))
         .users
         .clips(UsersClipsRequest(userId: userId, untilId: untilId));
+    if (untilId != null) {
+      return clips.where((clip) => clip.id.compareTo(untilId) < 0);
+    } else {
+      return clips;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_clips_notifier_provider.g.dart
+++ b/lib/provider/api/user_clips_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'user_clips_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userClipsNotifierHash() => r'ac4b328367a1f90db2d6830c5c9b7de2f27644c3';
+String _$userClipsNotifierHash() => r'85322d93ecf1fb1f5b434a89cc7a051cd913805d';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_featured_notes_notifier_provider.dart
+++ b/lib/provider/api/user_featured_notes_notifier_provider.dart
@@ -27,7 +27,11 @@ class UserFeaturedNotesNotifier extends _$UserFeaturedNotesNotifier {
           UsersFeaturedNotesRequest(userId: userId, untilId: untilId),
         );
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_featured_notes_notifier_provider.g.dart
+++ b/lib/provider/api/user_featured_notes_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'user_featured_notes_notifier_provider.dart';
 // **************************************************************************
 
 String _$userFeaturedNotesNotifierHash() =>
-    r'da412a0c68d28d36460d4cae615b408e42549703';
+    r'fe22f68baa52802d07c744f1f61f1925c500efa9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_followers_notifier_provider.dart
+++ b/lib/provider/api/user_followers_notifier_provider.dart
@@ -21,11 +21,16 @@ class UserFollowersNotifier extends _$UserFollowersNotifier {
     }
   }
 
-  Future<Iterable<Following>> _fetchFollowers({String? untilId}) {
-    return ref
+  Future<Iterable<Following>> _fetchFollowers({String? untilId}) async {
+    final followers = await ref
         .read(misskeyProvider(account))
         .users
         .followers(UsersFollowersRequest(userId: userId, untilId: untilId));
+    if (untilId != null) {
+      return followers.where((follower) => follower.id.compareTo(untilId) < 0);
+    } else {
+      return followers;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_followers_notifier_provider.g.dart
+++ b/lib/provider/api/user_followers_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'user_followers_notifier_provider.dart';
 // **************************************************************************
 
 String _$userFollowersNotifierHash() =>
-    r'f138457be065a165fc35355cdae1386b1e33c5f7';
+    r'a51bbcd36e54b5c88667d87c63a332454b00bbf4';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_following_notifier_provider.dart
+++ b/lib/provider/api/user_following_notifier_provider.dart
@@ -21,11 +21,18 @@ class UserFollowingNotifier extends _$UserFollowingNotifier {
     }
   }
 
-  Future<Iterable<Following>> _fetchFollowing({String? untilId}) {
-    return ref
+  Future<Iterable<Following>> _fetchFollowing({String? untilId}) async {
+    final followings = await ref
         .read(misskeyProvider(account))
         .users
         .following(UsersFollowingRequest(userId: userId, untilId: untilId));
+    if (untilId != null) {
+      return followings.where(
+        (following) => following.id.compareTo(untilId) < 0,
+      );
+    } else {
+      return followings;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_following_notifier_provider.g.dart
+++ b/lib/provider/api/user_following_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'user_following_notifier_provider.dart';
 // **************************************************************************
 
 String _$userFollowingNotifierHash() =>
-    r'cad76cb296765c5e1c175ed9832cf345f57a5a60';
+    r'262c3f53d047c2184dad660bd06f78072df028ac';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/user_gallery_posts_notifier_provider.dart
@@ -40,7 +40,11 @@ class UserGalleryPostsNotifier extends _$UserGalleryPostsNotifier {
         .users
         .gallery
         .posts(UsersGalleryPostsRequest(userId: userId, untilId: untilId));
-    return posts;
+    if (untilId != null) {
+      return posts.where((post) => post.id.compareTo(untilId) < 0);
+    } else {
+      return posts;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/user_gallery_posts_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'user_gallery_posts_notifier_provider.dart';
 // **************************************************************************
 
 String _$userGalleryPostsNotifierHash() =>
-    r'33de368cc73097706dd882275463ab2a64f10780';
+    r'44e6554068d27d478041c1f43dca8c3a4299ea4a';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_pages_notifier_provider.dart
+++ b/lib/provider/api/user_pages_notifier_provider.dart
@@ -31,11 +31,16 @@ class UserPagesNotifier extends _$UserPagesNotifier {
     }
   }
 
-  Future<Iterable<Page>> _fetchPages({String? untilId}) {
-    return ref
+  Future<Iterable<Page>> _fetchPages({String? untilId}) async {
+    final pages = await ref
         .read(misskeyProvider(account))
         .users
         .pages(UsersPagesRequest(userId: userId, untilId: untilId));
+    if (untilId != null) {
+      return pages.where((page) => page.id.compareTo(untilId) < 0);
+    } else {
+      return pages;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_pages_notifier_provider.g.dart
+++ b/lib/provider/api/user_pages_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'user_pages_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userPagesNotifierHash() => r'04501d3b9903d6d1b459e048b7490e3b3ae46758';
+String _$userPagesNotifierHash() => r'63981b92124f16e1dcca0d676ef5735e4ca8fce5';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_plays_notifier_provider.dart
+++ b/lib/provider/api/user_plays_notifier_provider.dart
@@ -31,11 +31,16 @@ class UserPlaysNotifier extends _$UserPlaysNotifier {
     }
   }
 
-  Future<Iterable<Flash>> _fetchPlays({String? untilId}) {
-    return ref
+  Future<Iterable<Flash>> _fetchPlays({String? untilId}) async {
+    final plays = await ref
         .read(misskeyProvider(account))
         .users
         .flashs(UsersFlashsRequest(userId: userId, untilId: untilId));
+    if (untilId != null) {
+      return plays.where((play) => play.id.compareTo(untilId) < 0);
+    } else {
+      return plays;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_plays_notifier_provider.g.dart
+++ b/lib/provider/api/user_plays_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'user_plays_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userPlaysNotifierHash() => r'106a3c576cc3456df0acdd90c46b326bd1289db1';
+String _$userPlaysNotifierHash() => r'76944d61597898d3499b3c3c521a025c03fe1d66';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/user_reactions_notifier_provider.dart
+++ b/lib/provider/api/user_reactions_notifier_provider.dart
@@ -44,7 +44,11 @@ class UserReactionsNotifier extends _$UserReactionsNotifier {
         .reactions(UsersReactionsRequest(userId: userId, untilId: untilId));
     final notes = reactions.map((reaction) => reaction.note);
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return reactions;
+    if (untilId != null) {
+      return reactions.where((reaction) => reaction.id.compareTo(untilId) < 0);
+    } else {
+      return reactions;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/api/user_reactions_notifier_provider.g.dart
+++ b/lib/provider/api/user_reactions_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'user_reactions_notifier_provider.dart';
 // **************************************************************************
 
 String _$userReactionsNotifierHash() =>
-    r'a2bf8dee78f8eed0871734db8d4395b4278518a0';
+    r'a80f1c0d1abd3c6e2e423237c41cb6d25279fa89';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/api/users_notifier_provider.dart
+++ b/lib/provider/api/users_notifier_provider.dart
@@ -45,18 +45,13 @@ class UsersNotifier extends _$UsersNotifier {
     if (value.isLastLoaded) {
       return;
     }
-    bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchUsers(offset: value.items.length);
-      shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
         items: [...value.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });
-    if (shouldLoadMore) {
-      await loadMore();
-    }
   }
 }

--- a/lib/provider/api/users_notifier_provider.g.dart
+++ b/lib/provider/api/users_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'users_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$usersNotifierHash() => r'599ab1f8c17f08eab04e6888b284fc5982a21ecf';
+String _$usersNotifierHash() => r'e054ad084a328b8dea2b770e85737649c6c1cfa9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/provider/mentions_notifier_provider.dart
+++ b/lib/provider/mentions_notifier_provider.dart
@@ -33,7 +33,11 @@ class MentionsNotifier extends _$MentionsNotifier {
           ),
         );
     ref.read(notesNotifierProvider(account).notifier).addAll(notes);
-    return notes;
+    if (untilId != null) {
+      return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else {
+      return notes;
+    }
   }
 
   Future<void> loadMore({bool skipError = false}) async {

--- a/lib/provider/mentions_notifier_provider.g.dart
+++ b/lib/provider/mentions_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'mentions_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$mentionsNotifierHash() => r'df29b48deacd4dd5beec274c568c80cd807c4a18';
+String _$mentionsNotifierHash() => r'0b66641d0a1f86c1bfcec3756b5ce8053ffd7d8b';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
For pagination endpoints, added a check to ensure the response id is less than the provided `untilId`.