### PR TITLE
refactor: add subtitleBuilder to RadioDialog

### DIFF
--- a/lib/view/dialog/antenna_settings_dialog.dart
+++ b/lib/view/dialog/antenna_settings_dialog.dart
@@ -81,7 +81,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
                 title: Text(t.misskey.antennaSource),
                 values: AntennaSource.values,
                 initialValue: settings.value.src,
-                itemBuilder: (context, antennaSource) =>
+                titleBuilder: (context, antennaSource) =>
                     AntennaSourceWidget(antennaSource: antennaSource),
               );
               if (result != null) {
@@ -100,7 +100,7 @@ class AntennaSettingsDialog extends HookConsumerWidget {
                   title: Text(t.misskey.userList),
                   values: AntennaSource.values,
                   initialValue: settings.value.src,
-                  itemBuilder: (context, antennaSource) =>
+                  titleBuilder: (context, antennaSource) =>
                       AntennaSourceWidget(antennaSource: antennaSource),
                 );
                 if (result != null) {

--- a/lib/view/dialog/radio_dialog.dart
+++ b/lib/view/dialog/radio_dialog.dart
@@ -9,6 +9,7 @@ Future<T?> showRadioDialog<T>(
   required Iterable<T> values,
   T? initialValue,
   required Widget Function(BuildContext context, T value) titleBuilder,
+  Widget Function(BuildContext context, T value)? subtitleBuilder,
 }) {
   return showDialog<T>(
     context: context,
@@ -18,6 +19,7 @@ Future<T?> showRadioDialog<T>(
       values: values,
       initialValue: initialValue,
       titleBuilder: titleBuilder,
+      subtitleBuilder: subtitleBuilder,
     ),
   );
 }
@@ -30,6 +32,7 @@ class RadioDialog<T> extends HookWidget {
     required this.values,
     this.initialValue,
     required this.titleBuilder,
+    this.subtitleBuilder,
   });
 
   final Widget? title;
@@ -37,6 +40,7 @@ class RadioDialog<T> extends HookWidget {
   final Iterable<T> values;
   final T? initialValue;
   final Widget Function(BuildContext context, T value) titleBuilder;
+  final Widget Function(BuildContext context, T value)? subtitleBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -55,6 +59,7 @@ class RadioDialog<T> extends HookWidget {
             ...values.map(
               (value) => RadioListTile(
                 title: titleBuilder(context, value),
+                subtitle: subtitleBuilder?.call(context, value),
                 value: value,
               ),
             ),

--- a/lib/view/dialog/radio_dialog.dart
+++ b/lib/view/dialog/radio_dialog.dart
@@ -8,7 +8,7 @@ Future<T?> showRadioDialog<T>(
   Widget? header,
   required Iterable<T> values,
   T? initialValue,
-  required Widget Function(BuildContext context, T value) itemBuilder,
+  required Widget Function(BuildContext context, T value) titleBuilder,
 }) {
   return showDialog<T>(
     context: context,
@@ -17,7 +17,7 @@ Future<T?> showRadioDialog<T>(
       header: header,
       values: values,
       initialValue: initialValue,
-      itemBuilder: itemBuilder,
+      titleBuilder: titleBuilder,
     ),
   );
 }
@@ -29,14 +29,14 @@ class RadioDialog<T> extends HookWidget {
     this.header,
     required this.values,
     this.initialValue,
-    required this.itemBuilder,
+    required this.titleBuilder,
   });
 
   final Widget? title;
   final Widget? header;
   final Iterable<T> values;
   final T? initialValue;
-  final Widget Function(BuildContext context, T value) itemBuilder;
+  final Widget Function(BuildContext context, T value) titleBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +54,7 @@ class RadioDialog<T> extends HookWidget {
             ],
             ...values.map(
               (value) => RadioListTile(
-                title: itemBuilder(context, value),
+                title: titleBuilder(context, value),
                 value: value,
               ),
             ),

--- a/lib/view/page/settings/behavior_page.dart
+++ b/lib/view/page/settings/behavior_page.dart
@@ -102,7 +102,7 @@ class BehaviorPage extends ConsumerWidget {
                     title: Text(t.aria.noteTapAction),
                     values: NoteActionType.values,
                     initialValue: settings.noteTapAction,
-                    itemBuilder: (context, value) => Text(switch (value) {
+                    titleBuilder: (context, value) => Text(switch (value) {
                       NoteActionType.none => t.misskey.doNothing,
                       NoteActionType.expand => t.aria.expandNote,
                       NoteActionType.menu => t.aria.openMenu,
@@ -137,7 +137,7 @@ class BehaviorPage extends ConsumerWidget {
                     title: Text(t.aria.noteDoubleTapAction),
                     values: NoteActionType.values,
                     initialValue: settings.noteDoubleTapAction,
-                    itemBuilder: (context, value) => Text(switch (value) {
+                    titleBuilder: (context, value) => Text(switch (value) {
                       NoteActionType.none => t.misskey.doNothing,
                       NoteActionType.expand => t.aria.expandNote,
                       NoteActionType.menu => t.aria.openMenu,
@@ -172,7 +172,7 @@ class BehaviorPage extends ConsumerWidget {
                     title: Text(t.aria.noteLongPressAction),
                     values: NoteActionType.values,
                     initialValue: settings.noteLongPressAction,
-                    itemBuilder: (context, value) => Text(switch (value) {
+                    titleBuilder: (context, value) => Text(switch (value) {
                       NoteActionType.none => t.misskey.doNothing,
                       NoteActionType.expand => t.aria.expandNote,
                       NoteActionType.menu => t.aria.openMenu,
@@ -275,7 +275,7 @@ class BehaviorPage extends ConsumerWidget {
                       LaunchMode.externalApplication,
                     ],
                     initialValue: settings.launchMode,
-                    itemBuilder: (context, value) => Text(switch (value) {
+                    titleBuilder: (context, value) => Text(switch (value) {
                       LaunchMode.inAppBrowserView =>
                         t.aria.openInInternalBrowser,
                       LaunchMode.externalApplication =>

--- a/lib/view/page/settings/note_display_page.dart
+++ b/lib/view/page/settings/note_display_page.dart
@@ -125,14 +125,15 @@ class NoteDisplayPage extends HookConsumerWidget {
                           title: Text(t.misskey.displayOfSensitiveMedia),
                           values: SensitiveMediaDisplay.values,
                           initialValue: settings.sensitive,
-                          itemBuilder: (context, value) => Text(switch (value) {
-                            SensitiveMediaDisplay.respect =>
-                              t.misskey.displayOfSensitiveMedia_.respect,
-                            SensitiveMediaDisplay.ignore =>
-                              t.misskey.displayOfSensitiveMedia_.ignore,
-                            SensitiveMediaDisplay.force =>
-                              t.misskey.displayOfSensitiveMedia_.force,
-                          }),
+                          titleBuilder: (context, value) =>
+                              Text(switch (value) {
+                                SensitiveMediaDisplay.respect =>
+                                  t.misskey.displayOfSensitiveMedia_.respect,
+                                SensitiveMediaDisplay.ignore =>
+                                  t.misskey.displayOfSensitiveMedia_.ignore,
+                                SensitiveMediaDisplay.force =>
+                                  t.misskey.displayOfSensitiveMedia_.force,
+                              }),
                         );
                         if (result != null) {
                           await ref
@@ -280,14 +281,15 @@ class NoteDisplayPage extends HookConsumerWidget {
                           title: Text(t.misskey.instanceTicker),
                           values: InstanceTicker.values,
                           initialValue: settings.instanceTicker,
-                          itemBuilder: (context, value) => Text(switch (value) {
-                            InstanceTicker.none =>
-                              t.misskey.instanceTicker_.none,
-                            InstanceTicker.remote =>
-                              t.misskey.instanceTicker_.remote,
-                            InstanceTicker.always =>
-                              t.misskey.instanceTicker_.always,
-                          }),
+                          titleBuilder: (context, value) =>
+                              Text(switch (value) {
+                                InstanceTicker.none =>
+                                  t.misskey.instanceTicker_.none,
+                                InstanceTicker.remote =>
+                                  t.misskey.instanceTicker_.remote,
+                                InstanceTicker.always =>
+                                  t.misskey.instanceTicker_.always,
+                              }),
                         );
                         if (result != null) {
                           await ref
@@ -549,10 +551,11 @@ class NoteDisplayPage extends HookConsumerWidget {
                           title: Text(t.misskey.emojiStyle),
                           values: EmojiStyle.values,
                           initialValue: settings.emojiStyle,
-                          itemBuilder: (context, value) => Text(switch (value) {
-                            EmojiStyle.native => t.misskey.native,
-                            EmojiStyle.twemoji => 'Twemoji',
-                          }),
+                          titleBuilder: (context, value) =>
+                              Text(switch (value) {
+                                EmojiStyle.native => t.misskey.native,
+                                EmojiStyle.twemoji => 'Twemoji',
+                              }),
                         );
                         if (result != null) {
                           await ref
@@ -594,7 +597,7 @@ class NoteDisplayPage extends HookConsumerWidget {
                           initialValue: (
                             settings.mediaListWithOneImageAppearance,
                           ),
-                          itemBuilder: (context, value) =>
+                          titleBuilder: (context, value) =>
                               Text(switch (value.$1) {
                                 null => t.misskey.default_,
                                 MediaListWithOneImageAppearance.r16_9 =>
@@ -632,11 +635,12 @@ class NoteDisplayPage extends HookConsumerWidget {
                           title: Text(t.aria.displayOfThumbnail),
                           values: [BoxFit.contain, BoxFit.cover],
                           initialValue: settings.thumbnailBoxFit,
-                          itemBuilder: (context, value) => Text(switch (value) {
-                            BoxFit.contain => t.aria.showEntireImage,
-                            BoxFit.cover => t.aria.showExpandedImage,
-                            _ => t.misskey.unknown,
-                          }),
+                          titleBuilder: (context, value) =>
+                              Text(switch (value) {
+                                BoxFit.contain => t.aria.showEntireImage,
+                                BoxFit.cover => t.aria.showExpandedImage,
+                                _ => t.misskey.unknown,
+                              }),
                         );
                         if (result != null) {
                           await ref
@@ -674,7 +678,7 @@ class NoteDisplayPage extends HookConsumerWidget {
                             (FontFamily.pretendard,),
                           ],
                           initialValue: (settings.fontFamily,),
-                          itemBuilder: (context, value) => Text(
+                          titleBuilder: (context, value) => Text(
                             value.$1 ?? t.misskey.system,
                             style: TextStyle(fontFamily: value.$1),
                           ),

--- a/lib/view/page/settings/privacy_page.dart
+++ b/lib/view/page/settings/privacy_page.dart
@@ -100,7 +100,7 @@ class PrivacyPage extends ConsumerWidget {
                       title: Text(t.misskey.followingVisibility),
                       values: FFVisibility.values,
                       initialValue: i.followingVisibility ?? i.ffVisibility,
-                      itemBuilder: (context, visibility) =>
+                      titleBuilder: (context, visibility) =>
                           FfVisibilityWidget(visibility: visibility),
                     );
                     if (!context.mounted) return;
@@ -132,7 +132,7 @@ class PrivacyPage extends ConsumerWidget {
                       title: Text(t.misskey.followersVisibility),
                       values: FFVisibility.values,
                       initialValue: i.followersVisibility ?? i.ffVisibility,
-                      itemBuilder: (context, visibility) =>
+                      titleBuilder: (context, visibility) =>
                           FfVisibilityWidget(visibility: visibility),
                     );
                     if (!context.mounted) return;
@@ -250,7 +250,7 @@ class PrivacyPage extends ConsumerWidget {
                       ),
                       values: ChatScope.values,
                       initialValue: i?.chatScope,
-                      itemBuilder: (context, chatScope) => ListTile(
+                      titleBuilder: (context, chatScope) => ListTile(
                         title: _ChatScopeWidget(chatScope: chatScope),
                       ),
                     );
@@ -317,7 +317,7 @@ class PrivacyPage extends ConsumerWidget {
                       title: Text(t.misskey.defaultNoteVisibility),
                       values: NoteVisibility.values,
                       initialValue: settings.defaultNoteVisibility,
-                      itemBuilder: (context, visibility) => ListTile(
+                      titleBuilder: (context, visibility) => ListTile(
                         title: NoteVisibilityWidget(visibility: visibility),
                         subtitle: Text(switch (visibility) {
                           NoteVisibility.public =>
@@ -393,7 +393,7 @@ class PrivacyPage extends ConsumerWidget {
                       ),
                       values: NoteVisibility.values,
                       initialValue: settings.defaultRenoteVisibility,
-                      itemBuilder: (context, visibility) => ListTile(
+                      titleBuilder: (context, visibility) => ListTile(
                         title: NoteVisibilityWidget(visibility: visibility),
                         subtitle: Text(switch (visibility) {
                           NoteVisibility.public =>
@@ -454,7 +454,7 @@ class PrivacyPage extends ConsumerWidget {
                       ...ReactionAcceptance.values,
                     ].map((value) => (value,)).toList(),
                     initialValue: (settings.reactionAcceptance,),
-                    itemBuilder: (context, acceptance) =>
+                    titleBuilder: (context, acceptance) =>
                         ReactionAcceptanceWidget(acceptance: acceptance.$1),
                   );
                   if (result != null) {

--- a/lib/view/page/settings/privacy_page.dart
+++ b/lib/view/page/settings/privacy_page.dart
@@ -250,9 +250,8 @@ class PrivacyPage extends ConsumerWidget {
                       ),
                       values: ChatScope.values,
                       initialValue: i?.chatScope,
-                      titleBuilder: (context, chatScope) => ListTile(
-                        title: _ChatScopeWidget(chatScope: chatScope),
-                      ),
+                      titleBuilder: (context, chatScope) =>
+                          _ChatScopeWidget(chatScope: chatScope),
                     );
                     if (!context.mounted) return;
                     if (result != null) {
@@ -317,19 +316,12 @@ class PrivacyPage extends ConsumerWidget {
                       title: Text(t.misskey.defaultNoteVisibility),
                       values: NoteVisibility.values,
                       initialValue: settings.defaultNoteVisibility,
-                      titleBuilder: (context, visibility) => ListTile(
-                        title: NoteVisibilityWidget(visibility: visibility),
-                        subtitle: Text(switch (visibility) {
-                          NoteVisibility.public =>
-                            t.misskey.visibility_.publicDescription,
-                          NoteVisibility.home =>
-                            t.misskey.visibility_.homeDescription,
-                          NoteVisibility.followers =>
-                            t.misskey.visibility_.followersDescription,
-                          NoteVisibility.specified =>
-                            t.misskey.visibility_.specifiedDescription,
-                        }),
-                      ),
+                      titleBuilder: (context, visibility) =>
+                          NoteVisibilityWidget(visibility: visibility),
+                      subtitleBuilder: (context, visibility) =>
+                          _NoteVisibilityDescriptionWidget(
+                            visibility: visibility,
+                          ),
                     );
                     if (result != null) {
                       await ref
@@ -393,19 +385,12 @@ class PrivacyPage extends ConsumerWidget {
                       ),
                       values: NoteVisibility.values,
                       initialValue: settings.defaultRenoteVisibility,
-                      titleBuilder: (context, visibility) => ListTile(
-                        title: NoteVisibilityWidget(visibility: visibility),
-                        subtitle: Text(switch (visibility) {
-                          NoteVisibility.public =>
-                            t.misskey.visibility_.publicDescription,
-                          NoteVisibility.home =>
-                            t.misskey.visibility_.homeDescription,
-                          NoteVisibility.followers =>
-                            t.misskey.visibility_.followersDescription,
-                          NoteVisibility.specified =>
-                            t.misskey.visibility_.specifiedDescription,
-                        }),
-                      ),
+                      titleBuilder: (context, visibility) =>
+                          NoteVisibilityWidget(visibility: visibility),
+                      subtitleBuilder: (context, visibility) =>
+                          _NoteVisibilityDescriptionWidget(
+                            visibility: visibility,
+                          ),
                     );
                     if (result != null) {
                       await ref
@@ -487,6 +472,22 @@ class _ChatScopeWidget extends StatelessWidget {
       ChatScope.mutual => t.misskey.chat_.chatAllowedUsers_.mutual,
       ChatScope.none => t.misskey.chat_.chatAllowedUsers_.none,
       null => t.misskey.unknown,
+    });
+  }
+}
+
+class _NoteVisibilityDescriptionWidget extends StatelessWidget {
+  const _NoteVisibilityDescriptionWidget({required this.visibility});
+
+  final NoteVisibility visibility;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(switch (visibility) {
+      NoteVisibility.public => t.misskey.visibility_.publicDescription,
+      NoteVisibility.home => t.misskey.visibility_.homeDescription,
+      NoteVisibility.followers => t.misskey.visibility_.followersDescription,
+      NoteVisibility.specified => t.misskey.visibility_.specifiedDescription,
     });
   }
 }

--- a/lib/view/page/settings/profile_page.dart
+++ b/lib/view/page/settings/profile_page.dart
@@ -525,7 +525,7 @@ class ProfilePage extends HookConsumerWidget {
                         (final key?, final value?) => (key, value),
                         _ => null,
                       },
-                      itemBuilder: (context, lang) => Text(lang.$2.nativeName),
+                      titleBuilder: (context, lang) => Text(lang.$2.nativeName),
                     );
                     if (!context.mounted) return;
                     if (result != null) {

--- a/lib/view/page/settings/tab_settings_page.dart
+++ b/lib/view/page/settings/tab_settings_page.dart
@@ -63,7 +63,7 @@ class TabSettingsPage extends HookConsumerWidget {
       title: Text(t.misskey.role),
       values: roles,
       initialValue: role,
-      itemBuilder: (context, role) => Text(role.name),
+      titleBuilder: (context, role) => Text(role.name),
     );
   }
 
@@ -84,7 +84,7 @@ class TabSettingsPage extends HookConsumerWidget {
       title: Text(t.misskey.selectList),
       values: lists,
       initialValue: list != null ? UsersList.fromJson(list.toJson()) : null,
-      itemBuilder: (context, list) => Text(list.name ?? ''),
+      titleBuilder: (context, list) => Text(list.name ?? ''),
     );
   }
 
@@ -105,7 +105,7 @@ class TabSettingsPage extends HookConsumerWidget {
       title: Text(t.misskey.selectAntenna),
       values: antennas,
       initialValue: antenna,
-      itemBuilder: (context, antenna) => Text(antenna.name),
+      titleBuilder: (context, antenna) => Text(antenna.name),
     );
   }
 
@@ -335,7 +335,7 @@ class TabSettingsPage extends HookConsumerWidget {
                         },
                       ),
                       initialValue: tabType,
-                      itemBuilder: (context, value) =>
+                      titleBuilder: (context, value) =>
                           TabTypeWidget(tabType: value),
                     );
                     if (!ref.context.mounted) return;

--- a/lib/view/page/settings/theme_page.dart
+++ b/lib/view/page/settings/theme_page.dart
@@ -44,7 +44,7 @@ class ThemePage extends ConsumerWidget {
                     title: Text(t.misskey.theme),
                     values: ThemeMode.values,
                     initialValue: generalSettings.themeMode,
-                    itemBuilder: (context, value) =>
+                    titleBuilder: (context, value) =>
                         ThemeModeWidget(themeMode: value),
                   );
                   if (result != null) {
@@ -73,7 +73,7 @@ class ThemePage extends ConsumerWidget {
                       ...installedColors,
                     ].where((colors) => !colors.isDark).toList(),
                     initialValue: lightColors,
-                    itemBuilder: (context, value) => Text(value.name),
+                    titleBuilder: (context, value) => Text(value.name),
                   );
                   if (result != null) {
                     await ref
@@ -101,7 +101,7 @@ class ThemePage extends ConsumerWidget {
                       ...installedColors,
                     ].where((colors) => colors.isDark).toList(),
                     initialValue: darkColors,
-                    itemBuilder: (context, value) => Text(value.name),
+                    titleBuilder: (context, value) => Text(value.name),
                   );
                   if (result != null) {
                     await ref

--- a/lib/view/page/settings/timeline_buttons_page.dart
+++ b/lib/view/page/settings/timeline_buttons_page.dart
@@ -103,7 +103,7 @@ class TimelineButtonsPage extends ConsumerWidget {
                             values: TimelinesPageButtonType.values,
                             initialValue: type,
                             title: Text(t.aria.buttonTypes),
-                            itemBuilder: (context, type) =>
+                            titleBuilder: (context, type) =>
                                 _TimelinesPageButtonTypeNameWidget(
                                   buttonType: type,
                                 ),
@@ -198,7 +198,7 @@ class TimelineButtonsPage extends ConsumerWidget {
                     values: TimelinesPageButtonType.values,
                     initialValue: type,
                     title: Text(t.aria.buttonTypes),
-                    itemBuilder: (context, type) =>
+                    titleBuilder: (context, type) =>
                         _TimelinesPageButtonTypeNameWidget(buttonType: type),
                   );
                   if (result != null && result != type) {

--- a/lib/view/page/tag/tag_users.dart
+++ b/lib/view/page/tag/tag_users.dart
@@ -51,7 +51,7 @@ class TagUsers extends HookConsumerWidget {
                         title: Text(t.misskey.sort),
                         values: UsersSortType.values,
                         initialValue: sort.value,
-                        itemBuilder: (context, sort) =>
+                        titleBuilder: (context, sort) =>
                             UsersSortTypeWidget(sort: sort),
                       );
                       if (!context.mounted) return;


### PR DESCRIPTION
Renamed `itemBuilder` of `RadioDialog` to `titleBuilder` and added `subtitleBuilder`.

With this, each item in the dialog can have a title and a subtitle, rather than the title being a `ListTile` that includes both.