### PR TITLE
fix: remove empty comment when updating drive file

### DIFF
--- a/lib/provider/api/drive_file_notifier_provider.dart
+++ b/lib/provider/api/drive_file_notifier_provider.dart
@@ -18,23 +18,42 @@ class DriveFileNotifier extends _$DriveFileNotifier {
         .show(DriveFilesShowRequest(fileId: fileId));
   }
 
-  Future<void> updateFile({
-    String? name,
-    bool? isSensitive,
-    String? comment,
-  }) async {
+  Future<void> updateName(String name) async {
+    final response = await ref
+        .read(misskeyProvider(account))
+        .drive
+        .files
+        .update(DriveFilesUpdateRequest(fileId: fileId, name: name));
+    state = AsyncValue.data(response);
+    ref
+        .read(driveFilesNotifierProvider(account, response.folderId).notifier)
+        .replace(response);
+  }
+
+  Future<void> updateIsSensitive(bool isSensitive) async {
     final response = await ref
         .read(misskeyProvider(account))
         .drive
         .files
         .update(
-          DriveFilesUpdateRequest(
-            fileId: fileId,
-            name: name,
-            isSensitive: isSensitive,
-            comment: comment,
-          ),
+          DriveFilesUpdateRequest(fileId: fileId, isSensitive: isSensitive),
         );
+    state = AsyncValue.data(response);
+    ref
+        .read(driveFilesNotifierProvider(account, response.folderId).notifier)
+        .replace(response);
+  }
+
+  Future<void> updateComment(String? comment) async {
+    final response = await ref
+        .read(misskeyProvider(account))
+        .apiService
+        .post<Map<String, dynamic>>(
+          'drive/files/update',
+          DriveFilesUpdateRequest(fileId: fileId, comment: comment).toJson(),
+          excludeRemoveNullPredicate: (key, _) => key == 'comment',
+        )
+        .then((response) => DriveFile.fromJson(response));
     state = AsyncValue.data(response);
     ref
         .read(driveFilesNotifierProvider(account, response.folderId).notifier)

--- a/lib/provider/api/drive_file_notifier_provider.g.dart
+++ b/lib/provider/api/drive_file_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class DriveFileNotifierProvider
   }
 }
 
-String _$driveFileNotifierHash() => r'089739ee8d5b2d93121b4049441aac475c55c466';
+String _$driveFileNotifierHash() => r'923aef0869e9fbd7933cfdda4b1aae9d2e2f79e5';
 
 final class DriveFileNotifierFamily extends $Family
     with

--- a/lib/provider/api/drive_files_notifier_provider.dart
+++ b/lib/provider/api/drive_files_notifier_provider.dart
@@ -140,20 +140,42 @@ class DriveFilesNotifier extends _$DriveFilesNotifier {
     );
   }
 
-  Future<void> updateFile({
-    required String fileId,
-    String? name,
-    bool? isSensitive,
-    String? comment,
-  }) async {
+  Future<void> updateName(String fileId, String name) async {
     final response = await _misskey.drive.files.update(
-      DriveFilesUpdateRequest(
-        fileId: fileId,
-        name: name,
-        isSensitive: isSensitive,
-        comment: comment,
+      DriveFilesUpdateRequest(fileId: fileId, name: name),
+    );
+    final value = state.value ?? const PaginationState();
+    state = AsyncValue.data(
+      value.copyWith(
+        items: value.items
+            .map((file) => file.id == fileId ? response : file)
+            .toList(),
       ),
     );
+  }
+
+  Future<void> updateIsSensitive(String fileId, bool isSensitive) async {
+    final response = await _misskey.drive.files.update(
+      DriveFilesUpdateRequest(fileId: fileId, isSensitive: isSensitive),
+    );
+    final value = state.value ?? const PaginationState();
+    state = AsyncValue.data(
+      value.copyWith(
+        items: value.items
+            .map((file) => file.id == fileId ? response : file)
+            .toList(),
+      ),
+    );
+  }
+
+  Future<void> updateComment(String fileId, String? comment) async {
+    final response = await _misskey.apiService
+        .post<Map<String, dynamic>>(
+          'drive/files/update',
+          DriveFilesUpdateRequest(fileId: fileId, comment: comment).toJson(),
+          excludeRemoveNullPredicate: (key, _) => key == 'comment',
+        )
+        .then((response) => DriveFile.fromJson(response));
     final value = state.value ?? const PaginationState();
     state = AsyncValue.data(
       value.copyWith(

--- a/lib/provider/api/drive_files_notifier_provider.g.dart
+++ b/lib/provider/api/drive_files_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class DriveFilesNotifierProvider
 }
 
 String _$driveFilesNotifierHash() =>
-    r'25f14394f1613b4797d429719051b968d8c52428';
+    r'f1a8f61fd487045b7e143a9d1c0ac3f930f6a61c';
 
 final class DriveFilesNotifierFamily extends $Family
     with

--- a/lib/view/widget/drive_file_info.dart
+++ b/lib/view/widget/drive_file_info.dart
@@ -38,7 +38,7 @@ class DriveFileInfo extends ConsumerWidget {
         ref.context,
         ref
             .read(driveFileNotifierProvider(account, file.id).notifier)
-            .updateFile(name: name),
+            .updateName(name),
       );
     }
   }
@@ -55,7 +55,7 @@ class DriveFileInfo extends ConsumerWidget {
         ref.context,
         ref
             .read(driveFileNotifierProvider(account, file.id).notifier)
-            .updateFile(comment: comment),
+            .updateComment(comment.isNotEmpty ? comment : null),
       );
     }
   }
@@ -64,7 +64,7 @@ class DriveFileInfo extends ConsumerWidget {
     if (isSensitive == null) return;
     await ref
         .read(driveFileNotifierProvider(account, file.id).notifier)
-        .updateFile(isSensitive: isSensitive);
+        .updateIsSensitive(isSensitive);
   }
 
   @override

--- a/lib/view/widget/drive_file_sheet.dart
+++ b/lib/view/widget/drive_file_sheet.dart
@@ -42,7 +42,7 @@ class DriveFileSheet extends ConsumerWidget {
         ref.context,
         ref
             .read(driveFilesNotifierProvider(account, file.folderId).notifier)
-            .updateFile(fileId: file.id, name: result),
+            .updateName(file.id, result),
       );
       if (!ref.context.mounted) return;
       ref.context.pop();
@@ -54,7 +54,7 @@ class DriveFileSheet extends ConsumerWidget {
       ref.context,
       ref
           .read(driveFilesNotifierProvider(account, file.folderId).notifier)
-          .updateFile(fileId: file.id, isSensitive: isSensitive),
+          .updateIsSensitive(file.id, isSensitive),
     );
     if (!ref.context.mounted) return;
     ref.context.pop();
@@ -72,7 +72,7 @@ class DriveFileSheet extends ConsumerWidget {
         ref.context,
         ref
             .read(driveFilesNotifierProvider(account, file.folderId).notifier)
-            .updateFile(fileId: file.id, comment: result),
+            .updateComment(file.id, result.isNotEmpty ? result : null),
       );
       if (!ref.context.mounted) return;
       ref.context.pop();

--- a/lib/view/widget/post_form_attaches.dart
+++ b/lib/view/widget/post_form_attaches.dart
@@ -175,14 +175,16 @@ class PostFormAttaches extends ConsumerWidget {
             ref.context,
             ref
                 .read(misskeyProvider(account))
-                .drive
-                .files
-                .update(
+                .apiService
+                .post<Map<String, dynamic>>(
+                  'drive/files/update',
                   DriveFilesUpdateRequest(
                     fileId: file.file.id,
-                    comment: result,
-                  ),
-                ),
+                    comment: result.isNotEmpty ? result : null,
+                  ).toJson(),
+                  excludeRemoveNullPredicate: (key, _) => key == 'comment',
+                )
+                .then((response) => DriveFile.fromJson(response)),
           );
           if (driveFile != null) {
             ref
@@ -206,7 +208,10 @@ class PostFormAttaches extends ConsumerWidget {
                   chat: chat,
                 ).notifier,
               )
-              .replace(index, file.copyWith(comment: result));
+              .replace(
+                index,
+                file.copyWith(comment: result.isNotEmpty ? result : null),
+              );
       }
     }
     if (!ref.context.mounted) return;


### PR DESCRIPTION
Changed to use `null` instead of an empty string when updating the drive file's comment to empty.

ref: [misskey-dev/misskey#16737](https://redirect.github.com/misskey-dev/misskey/issues/16737)
ref: shiosyakeyakini-info/miria#849