### PR TITLE
fix: show image placeholder with stack

### DIFF
--- a/lib/view/widget/image_widget.dart
+++ b/lib/view/widget/image_widget.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -46,6 +47,7 @@ class ImageWidget extends ConsumerWidget {
         height: height,
         child: BlurHash(
           hash: blurHash,
+          color: Colors.transparent,
           optimizationMode: BlurHashOptimizationMode.approximation,
         ),
       );
@@ -93,23 +95,21 @@ class ImageWidget extends ConsumerWidget {
       );
     }
     if (enableFadeIn) {
-      return Semantics(
-        label: semanticLabel,
-        child: CachedNetworkImage(
-          imageUrl: url,
-          httpHeaders: {'User-Agent': ?userAgent},
-          width: width,
-          height: height,
-          fit: fit,
-          alignment: alignment,
+      return _FadeImageWidget(
+        image: CachedNetworkImageProvider(
+          url,
+          headers: {'User-Agent': ?userAgent},
           cacheManager: cacheManager,
-          placeholder: (context, _) => _buildPlaceholder(context),
-          errorWidget:
-              errorBuilder ?? (context, _, _) => _buildPlaceholder(context),
-          color: opacity < 1.0 ? Color.fromRGBO(255, 255, 255, opacity) : null,
-          colorBlendMode: BlendMode.modulate,
-          fadeOutDuration: Duration.zero,
         ),
+        width: width,
+        height: height,
+        fit: fit,
+        alignment: alignment,
+        opacity: opacity,
+        placeholderBuilder: _buildPlaceholder,
+        errorBuilder:
+            errorBuilder ?? (context, _, _) => _buildPlaceholder(context),
+        semanticLabel: semanticLabel,
       );
     } else {
       return Image(
@@ -132,5 +132,118 @@ class ImageWidget extends ConsumerWidget {
         semanticLabel: semanticLabel,
       );
     }
+  }
+}
+
+class _FadeImageWidget extends HookWidget {
+  const _FadeImageWidget({
+    required this.image,
+    this.width,
+    this.height,
+    this.fit,
+    this.alignment = Alignment.center,
+    this.opacity = 1.0,
+    required this.placeholderBuilder,
+    this.errorBuilder,
+    this.semanticLabel,
+  });
+
+  final ImageProvider<Object> image;
+  final double? width;
+  final double? height;
+  final BoxFit? fit;
+  final AlignmentGeometry alignment;
+  final double opacity;
+  final Widget Function(BuildContext context) placeholderBuilder;
+  final Widget Function(BuildContext, Object, Object?)? errorBuilder;
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoaded = useState(false);
+    final controller = useAnimationController(
+      duration: const Duration(milliseconds: 500),
+    );
+    useEffect(() {
+      void callback() {
+        if (isLoaded.value && !controller.isAnimating) {
+          controller.forward(from: 0.0);
+        }
+      }
+
+      callback();
+      isLoaded.addListener(callback);
+      return () => isLoaded.removeListener(callback);
+    }, []);
+
+    return Image(
+      image: image,
+      width: width,
+      height: height,
+      fit: fit,
+      alignment: alignment,
+      opacity: AlwaysStoppedAnimation(opacity),
+      frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+        if (wasSynchronouslyLoaded) {
+          return child;
+        }
+        Future(() => isLoaded.value = frame != null);
+        return _FadeStack(
+          controller: controller,
+          placeholderBuilder: placeholderBuilder,
+          child: child,
+        );
+      },
+      errorBuilder:
+          errorBuilder ?? (context, _, _) => placeholderBuilder(context),
+      semanticLabel: semanticLabel,
+    );
+  }
+}
+
+class _FadeStack extends HookWidget {
+  const _FadeStack({
+    required this.controller,
+    required this.placeholderBuilder,
+    required this.child,
+  });
+
+  final AnimationController controller;
+  final Widget Function(BuildContext context) placeholderBuilder;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final animationStatus = useState(AnimationStatus.dismissed);
+    useEffect(() {
+      void callback(AnimationStatus status) {
+        animationStatus.value = status;
+      }
+
+      callback(controller.status);
+      controller.addStatusListener(callback);
+      return () => controller.removeStatusListener(callback);
+    }, []);
+
+    return Stack(
+      alignment: Alignment.center,
+      fit: StackFit.passthrough,
+      children: [
+        if (!animationStatus.value.isCompleted)
+          FadeTransition(
+            opacity: Tween(begin: 1.0, end: 0.0).animate(
+              CurveTween(
+                curve: const Interval(0.0, 0.5, curve: Curves.easeOut),
+              ).animate(controller),
+            ),
+            child: placeholderBuilder(context),
+          ),
+        if (animationStatus.value.isForwardOrCompleted)
+          FadeTransition(
+            opacity: CurveTween(curve: Curves.easeIn).animate(controller),
+            child: child,
+          ),
+      ],
+    );
   }
 }


### PR DESCRIPTION
Replaced `CachedNetworkImage` with `Stack` and `FadeTransition` widgets.

The placeholder of `CachedNetworkImage` flickers when the image finishes loading. With the new widgets, the placeholder remains visible while loading and begins to fade out as the image fades in.