### PR TITLE
fix: use emoji picker for reaction in note action

### DIFF
--- a/lib/util/get_note_action.dart
+++ b/lib/util/get_note_action.dart
@@ -44,8 +44,8 @@ void Function()? getNoteAction(
                   : await pickEmoji(
                       ref,
                       account,
-                      saveHistory: false,
-                      confirmBeforePop: true,
+                      reaction: true,
+                      targetNote: appearNote,
                     );
               if (!ref.context.mounted) return;
               if (emoji != null) {


### PR DESCRIPTION
Fixed an issue where an emoji picker opened from a note action displays the general emoji picker and shows a confirmation when a user taps an emoji.