### PR TITLE
fix: correct locale change function in languages page

### DIFF
--- a/lib/view/page/settings/languages_page.dart
+++ b/lib/view/page/settings/languages_page.dart
@@ -28,13 +28,11 @@ class LanguagesPage extends ConsumerWidget {
         child: RadioGroup<AppLocale?>(
           groupValue: locale,
           onChanged: (value) {
-            ref
-                .read(generalSettingsNotifierProvider.notifier)
-                .setLocale(locale);
-            if (locale == null) {
+            ref.read(generalSettingsNotifierProvider.notifier).setLocale(value);
+            if (value == null) {
               LocaleSettings.useDeviceLocale();
             } else {
-              LocaleSettings.setLocale(locale);
+              LocaleSettings.setLocale(value);
             }
           },
           child: ListView(


### PR DESCRIPTION
Fixed an issue where the UI language could not be changed.

Follow up for #711