### PR TITLE
fix: handle empty translation response

### DIFF
--- a/lib/provider/api/translated_note_provider.dart
+++ b/lib/provider/api/translated_note_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -7,14 +9,27 @@ import 'misskey_provider.dart';
 part 'translated_note_provider.g.dart';
 
 @riverpod
-FutureOr<NotesTranslateResponse> translatedNote(
+FutureOr<NotesTranslateResponse?> translatedNote(
   Ref ref,
   Account account,
   String noteId,
   String targetLang,
 ) {
-  return ref
-      .watch(misskeyProvider(account))
-      .notes
-      .translate(NotesTranslateRequest(noteId: noteId, targetLang: targetLang));
+  final link = ref.keepAlive();
+  Timer? timer;
+  ref.onCancel(() => timer = Timer(const Duration(minutes: 5), link.close));
+  ref.onResume(() => timer?.cancel());
+  ref.onDispose(() => timer?.cancel());
+  try {
+    return ref
+        .watch(misskeyProvider(account))
+        .notes
+        .translate(
+          NotesTranslateRequest(noteId: noteId, targetLang: targetLang),
+        );
+  } catch (_) {
+    timer?.cancel();
+    link.close();
+    rethrow;
+  }
 }

--- a/lib/provider/api/translated_note_provider.g.dart
+++ b/lib/provider/api/translated_note_provider.g.dart
@@ -15,13 +15,13 @@ final translatedNoteProvider = TranslatedNoteFamily._();
 final class TranslatedNoteProvider
     extends
         $FunctionalProvider<
-          AsyncValue<NotesTranslateResponse>,
-          NotesTranslateResponse,
-          FutureOr<NotesTranslateResponse>
+          AsyncValue<NotesTranslateResponse?>,
+          NotesTranslateResponse?,
+          FutureOr<NotesTranslateResponse?>
         >
     with
-        $FutureModifier<NotesTranslateResponse>,
-        $FutureProvider<NotesTranslateResponse> {
+        $FutureModifier<NotesTranslateResponse?>,
+        $FutureProvider<NotesTranslateResponse?> {
   TranslatedNoteProvider._({
     required TranslatedNoteFamily super.from,
     required (Account, String, String) super.argument,
@@ -45,12 +45,12 @@ final class TranslatedNoteProvider
 
   @$internal
   @override
-  $FutureProviderElement<NotesTranslateResponse> $createElement(
+  $FutureProviderElement<NotesTranslateResponse?> $createElement(
     $ProviderPointer pointer,
   ) => $FutureProviderElement(pointer);
 
   @override
-  FutureOr<NotesTranslateResponse> create(Ref ref) {
+  FutureOr<NotesTranslateResponse?> create(Ref ref) {
     final argument = this.argument as (Account, String, String);
     return translatedNote(ref, argument.$1, argument.$2, argument.$3);
   }
@@ -66,12 +66,12 @@ final class TranslatedNoteProvider
   }
 }
 
-String _$translatedNoteHash() => r'e59caed4eda77ad53b60e79ca086d203c20a729b';
+String _$translatedNoteHash() => r'b918d5336b98438db6320e82e5f52bee2e365172';
 
 final class TranslatedNoteFamily extends $Family
     with
         $FunctionalFamilyOverride<
-          FutureOr<NotesTranslateResponse>,
+          FutureOr<NotesTranslateResponse?>,
           (Account, String, String)
         > {
   TranslatedNoteFamily._()

--- a/lib/view/widget/translated_note_sheet.dart
+++ b/lib/view/widget/translated_note_sheet.dart
@@ -38,9 +38,13 @@ class TranslatedNoteSheet extends ConsumerWidget {
               title: Text(
                 t.misskey.translatedFrom(x: translatedNote.sourceLang),
               ),
-              trailing: IconButton(
-                onPressed: () => copyToClipboard(context, translatedNote.text),
-                icon: const Icon(Icons.copy),
+              trailing: IconButtonTheme(
+                data: const IconButtonThemeData(),
+                child: IconButton(
+                  onPressed: () =>
+                      copyToClipboard(context, translatedNote.text),
+                  icon: const Icon(Icons.copy),
+                ),
               ),
             ),
             const Divider(height: 0.0),
@@ -55,6 +59,19 @@ class TranslatedNoteSheet extends ConsumerWidget {
                   author: note.user,
                   noteId: note.id,
                   nyaize: true,
+                ),
+              ),
+            ),
+          ],
+          AsyncValue(hasValue: true) => [
+            ListTile(title: Text(t.misskey.translate)),
+            const Divider(height: 0.0),
+            SizedBox(
+              width: double.infinity,
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(t.misskey.nothing),
                 ),
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1337,8 +1337,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0c78912076e8cd70b57224c75ec510904d043946"
-      resolved-ref: "0c78912076e8cd70b57224c75ec510904d043946"
+      ref: cca00d86bf0ad1039f673381428fa3941a7e79c0
+      resolved-ref: cca00d86bf0ad1039f673381428fa3941a7e79c0
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,7 +92,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: 0c78912076e8cd70b57224c75ec510904d043946
+      ref: cca00d86bf0ad1039f673381428fa3941a7e79c0
   multi_split_view: ^3.6.1
   package_info_plus: ^9.0.0
   path: ^1.9.1


### PR DESCRIPTION
Changed `TranslatedNoteSheet` to indicate that the translation result is empty when a note without text is translated.

Fix #783

<details>
<summary>Screenshot</summary>

![](https://github.com/user-attachments/assets/e63e466e-dbfb-4805-bebe-088c85bc5668)

</details>