### PR TITLE
fix: change icon of message dialog

### DIFF
--- a/lib/view/dialog/message_dialog.dart
+++ b/lib/view/dialog/message_dialog.dart
@@ -3,22 +3,27 @@ import 'package:go_router/go_router.dart';
 
 import '../../i18n/strings.g.dart';
 
-Future<void> showMessageDialog(BuildContext context, String message) async {
+Future<void> showMessageDialog(
+  BuildContext context,
+  String message, {
+  Widget icon = const Icon(Icons.error_outline),
+}) async {
   await showDialog<void>(
     context: context,
-    builder: (context) => MessageDialog(message: message),
+    builder: (context) => MessageDialog(message: message, icon: icon),
   );
 }
 
 class MessageDialog extends StatelessWidget {
-  const MessageDialog({super.key, required this.message});
+  const MessageDialog({super.key, required this.message, required this.icon});
 
   final String message;
+  final Widget icon;
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      icon: const Icon(Icons.error_outline, size: 36.0),
+      icon: IconTheme(data: const IconThemeData(size: 36.0), child: icon),
       content: Text(message),
       actions: [
         ElevatedButton(

--- a/lib/view/page/settings/import_export_page.dart
+++ b/lib/view/page/settings/import_export_page.dart
@@ -282,6 +282,7 @@ class ImportExportPage extends ConsumerWidget {
                             await showMessageDialog(
                               context,
                               t.aria.importCompleted,
+                              icon: const Icon(Icons.info_outline),
                             );
                           }
                         } catch (_) {
@@ -325,6 +326,7 @@ class ImportExportPage extends ConsumerWidget {
                             await showMessageDialog(
                               context,
                               t.aria.importCompleted,
+                              icon: const Icon(Icons.info_outline),
                             );
                           }
                         } catch (_) {

--- a/lib/view/page/settings/theme_manage_page.dart
+++ b/lib/view/page/settings/theme_manage_page.dart
@@ -55,6 +55,7 @@ class ThemeManagePage extends ConsumerWidget {
       await showMessageDialog(
         ref.context,
         t.misskey.theme_.installed(name: theme.name),
+        icon: const Icon(Icons.info_outline),
       );
     } catch (e, st) {
       if (!ref.context.mounted) return;


### PR DESCRIPTION
Changed the icon of the `MessageDialog` for non-error messages.