### PR TITLE
build: remove fvp from platforms not using it

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,10 +18,6 @@ PODS:
     - Flutter
   - fluttertoast (0.0.2):
     - Flutter
-  - fvp (0.34.0):
-    - Flutter
-    - FlutterMacOS
-    - mdk (~> 0.34.0)
   - image_editor_common (1.0.0):
     - Flutter
   - libwebp (1.3.2):
@@ -39,7 +35,6 @@ PODS:
   - Mantle (2.2.0):
     - Mantle/extobjc (= 2.2.0)
   - Mantle/extobjc (2.2.0)
-  - mdk (0.34.0)
   - OrderedSet (6.0.3)
   - receive_sharing_intent (1.8.1):
     - Flutter
@@ -62,7 +57,6 @@ DEPENDENCIES:
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-  - fvp (from `.symlinks/plugins/fvp/darwin`)
   - image_editor_common (from `.symlinks/plugins/image_editor_common/ios`)
   - receive_sharing_intent (from `.symlinks/plugins/receive_sharing_intent/ios`)
   - rust_lib_aria (from `.symlinks/plugins/rust_lib_aria/ios`)
@@ -72,7 +66,6 @@ SPEC REPOS:
   trunk:
     - libwebp
     - Mantle
-    - mdk
     - OrderedSet
     - SDWebImage
     - SDWebImageWebPCoder
@@ -90,8 +83,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
-  fvp:
-    :path: ".symlinks/plugins/fvp/darwin"
   image_editor_common:
     :path: ".symlinks/plugins/image_editor_common/ios"
   receive_sharing_intent:
@@ -108,11 +99,9 @@ SPEC CHECKSUMS:
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
   fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
-  fvp: 0ba1ba9d2adfbb9baea21009d94b561330910027
   image_editor_common: d6f6644ae4a6de80481e89fe6d0a8c49e30b4b43
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  mdk: c54ab482a3457f754b2bf6b4b615c117379f5885
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
   rust_lib_aria: 0c3df7954648e308ecb56b46643d21fedce9a23d

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,6 @@ import flutter_image_compress_macos
 import flutter_inappwebview_macos
 import flutter_local_notifications
 import flutter_secure_storage_macos
-import fvp
 import image_editor_common
 import just_audio
 import package_info_plus
@@ -41,7 +40,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
-  FvpPlugin.register(with: registry.registrar(forPlugin: "FvpPlugin"))
   ImageEditorPlugin.register(with: registry.registrar(forPlugin: "ImageEditorPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,14 +7,9 @@ PODS:
   - flutter_secure_storage_macos (6.1.3):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - fvp (0.34.0):
-    - Flutter
-    - FlutterMacOS
-    - mdk (~> 0.34.0)
   - image_editor_common (1.0.0):
     - Flutter
     - FlutterMacOS
-  - mdk (0.34.0)
   - OrderedSet (6.0.3)
   - rust_lib_aria (0.0.1):
     - FlutterMacOS
@@ -29,7 +24,6 @@ DEPENDENCIES:
   - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
   - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - fvp (from `Flutter/ephemeral/.symlinks/plugins/fvp/darwin`)
   - image_editor_common (from `Flutter/ephemeral/.symlinks/plugins/image_editor_common/macos`)
   - rust_lib_aria (from `Flutter/ephemeral/.symlinks/plugins/rust_lib_aria/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
@@ -37,7 +31,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - mdk
     - OrderedSet
 
 EXTERNAL SOURCES:
@@ -49,8 +42,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  fvp:
-    :path: Flutter/ephemeral/.symlinks/plugins/fvp/darwin
   image_editor_common:
     :path: Flutter/ephemeral/.symlinks/plugins/image_editor_common/macos
   rust_lib_aria:
@@ -65,9 +56,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview_macos: bdf207b8f4ebd58e86ae06cd96b147de99a67c9b
   flutter_secure_storage_macos: c2754d3483d20bb207bb9e5a14f1b8e771abcdb9
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  fvp: 0ba1ba9d2adfbb9baea21009d94b561330910027
   image_editor_common: 1b11f59fad8909bafcdaa0f31cc9373425b58600
-  mdk: c54ab482a3457f754b2bf6b4b615c117379f5885
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   rust_lib_aria: 793a1cb9897092ee3e848adb8d284dee13466e34
   screen_retriever_macos: 776e0fa5d42c6163d2bf772d22478df4b302b161

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -933,11 +933,12 @@ packages:
   fvp:
     dependency: "direct main"
     description:
-      name: fvp
-      sha256: a2850b856e177cb48f3e49940613f2180f3375bcceab2f75e3d7b915009a2840
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.34.0"
+      path: "."
+      ref: "179602adaddc48963c8650f8ee12e99ab1183df7"
+      resolved-ref: "179602adaddc48963c8650f8ee12e99ab1183df7"
+      url: "https://github.com/poppingmoon/fvp"
+    source: git
+    version: "0.35.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,10 @@ dependencies:
   flutter_svg: ^2.2.1
   fluttertoast: ^8.2.14
   freezed_annotation: ^3.1.0
-  fvp: ^0.34.0
+  fvp:
+    git:
+      url: https://github.com/poppingmoon/fvp
+      ref: 179602adaddc48963c8650f8ee12e99ab1183df7
   go_router: ^16.2.4
   highlighting:
     git:


### PR DESCRIPTION
Changed to use the [forked version of fvp](https://github.com/poppingmoon/fvp) which omits implementations for platforms other than Windows and Linux.

Aria uses fvp only on Windows and Linux, so the library is not needed for other platforms.

ref: #743