### PR TITLE
feat: add copy remote link button

### DIFF
--- a/lib/view/widget/note_sheet.dart
+++ b/lib/view/widget/note_sheet.dart
@@ -187,6 +187,15 @@ class NoteSheet extends ConsumerWidget {
               context.pop();
             },
           ),
+          if (remoteUrl != null)
+            ListTile(
+              leading: const Icon(Icons.public),
+              title: Text(t.misskey.copyRemoteLink),
+              onTap: () {
+                copyToClipboard(context, remoteUrl.toString());
+                context.pop();
+              },
+            ),
           ListTile(
             leading: const Icon(Icons.open_in_browser),
             title: Text(t.aria.openInBrowser),


### PR DESCRIPTION
Added a button in `NoteSheet` which copies the link of the note on the remote server.

ref: [misskey-dev/misskey#15091](https://redirect.github.com/misskey-dev/misskey/pull/15091)

Fix #770 