### PR TITLE
fix: maintain focusability for hidden text field

### DIFF
--- a/lib/view/widget/chat_post_form.dart
+++ b/lib/view/widget/chat_post_form.dart
@@ -156,6 +156,7 @@ class ChatPostForm extends HookConsumerWidget {
             Visibility(
               visible: showTextField,
               maintainState: true,
+              maintainFocusability: true,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                 child: TextField(

--- a/test/view/widget/chat_post_form_test.dart
+++ b/test/view/widget/chat_post_form_test.dart
@@ -1,0 +1,45 @@
+import 'package:aria/i18n/strings.g.dart';
+import 'package:aria/model/account.dart';
+import 'package:aria/view/widget/chat_post_form.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../test_util/create_overrides.dart';
+
+Future<ProviderContainer> setupWidget(
+  WidgetTester tester, {
+  required Account account,
+  String? userId,
+  String? roomId,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: createOverrides(account),
+      child: MaterialApp(
+        home: Material(
+          child: ChatPostForm(account: account, userId: userId, roomId: roomId),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  final container = ProviderScope.containerOf(
+    tester.element(find.byType(ChatPostForm)),
+  );
+  return container;
+}
+
+void main() {
+  group('basic', () {
+    testWidgets('should show entered text', (tester) async {
+      const account = Account(host: 'misskey.tld', username: 'testuser');
+      await setupWidget(tester, account: account, userId: '');
+      await tester.tap(find.text(t.misskey.inputMessageHere));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'test message');
+      await tester.pumpAndSettle();
+      expect(find.text('test message'), findsOne);
+    });
+  });
+}


### PR DESCRIPTION
Fixed an issue where the text field in the chat post form did not open when tapped.

ref: [flutter/flutter#174652](https://redirect.github.com/flutter/flutter/issues/174652) 