### PR TITLE
refactor: reorder popup menu items for consistency

### DIFF
--- a/lib/view/dialog/audio_dialog.dart
+++ b/lib/view/dialog/audio_dialog.dart
@@ -17,6 +17,7 @@ import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/audio_handler_provider.dart';
 import '../../provider/cache_manager_provider.dart';
+import '../../util/copy_text.dart';
 import '../../util/future_with_dialog.dart';
 import '../../util/launch_url.dart';
 import '../../util/show_toast.dart';
@@ -325,6 +326,13 @@ class _AudioHeader extends ConsumerWidget {
               child: ListTile(
                 leading: const Icon(Icons.open_in_browser),
                 title: Text(t.aria.openInBrowser),
+              ),
+            ),
+            PopupMenuItem(
+              onTap: () => copyToClipboard(context, file.url),
+              child: ListTile(
+                leading: const Icon(Icons.copy),
+                title: Text(t.misskey.copyLink),
               ),
             ),
           ],

--- a/lib/view/dialog/image_dialog.dart
+++ b/lib/view/dialog/image_dialog.dart
@@ -13,6 +13,7 @@ import 'package:photo_view/photo_view.dart';
 import '../../i18n/strings.g.dart';
 import '../../provider/cache_manager_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
+import '../../util/copy_text.dart';
 import '../../util/future_with_dialog.dart';
 import '../../util/launch_url.dart';
 import '../../util/show_toast.dart';
@@ -180,6 +181,14 @@ class ImageDialog extends HookConsumerWidget {
                               child: ListTile(
                                 leading: const Icon(Icons.open_in_browser),
                                 title: Text(t.aria.openInBrowser),
+                              ),
+                            ),
+                            PopupMenuItem(
+                              onTap: () =>
+                                  copyToClipboard(context, url.toString()),
+                              child: ListTile(
+                                leading: const Icon(Icons.copy),
+                                title: Text(t.misskey.copyLink),
                               ),
                             ),
                           ],

--- a/lib/view/dialog/video_dialog.dart
+++ b/lib/view/dialog/video_dialog.dart
@@ -12,6 +12,7 @@ import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/cache_manager_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
+import '../../util/copy_text.dart';
 import '../../util/future_with_dialog.dart';
 import '../../util/launch_url.dart';
 import '../../util/show_toast.dart';
@@ -153,6 +154,13 @@ class VideoDialog extends HookConsumerWidget {
                       child: ListTile(
                         leading: const Icon(Icons.open_in_browser),
                         title: Text(t.aria.openInBrowser),
+                      ),
+                    ),
+                    PopupMenuItem(
+                      onTap: () => copyToClipboard(context, url.toString()),
+                      child: ListTile(
+                        leading: const Icon(Icons.copy),
+                        title: Text(t.misskey.copyLink),
                       ),
                     ),
                   ],

--- a/lib/view/page/chat/chat_room_page.dart
+++ b/lib/view/page/chat/chat_room_page.dart
@@ -88,17 +88,17 @@ class ChatRoomPage extends ConsumerWidget {
               PopupMenuButton<void>(
                 itemBuilder: (context) => [
                   PopupMenuItem(
-                    onTap: () => copyToClipboard(context, url.toString()),
-                    child: ListTile(
-                      leading: const Icon(Icons.copy),
-                      title: Text(t.misskey.copyLink),
-                    ),
-                  ),
-                  PopupMenuItem(
                     onTap: () => launchUrl(ref, url),
                     child: ListTile(
                       leading: const Icon(Icons.open_in_browser),
                       title: Text(t.aria.openInBrowser),
+                    ),
+                  ),
+                  PopupMenuItem(
+                    onTap: () => copyToClipboard(context, url.toString()),
+                    child: ListTile(
+                      leading: const Icon(Icons.copy),
+                      title: Text(t.misskey.copyLink),
                     ),
                   ),
                   if (userId != null)

--- a/lib/view/page/gallery/gallery_post_page.dart
+++ b/lib/view/page/gallery/gallery_post_page.dart
@@ -74,12 +74,12 @@ class GalleryPostPage extends ConsumerWidget {
                 ),
               ],
               PopupMenuItem(
-                onTap: () => copyToClipboard(context, url.toString()),
-                child: Text(t.misskey.copyLink),
-              ),
-              PopupMenuItem(
                 onTap: () => launchUrl(ref, url),
                 child: Text(t.aria.openInBrowser),
+              ),
+              PopupMenuItem(
+                onTap: () => copyToClipboard(context, url.toString()),
+                child: Text(t.misskey.copyLink),
               ),
               PopupMenuItem(
                 onTap: () => SharePlus.instance.share(
@@ -233,15 +233,15 @@ class GalleryPostPage extends ConsumerWidget {
                           icon: const Icon(Icons.repeat_rounded),
                         ),
                       IconButton(
+                        tooltip: t.aria.openInBrowser,
+                        onPressed: () => launchUrl(ref, url),
+                        icon: const Icon(Icons.open_in_browser),
+                      ),
+                      IconButton(
                         tooltip: t.misskey.copyLink,
                         onPressed: () =>
                             copyToClipboard(context, url.toString()),
                         icon: const Icon(Icons.link),
-                      ),
-                      IconButton(
-                        tooltip: t.aria.openInBrowser,
-                        onPressed: () => launchUrl(ref, url),
-                        icon: const Icon(Icons.open_in_browser),
                       ),
                       IconButton(
                         tooltip: t.misskey.share,

--- a/lib/view/page/page/page_page.dart
+++ b/lib/view/page/page/page_page.dart
@@ -205,12 +205,12 @@ class PagePage extends ConsumerWidget {
                   child: Text(t.misskey.shareWithNote),
                 ),
               PopupMenuItem(
-                onTap: () => copyToClipboard(context, url.toString()),
-                child: Text(t.misskey.copyLink),
-              ),
-              PopupMenuItem(
                 onTap: () => launchUrl(ref, url),
                 child: Text(t.aria.openInBrowser),
+              ),
+              PopupMenuItem(
+                onTap: () => copyToClipboard(context, url.toString()),
+                child: Text(t.misskey.copyLink),
               ),
               PopupMenuItem(
                 onTap: () => SharePlus.instance.share(
@@ -428,15 +428,15 @@ class PagePage extends ConsumerWidget {
                           icon: const Icon(Icons.repeat_rounded),
                         ),
                       IconButton(
+                        tooltip: t.aria.openInBrowser,
+                        onPressed: () => launchUrl(ref, url),
+                        icon: const Icon(Icons.open_in_browser),
+                      ),
+                      IconButton(
                         tooltip: t.misskey.copyLink,
                         onPressed: () =>
                             copyToClipboard(context, url.toString()),
                         icon: const Icon(Icons.link),
-                      ),
-                      IconButton(
-                        tooltip: t.aria.openInBrowser,
-                        onPressed: () => launchUrl(ref, url),
-                        icon: const Icon(Icons.open_in_browser),
                       ),
                       IconButton(
                         tooltip: t.misskey.share,

--- a/lib/view/page/play/play_page.dart
+++ b/lib/view/page/play/play_page.dart
@@ -62,12 +62,12 @@ class PlayPage extends HookConsumerWidget {
                   child: Text(t.misskey.shareWithNote),
                 ),
               PopupMenuItem(
-                onTap: () => copyToClipboard(context, url.toString()),
-                child: Text(t.misskey.copyLink),
-              ),
-              PopupMenuItem(
                 onTap: () => launchUrl(ref, url),
                 child: Text(t.aria.openInBrowser),
+              ),
+              PopupMenuItem(
+                onTap: () => copyToClipboard(context, url.toString()),
+                child: Text(t.misskey.copyLink),
               ),
               PopupMenuItem(
                 onTap: () => SharePlus.instance.share(

--- a/lib/view/page/server/server_page.dart
+++ b/lib/view/page/server/server_page.dart
@@ -113,14 +113,14 @@ class ServerPage extends HookConsumerWidget {
                       context.push('/$account/explore/users?host=$host'),
                 ),
               ListTile(
-                leading: const Icon(Icons.copy),
-                title: Text(t.misskey.copyLink),
-                onTap: () => copyToClipboard(context, host),
-              ),
-              ListTile(
                 leading: const Icon(Icons.open_in_browser),
                 title: Text(t.aria.openInBrowser),
                 onTap: () => launchUrl(ref, serverUrl),
+              ),
+              ListTile(
+                leading: const Icon(Icons.copy),
+                title: Text(t.misskey.copyLink),
+                onTap: () => copyToClipboard(context, host),
               ),
             ],
           ),

--- a/lib/view/widget/play_widget.dart
+++ b/lib/view/widget/play_widget.dart
@@ -151,15 +151,15 @@ class PlayWidget extends HookConsumerWidget {
                                   icon: const Icon(Icons.repeat_rounded),
                                 ),
                               IconButton(
+                                tooltip: t.aria.openInBrowser,
+                                onPressed: () => launchUrl(ref, url),
+                                icon: const Icon(Icons.open_in_browser),
+                              ),
+                              IconButton(
                                 tooltip: t.misskey.copyLink,
                                 onPressed: () =>
                                     copyToClipboard(context, url.toString()),
                                 icon: const Icon(Icons.link),
-                              ),
-                              IconButton(
-                                tooltip: t.aria.openInBrowser,
-                                onPressed: () => launchUrl(ref, url),
-                                icon: const Icon(Icons.open_in_browser),
                               ),
                               IconButton(
                                 tooltip: t.misskey.share,


### PR DESCRIPTION
Reordered items in popup menus so that the "Open in browser" button is above the "Copy link" button in all menus.