### PR TITLE
test: unify integration tests into one file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 3
-          command: flutter test integration_test --ignore-timeouts
+          command: flutter test integration_test/all_tests.dart --ignore-timeouts
 
   check-i18n-sorting:
     runs-on: ubuntu-latest

--- a/integration_test/all_tests.dart
+++ b/integration_test/all_tests.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'play_test.dart' as play_test;
+import 'timeline_test.dart' as timeline_test;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Play', play_test.main);
+  group('timeline', timeline_test.main);
+}


### PR DESCRIPTION
Added `all_tests.dart`, which runs all integration tests.

Changed to run that file in the integration test job of the CI workflow to reduce setup time.