### PR TITLE
fix: show lists in antenna settings

### DIFF
--- a/lib/provider/api/antennas_notifier_provider.dart
+++ b/lib/provider/api/antennas_notifier_provider.dart
@@ -19,6 +19,7 @@ class AntennasNotifier extends _$AntennasNotifier {
   Future<void> create({
     required String name,
     AntennaSource? src,
+    String? userListId,
     List<List<String>>? keywords,
     List<List<String>>? excludeKeywords,
     List<String>? users,
@@ -33,6 +34,7 @@ class AntennasNotifier extends _$AntennasNotifier {
       AntennasCreateRequest(
         name: name,
         src: src ?? AntennaSource.all,
+        userListId: userListId,
         keywords: keywords ?? [],
         excludeKeywords: excludeKeywords ?? [],
         users: users ?? [],
@@ -52,6 +54,7 @@ class AntennasNotifier extends _$AntennasNotifier {
     Antenna antenna, {
     String? name,
     AntennaSource? src,
+    String? userListId,
     List<List<String>>? keywords,
     List<List<String>>? excludeKeywords,
     List<String>? users,
@@ -67,6 +70,7 @@ class AntennasNotifier extends _$AntennasNotifier {
         antennaId: antenna.id,
         name: name ?? antenna.name,
         src: src ?? antenna.src ?? AntennaSource.all,
+        userListId: userListId ?? antenna.userListId,
         keywords: keywords ?? antenna.keywords,
         excludeKeywords: excludeKeywords ?? antenna.excludeKeywords,
         users: users ?? antenna.users,
@@ -88,6 +92,7 @@ class AntennasNotifier extends _$AntennasNotifier {
             ? e.copyWith(
                 name: name ?? antenna.name,
                 src: src ?? antenna.src ?? AntennaSource.all,
+                userListId: userListId ?? antenna.userListId,
                 keywords: keywords ?? antenna.keywords,
                 excludeKeywords: excludeKeywords ?? antenna.excludeKeywords,
                 users: users ?? antenna.users,
@@ -120,6 +125,7 @@ class AntennasNotifier extends _$AntennasNotifier {
         antennaId: antennaId,
         name: antenna.name,
         src: antenna.src ?? AntennaSource.users,
+        userListId: antenna.userListId,
         keywords: antenna.keywords,
         excludeKeywords: antenna.excludeKeywords,
         users: users,
@@ -149,6 +155,7 @@ class AntennasNotifier extends _$AntennasNotifier {
         antennaId: antennaId,
         name: antenna.name,
         src: antenna.src ?? AntennaSource.users,
+        userListId: antenna.userListId,
         keywords: antenna.keywords,
         excludeKeywords: antenna.excludeKeywords,
         users: users,

--- a/lib/provider/api/antennas_notifier_provider.g.dart
+++ b/lib/provider/api/antennas_notifier_provider.g.dart
@@ -6,7 +6,7 @@ part of 'antennas_notifier_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$antennasNotifierHash() => r'7c5f6e969bdcc4677079930a0c33164ed0395ff3';
+String _$antennasNotifierHash() => r'5934dd55e25c0d7b92bc297c2cdc8d2a8722fd25';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/dialog/antenna_dialog.dart
+++ b/lib/view/dialog/antenna_dialog.dart
@@ -72,6 +72,7 @@ class AntennaDialog extends HookConsumerWidget {
                     .create(
                       name: result.name ?? '',
                       src: result.src,
+                      userListId: result.userListId,
                       keywords: result.keywords,
                       excludeKeywords: result.excludeKeywords,
                       users: result.users,

--- a/lib/view/page/antenna_page.dart
+++ b/lib/view/page/antenna_page.dart
@@ -45,6 +45,7 @@ class AntennaPage extends ConsumerWidget {
               antenna,
               name: result.name,
               src: result.src,
+              userListId: result.userListId,
               keywords: result.keywords,
               excludeKeywords: result.excludeKeywords,
               users: result.users,

--- a/lib/view/page/antennas_page.dart
+++ b/lib/view/page/antennas_page.dart
@@ -114,6 +114,7 @@ class AntennasPage extends ConsumerWidget {
                   .create(
                     name: result.name ?? '',
                     src: result.src,
+                    userListId: result.userListId,
                     keywords: result.keywords,
                     excludeKeywords: result.excludeKeywords,
                     users: result.users,


### PR DESCRIPTION
Fixed an issue where a list could not be specified as a source for the antenna.