### PR TITLE
fix: hide message button in timeline menu if not logged in

### DIFF
--- a/lib/view/widget/timeline_menu.dart
+++ b/lib/view/widget/timeline_menu.dart
@@ -63,7 +63,8 @@ class TimelineMenu extends ConsumerWidget {
                 ),
               ),
             ),
-          if (i?.policies?.chatAvailability != ChatAvailability.unavailable &&
+          if (i != null &&
+              i.policies?.chatAvailability != ChatAvailability.unavailable &&
               (endpoints?.contains('chat/history') ?? true))
             Card(
               clipBehavior: Clip.hardEdge,
@@ -75,7 +76,7 @@ class TimelineMenu extends ConsumerWidget {
                     Stack(
                       children: [
                         const Icon(Icons.message),
-                        if (i?.hasUnreadChatMessages ?? false)
+                        if (i.hasUnreadChatMessages ?? false)
                           DecoratedBox(
                             decoration: BoxDecoration(
                               shape: BoxShape.circle,


### PR DESCRIPTION
Fixed an issue where the direct message button appeared in the timeline menu even when the account for the tab was a guest.