### PR TITLE
fix: convert api error in AiScript to json

### DIFF
--- a/lib/util/create_aiscript.dart
+++ b/lib/util/create_aiscript.dart
@@ -94,7 +94,7 @@ Future<AiScript> createAiScript(
           final response = await misskey.apiService.post<dynamic>(
             ep,
             json is Map<String, dynamic> ? json : {},
-            excludeRemoveNullPredicate: (_, _) => true,
+            excludeRemoveNullPredicate: (key, _) => key != 'i',
           );
           return (jsonEncode(response), null);
         } on MisskeyException catch (e) {
@@ -105,7 +105,7 @@ Future<AiScript> createAiScript(
               final response = await misskey.apiService.post<dynamic>(
                 ep,
                 json is Map<String, dynamic> ? json : {},
-                excludeRemoveNullPredicate: (_, _) => true,
+                excludeRemoveNullPredicate: (key, _) => key != 'i',
               );
               return (jsonEncode(response), null);
             } catch (e) {

--- a/rust/src/api/aiscript/api.rs
+++ b/rust/src/api/aiscript/api.rs
@@ -239,7 +239,10 @@ impl AsApiLib {
                         Ok(Value::new(if let Some(err) = &result.1 {
                             V::Error {
                                 value: "request_failed".to_string(),
-                                info: Some(Value::str(err).into()),
+                                info: serde_json::from_str(&err)
+                                    .ok()
+                                    .map(Value::new)
+                                    .map(Into::into),
                             }
                         } else {
                             serde_json::from_str(&result.0).unwrap_or_default()


### PR DESCRIPTION
Changed the `info` parameter of the error value returned by `Mk:api` to have the type object instead of a string.