### PR TITLE
fix: use abort in sw/register script

### DIFF
--- a/lib/view/dialog/sw_register_dialog.dart
+++ b/lib/view/dialog/sw_register_dialog.dart
@@ -72,7 +72,7 @@ class SwRegisterDialog extends HookConsumerWidget {
             code:
                 """
 if (USER_USERNAME != '${account.username}') {
-  return Mk:dialog('${t.misskey.permissionDeniedError}', '${t.aria.pleaseLoginAs(user: '@${account.username}')}', 'warning')
+  Core:abort(`**${t.misskey.permissionDeniedError}**{Str:lf}${t.aria.pleaseLoginAs(user: '@${account.username}')}`)
 }
 let params = {
   endpoint: '${request.endpoint}',


### PR DESCRIPTION
Replaced a top-level return statement with a `Core:abort` function call in the script in `SwRegisterDialog` .

In AiScript 1.x, return statements outside a function are prohibited.