### PR TITLE
fix: prevent removal of replies and renotes when they are cached

### DIFF
--- a/lib/provider/notes_notifier_provider.dart
+++ b/lib/provider/notes_notifier_provider.dart
@@ -24,12 +24,16 @@ class NotesNotifier extends _$NotesNotifier {
     if (note.renote case final renote?) {
       add(renote);
     } else if (note.renoteId case final renoteId? when detail) {
-      remove(renoteId);
+      if (!state.containsKey(renoteId)) {
+        remove(renoteId);
+      }
     }
     if (note.reply case final reply?) {
       add(reply, detail: false);
     } else if (note.replyId case final replyId? when detail) {
-      remove(replyId);
+      if (!state.containsKey(replyId)) {
+        remove(replyId);
+      }
     }
     final cachedNote = state[note.id];
     state = {

--- a/lib/provider/notes_notifier_provider.g.dart
+++ b/lib/provider/notes_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'notes_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$notesNotifierHash() => r'e3e49f151e121120f0ca66d57f92c2c2ea7ef0f0';
+String _$notesNotifierHash() => r'9a6e49fa5574247faa6819335e76348b72f5298f';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
Added handling for some v12 forks that omit replies for children.

ref: https://iceshrimp.dev/iceshrimp/iceshrimp/commit/3f9788cae89a60b73b2bf0ab85e36286b8517cf6

Fix #700 