### PR TITLE
fix: change condition to show emoji palette page

### DIFF
--- a/lib/view/dialog/paste_emojis_dialog.dart
+++ b/lib/view/dialog/paste_emojis_dialog.dart
@@ -32,7 +32,10 @@ class PasteEmojisDialog extends HookConsumerWidget {
     final endpoints = ref.watch(endpointsProvider(account.host)).valueOrNull;
     final isThirdPartyRegistrySupported =
         endpoints?.contains('i/registry/scopes-with-domain') ?? true;
-    final useEmojiPalette = endpoints?.contains('chat/history') ?? false;
+    final useEmojiPalette =
+        endpoints == null ||
+        endpoints.contains('chat/history') ||
+        !endpoints.contains('i/read-all-unread-notes');
     final serverUrl = ref.watch(serverUrlNotifierProvider(account.host));
     final registryUrl = serverUrl.replace(
       pathSegments: [

--- a/lib/view/widget/pinned_emojis_editor.dart
+++ b/lib/view/widget/pinned_emojis_editor.dart
@@ -30,7 +30,10 @@ class PinnedEmojisEditor extends HookConsumerWidget {
       pinnedEmojisNotifierProvider(account, reaction: reaction),
     );
     final endpoints = ref.watch(endpointsProvider(account.host)).valueOrNull;
-    final useEmojiPalette = endpoints?.contains('chat/history') ?? false;
+    final useEmojiPalette =
+        endpoints == null ||
+        endpoints.contains('chat/history') ||
+        !endpoints.contains('i/read-all-unread-notes');
 
     return ExpansionTile(
       leading: Icon(reaction ? Icons.push_pin : Icons.push_pin_outlined),


### PR DESCRIPTION
Changed to show the emoji palette page in `PasteEmojisDialog` when `i/read-all-unread-notes` is missing.

Follow up for #603