### PR TITLE
feat: open emoji sheet from emoji picker

### DIFF
--- a/lib/provider/pinned_emojis_notifier_provider.dart
+++ b/lib/provider/pinned_emojis_notifier_provider.dart
@@ -48,8 +48,8 @@ class PinnedEmojisNotifier extends _$PinnedEmojisNotifier {
     await _save(items);
   }
 
-  Future<void> delete(int index) async {
-    await _save([...state.sublist(0, index), ...state.sublist(index + 1)]);
+  Future<void> remove(int index) async {
+    await _save([...state.take(index), ...state.skip(index + 1)]);
   }
 
   Future<void> reset() async {

--- a/lib/provider/pinned_emojis_notifier_provider.g.dart
+++ b/lib/provider/pinned_emojis_notifier_provider.g.dart
@@ -7,7 +7,7 @@ part of 'pinned_emojis_notifier_provider.dart';
 // **************************************************************************
 
 String _$pinnedEmojisNotifierHash() =>
-    r'23a174ac8e1421ed1ae4511e437853546bc1f3f5';
+    r'feffc9bfae5ef98834ce943baa489d3be564a42d';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view/widget/custom_emoji.dart
+++ b/lib/view/widget/custom_emoji.dart
@@ -23,6 +23,7 @@ class CustomEmoji extends ConsumerWidget {
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
     this.onTap,
+    this.onLongPress,
     this.disableTooltip = false,
     this.fallbackTextStyle,
     this.fallbackToImage = true,
@@ -40,6 +41,7 @@ class CustomEmoji extends ConsumerWidget {
   final BoxFit fit;
   final Alignment alignment;
   final void Function()? onTap;
+  final void Function()? onLongPress;
   final bool disableTooltip;
   final TextStyle? fallbackTextStyle;
   final bool fallbackToImage;
@@ -101,8 +103,9 @@ class CustomEmoji extends ConsumerWidget {
 
     return InkWell(
       onTap: onTap,
+      onLongPress: onLongPress,
       child: TooltipVisibility(
-        visible: !disableTooltip,
+        visible: onLongPress == null && !disableTooltip,
         child: Tooltip(
           message: emoji.replaceFirst('@.', ''),
           child: RepaintBoundary(

--- a/lib/view/widget/emoji_picker.dart
+++ b/lib/view/widget/emoji_picker.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -22,6 +23,7 @@ import '../../provider/search_unicode_emojis_provider.dart';
 import '../../util/check_reaction_permissions.dart';
 import '../page/emoji_page.dart';
 import 'custom_emoji.dart';
+import 'emoji_sheet.dart';
 import 'unicode_emoji.dart';
 
 Future<String?> pickEmoji(
@@ -228,6 +230,11 @@ class EmojiPicker extends HookConsumerWidget {
                     onTap: enabled
                         ? () => onTapEmoji(emoji.emoji, keepOpen)
                         : null,
+                    onLongPress: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) =>
+                          EmojiSheet(account: account, emoji: emoji.emoji),
+                    ),
                     height: style.lineHeight * fontScaleFactor,
                     opacity: enabled ? 1.0 : 0.1,
                     fallbackTextStyle: style.apply(
@@ -241,6 +248,11 @@ class EmojiPicker extends HookConsumerWidget {
                     emoji: emoji,
                     style: style.apply(fontSizeFactor: fontScaleFactor),
                     onTap: () => onTapEmoji(emoji, keepOpen),
+                    onLongPress: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) =>
+                          EmojiSheet(account: account, emoji: emoji),
+                    ),
                   ),
                 ),
               ],
@@ -254,7 +266,7 @@ class EmojiPicker extends HookConsumerWidget {
             child: Wrap(
               spacing: 4.0,
               runSpacing: 4.0,
-              children: pinnedEmojis.map((emoji) {
+              children: pinnedEmojis.mapIndexed((index, emoji) {
                 if (emoji.startsWith(':')) {
                   final customEmoji = ref.watch(
                     emojiProvider(account.host, emoji),
@@ -268,6 +280,24 @@ class EmojiPicker extends HookConsumerWidget {
                     account: account,
                     emoji: emoji,
                     onTap: enabled ? () => onTapEmoji(emoji, keepOpen) : null,
+                    onLongPress: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) => EmojiSheet(
+                        account: account,
+                        emoji: emoji,
+                        remove: () {
+                          ref
+                              .read(
+                                pinnedEmojisNotifierProvider(
+                                  account,
+                                  reaction: reaction,
+                                ).notifier,
+                              )
+                              .remove(index);
+                          context.pop();
+                        },
+                      ),
+                    ),
                     height: style.lineHeight * fontScaleFactor,
                     opacity: enabled ? 1.0 : 0.1,
                     fallbackTextStyle: style.apply(
@@ -280,6 +310,24 @@ class EmojiPicker extends HookConsumerWidget {
                     emoji: emoji,
                     style: style.apply(fontSizeFactor: fontScaleFactor),
                     onTap: () => onTapEmoji(emoji, keepOpen),
+                    onLongPress: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) => EmojiSheet(
+                        account: account,
+                        emoji: emoji,
+                        remove: () {
+                          ref
+                              .read(
+                                pinnedEmojisNotifierProvider(
+                                  account,
+                                  reaction: reaction,
+                                ).notifier,
+                              )
+                              .remove(index);
+                          context.pop();
+                        },
+                      ),
+                    ),
                   );
                 }
               }).toList(),
@@ -298,7 +346,7 @@ class EmojiPicker extends HookConsumerWidget {
             child: Wrap(
               spacing: 4.0,
               runSpacing: 4.0,
-              children: recentlyUsedEmojis.map((emoji) {
+              children: recentlyUsedEmojis.mapIndexed((index, emoji) {
                 if (emoji.startsWith(':')) {
                   final customEmoji = ref.watch(
                     emojiProvider(account.host, emoji),
@@ -312,6 +360,23 @@ class EmojiPicker extends HookConsumerWidget {
                     account: account,
                     emoji: emoji,
                     onTap: enabled ? () => onTapEmoji(emoji, keepOpen) : null,
+                    onLongPress: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) => EmojiSheet(
+                        account: account,
+                        emoji: emoji,
+                        remove: () {
+                          ref
+                              .read(
+                                recentlyUsedEmojisNotifierProvider(
+                                  account,
+                                ).notifier,
+                              )
+                              .remove(index);
+                          context.pop();
+                        },
+                      ),
+                    ),
                     height: style.lineHeight * fontScaleFactor,
                     opacity: enabled ? 1.0 : 0.1,
                     fallbackTextStyle: style.apply(
@@ -324,6 +389,23 @@ class EmojiPicker extends HookConsumerWidget {
                     emoji: emoji,
                     style: style.apply(fontSizeFactor: fontScaleFactor),
                     onTap: () => onTapEmoji(emoji, keepOpen),
+                    onLongPress: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) => EmojiSheet(
+                        account: account,
+                        emoji: emoji,
+                        remove: () {
+                          ref
+                              .read(
+                                recentlyUsedEmojisNotifierProvider(
+                                  account,
+                                ).notifier,
+                              )
+                              .remove(index);
+                          context.pop();
+                        },
+                      ),
+                    ),
                   );
                 }
               }).toList(),
@@ -368,6 +450,13 @@ class EmojiPicker extends HookConsumerWidget {
                           onTap: enabled
                               ? () => onTapEmoji(emoji.emoji, keepOpen)
                               : null,
+                          onLongPress: () => showModalBottomSheet<void>(
+                            context: context,
+                            builder: (context) => EmojiSheet(
+                              account: account,
+                              emoji: emoji.emoji,
+                            ),
+                          ),
                           height: style.lineHeight * fontScaleFactor,
                           opacity: enabled ? 1.0 : 0.1,
                           fallbackTextStyle: style.apply(
@@ -426,6 +515,7 @@ class _CustomEmoji extends StatelessWidget {
     required this.account,
     required this.emoji,
     required this.onTap,
+    required this.onLongPress,
     required this.height,
     this.opacity = 1.0,
     required this.fallbackTextStyle,
@@ -434,6 +524,7 @@ class _CustomEmoji extends StatelessWidget {
   final Account account;
   final String emoji;
   final void Function()? onTap;
+  final void Function()? onLongPress;
   final double height;
   final double opacity;
   final TextStyle fallbackTextStyle;
@@ -446,6 +537,7 @@ class _CustomEmoji extends StatelessWidget {
       account: account,
       emoji: emoji,
       onTap: onTap,
+      onLongPress: onLongPress,
       height: height,
       opacity: opacity,
       fallbackTextStyle: fallbackTextStyle,

--- a/lib/view/widget/pinned_emojis_editor.dart
+++ b/lib/view/widget/pinned_emojis_editor.dart
@@ -84,7 +84,7 @@ class PinnedEmojisEditor extends HookConsumerWidget {
                                 reaction: reaction,
                               ).notifier,
                             )
-                            .delete(index),
+                            .remove(index),
                         style: style.apply(fontSizeFactor: 2.0),
                         disableTooltip: true,
                       ),

--- a/lib/view/widget/unicode_emoji.dart
+++ b/lib/view/widget/unicode_emoji.dart
@@ -32,6 +32,7 @@ class UnicodeEmoji extends ConsumerWidget {
     this.fit = BoxFit.contain,
     this.alignment = Alignment.center,
     this.onTap,
+    this.onLongPress,
     this.inline = false,
   });
 
@@ -41,6 +42,7 @@ class UnicodeEmoji extends ConsumerWidget {
   final BoxFit fit;
   final Alignment alignment;
   final void Function()? onTap;
+  final void Function()? onLongPress;
   final bool inline;
 
   @override
@@ -69,12 +71,14 @@ class UnicodeEmoji extends ConsumerWidget {
       case EmojiStyle.native:
         return InkWell(
           onTap: onTap,
+          onLongPress: onLongPress,
           child: Text(emoji, style: style),
         );
       case EmojiStyle.twemoji:
         final padding = style.fontSize! * ((style.height ?? 1.0) - 1.0) / 2;
         return InkWell(
           onTap: onTap,
+          onLongPress: onLongPress,
           child: Padding(
             padding: EdgeInsets.symmetric(
               horizontal: padding,


### PR DESCRIPTION
Enabled opening the emoji sheet by long-pressing an emoji in the emoji picker.