### PR TITLE
fix: add error message for push notification registration

### DIFF
--- a/lib/i18n/aria/aria.i18n.yaml
+++ b/lib/i18n/aria/aria.i18n.yaml
@@ -66,6 +66,8 @@ i18nInfo(rich): "Aria is being translated into various languages by volunteers. 
 iconAttribution(rich): "The icon of Aria was created by {sevenc_nanashi} and is licensed under {cc_by}."
 importCompleted: "Import completed"
 importConfirm: "Are you sure you want to import settings? Existing settings will be overwritten."
+invalidEndpoint: "Invalid endpoint"
+invalidEndpointDescription: "The endpoint in the response is invalid. Please make sure that the code you are running matches the one provided in the app."
 invalidListFormat: "List format is invalid"
 jumpTo: "Jump to {x}"
 keepOpen: "Keep open"

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 31
-/// Strings: 68932 (2223 per locale)
+/// Strings: 68934 (2223 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en_US.g.dart
+++ b/lib/i18n/strings_en_US.g.dart
@@ -274,6 +274,12 @@ class TranslationsAriaEnUs {
 	/// en-US: 'Are you sure you want to import settings? Existing settings will be overwritten.'
 	String get importConfirm => 'Are you sure you want to import settings? Existing settings will be overwritten.';
 
+	/// en-US: 'Invalid endpoint'
+	String get invalidEndpoint => 'Invalid endpoint';
+
+	/// en-US: 'The endpoint in the response is invalid. Please make sure that the code you are running matches the one provided in the app.'
+	String get invalidEndpointDescription => 'The endpoint in the response is invalid. Please make sure that the code you are running matches the one provided in the app.';
+
 	/// en-US: 'List format is invalid'
 	String get invalidListFormat => 'List format is invalid';
 

--- a/lib/view/page/settings/notifications_settings_page.dart
+++ b/lib/view/page/settings/notifications_settings_page.dart
@@ -235,10 +235,10 @@ class NotificationsSettingsPage extends ConsumerWidget {
                     ? (_) => _unsubscribe(ref)
                     : i != null && isPushNotificationSupported
                     ? (_) async {
-                        await _subscribe(ref);
                         await ref
                             .read(userIdsNotifierProvider.notifier)
                             .add(account, i.id);
+                        await _subscribe(ref);
                       }
                     : null,
                 tileColor: theme.colorScheme.surface,


### PR DESCRIPTION
Changed to show instructions when the registration in `SwRegisterDialog` fails.

ref: https://github.com/poppingmoon/aria/issues/762#issuecomment-3381000341

<details>
<summary>Screenshots</summary>

![](https://github.com/user-attachments/assets/1257ea5d-b485-41dc-84f8-f227bcb02e13)
![](https://github.com/user-attachments/assets/3925dc3e-5404-4b7b-b5cf-c5515d26b903)
</details>