### PR TITLE
fix: remove paddings around fallback text of custom emoji

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -515,7 +515,7 @@ class _Mfm extends StatelessWidget {
                   ),
                 )
               : null,
-          fallbackTextStyle: config.style,
+          fallbackTextStyle: config.style.copyWith(height: simple ? 1.0 : null),
           fallbackToImage: false,
           enableFadeIn: enableEmojiFadeIn,
         ),


### PR DESCRIPTION
Changed the `height` of fallback text for custom emojis to 1.0 to display the emoji code at the same level as the surrounding text.