### PR TITLE
perf: use JsonCacheInfoRepository for all platforms

### DIFF
--- a/lib/provider/cache_manager_provider.g.dart
+++ b/lib/provider/cache_manager_provider.g.dart
@@ -6,7 +6,7 @@ part of 'cache_manager_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$cacheManagerHash() => r'63556bcee54c9b9c5d46b2b588279e3033895b41';
+String _$cacheManagerHash() => r'221bc87cca5305060ad2e49b22ea483ce9b9126b';
 
 /// See also [cacheManager].
 @ProviderFor(cacheManager)

--- a/lib/view/page/settings/behavior_page.dart
+++ b/lib/view/page/settings/behavior_page.dart
@@ -12,6 +12,7 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import '../../../constant/max_content_width.dart';
 import '../../../i18n/strings.g.dart';
 import '../../../model/general_settings.dart';
+import '../../../provider/cache_manager_provider.dart';
 import '../../../provider/cache_size_provider.dart';
 import '../../../provider/general_settings_notifier_provider.dart';
 import '../../../util/future_with_dialog.dart';
@@ -572,19 +573,19 @@ class BehaviorPage extends HookConsumerWidget {
                   }),
                   trailing: const Icon(Icons.navigate_next),
                   enabled: cacheSize.valueOrNull != 0,
-                  onTap: () async {
-                    await futureWithDialog(
-                      context,
-                      getApplicationCacheDirectory().then(
-                        (cacheDir) => Future.wait(
-                          cacheDir.listSync().map(
-                            (e) => e.delete(recursive: true),
-                          ),
+                  onTap: () => futureWithDialog(
+                    context,
+                    Future(() async {
+                      await ref.read(cacheManagerProvider).emptyCache();
+                      final cacheDir = await getApplicationCacheDirectory();
+                      await Future.wait(
+                        cacheDir.listSync().map(
+                          (e) => e.delete(recursive: true),
                         ),
-                      ),
-                    );
-                    ref.invalidate(cacheSizeProvider);
-                  },
+                      );
+                      ref.invalidate(cacheSizeProvider);
+                    }),
+                  ),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8.0),
                   ),


### PR DESCRIPTION
Changed the `repo` of `CacheManager` to [`JsonCacheInfoRepository`](https://pub.dev/documentation/flutter_cache_manager/latest/flutter_cache_manager/JsonCacheInfoRepository-class.html) because its read and write speeds are significantly faster than that of the default [`CacheObjectProvider`](https://pub.dev/documentation/flutter_cache_manager/latest/flutter_cache_manager/CacheObjectProvider-class.html).

Also, increased the maximum number of caches to improve the likelihood of cache hits.