### PR TITLE
feat: support scheduled note post notification

### DIFF
--- a/ios/Localizable.xcstrings
+++ b/ios/Localizable.xcstrings
@@ -1447,6 +1447,88 @@
         }
       }
     },
+    "_notification.scheduledNotePosted": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geplante Notiz wurde veröffentlicht"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scheduled note has been posted"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La nota programada ha sido publicada"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La nota pianificata è stata pubblicata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "予約済みのノートが投稿されました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "定时帖子已发布"
+          }
+        }
+      }
+    },
+    "_notification.scheduledNotePostFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geplante Notiz konnte nicht veröffentlicht werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scheduled note posting has failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La publicación de la nota programada ha fallado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La pubblicazione pianificata delle note non è riuscita"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "予約済みのノートの投稿に失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "定时帖子发布失败"
+          }
+        }
+      }
+    },
     "_notification.roleAssigned": {
       "extractionState": "manual",
       "localizations": {
@@ -2011,47 +2093,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "帖子已定时"
-          }
-        }
-      }
-    },
-    "_notification.scheduledNotePosted": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geplante Notiz wurde veröffentlicht"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scheduled note has been posted"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La nota programada ha sido publicada"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La nota pianificata è stata pubblicata"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "予約済みのノートが投稿されました"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "定时帖子已发布"
           }
         }
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -263,11 +263,12 @@ class Aria extends HookConsumerWidget {
                 t.misskey.notification_.chatRoomInvitationReceived,
               NotificationType.createToken =>
                 t.misskey.notification_.createToken,
+              NotificationType.scheduledNotePosted =>
+                t.aria.scheduledNotePosted,
+              NotificationType.scheduledNotePostFailed ||
               NotificationType.scheduleNote ||
               NotificationType.scheduledNoteError => t.aria.scheduledNoteError,
               NotificationType.noteScheduled => t.aria.noteScheduled,
-              NotificationType.scheduledNotePosted =>
-                t.aria.scheduledNotePosted,
               NotificationType.app => body.header ?? body.body,
               NotificationType.test => t.misskey.notification_.testNotification,
               NotificationType.edited ||
@@ -482,6 +483,7 @@ class Aria extends HookConsumerWidget {
               NotificationType.app => body.header != null ? body.body : null,
               NotificationType.test =>
                 t.misskey.notification_.notificationWillBeDisplayedLikeThis,
+              NotificationType.scheduledNotePostFailed ||
               NotificationType.edited ||
               NotificationType.exportCompleted ||
               NotificationType.login ||

--- a/lib/view/widget/notification_widget.dart
+++ b/lib/view/widget/notification_widget.dart
@@ -436,7 +436,9 @@ class NotificationWidget extends ConsumerWidget {
             ),
           );
         }
-      case NotificationType.scheduleNote || NotificationType.scheduledNoteError:
+      case NotificationType.scheduledNotePostFailed ||
+          NotificationType.scheduleNote ||
+          NotificationType.scheduledNoteError:
         return _NotificationTile(
           account: account,
           user: i,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1327,8 +1327,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "66cefcc4863b5096af11e593a153bd80dd4afe55"
-      resolved-ref: "66cefcc4863b5096af11e593a153bd80dd4afe55"
+      ref: "259200550f17a81633158e1d8b515b6109719f07"
+      resolved-ref: "259200550f17a81633158e1d8b515b6109719f07"
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,7 +89,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: 66cefcc4863b5096af11e593a153bd80dd4afe55
+      ref: 259200550f17a81633158e1d8b515b6109719f07
   multi_split_view: ^3.6.1
   package_info_plus: ^8.3.1
   path: ^1.9.1

--- a/script/gen_localizable.dart
+++ b/script/gen_localizable.dart
@@ -47,6 +47,8 @@ const notificationKeys = [
   'achievementEarned',
   'login',
   'pollEnded',
+  'scheduledNotePosted',
+  'scheduledNotePostFailed',
   'roleAssigned',
   'chatRoomInvitationReceived',
   'createToken',
@@ -61,6 +63,7 @@ const scheduleNote = '_types.scheduleNote';
 const noteScheduled = 'noteScheduled';
 const scheduledNotePosted = 'scheduledNotePosted';
 const scheduledNoteError = 'scheduledNoteError';
+const scheduledNotePostFailed = 'scheduledNotePostFailed';
 
 const achievementTypes = [
   'notes1',
@@ -229,6 +232,7 @@ void main() {
       strings['_notification.$scheduledNotePosted']?[locale] = value;
     }
     if (ariaI18n[scheduledNoteError] case final String value) {
+      strings['_notification.$scheduledNotePostFailed']?[locale] = value;
       strings['_notification.$scheduleNote']?[locale] = value;
       strings['_notification.$scheduledNoteError']?[locale] = value;
     }


### PR DESCRIPTION
Added support for `scheduledNotePosted` and `scheduledNotePostFailed` notifications added in [misskey-dev/misskey#16577](https://redirect.github.com/misskey-dev/misskey/pull/16577).