### PR TITLE
fix: restore media saving

### DIFF
--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage",
       "state" : {
-        "revision" : "34cf2423a2c4088d06a3b08655603b5bc3eeeb3a",
-        "version" : "5.21.2"
+        "revision" : "36e79ba485e9bb4d3cd4e3318908866dac5e7b51",
+        "version" : "5.21.5"
       }
     },
     {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -56,13 +56,13 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>To take photos or videos, please allow permission to access your camera.</string>
+	<string>To take photos or videos, please allow access to your camera.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>To record audio files, please allow permission to access your microphone.</string>
+	<string>To record audio files, please allow access to your microphone.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>To download files, please allow permission to access your photo library.</string>
+	<string>To download files, please allow access to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>To upload files, please allow permission to access your photo library.</string>
+	<string>To upload files, please allow access to your photo library.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/lib/view/dialog/audio_dialog.dart
+++ b/lib/view/dialog/audio_dialog.dart
@@ -314,8 +314,8 @@ class _AudioHeader extends ConsumerWidget {
                 }
               },
               child: ListTile(
-                leading: const Icon(Icons.download),
-                title: Text(t.misskey.download),
+                leading: const Icon(Icons.download_outlined),
+                title: Text(t.misskey.saveAs),
               ),
             ),
             PopupMenuItem(

--- a/lib/view/dialog/image_gallery_dialog.dart
+++ b/lib/view/dialog/image_gallery_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:gal/gal.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:misskey_dart/misskey_dart.dart' hide Clip;
@@ -25,6 +26,7 @@ import '../widget/image_widget.dart';
 import '../widget/note_summary.dart';
 import '../widget/time_widget.dart';
 import '../widget/user_avatar.dart';
+import 'message_dialog.dart';
 
 Future<void> showImageGalleryDialog(
   BuildContext context, {
@@ -265,6 +267,31 @@ class ImageGalleryDialog extends HookConsumerWidget {
                             ),
                           PopupMenuItem(
                             onTap: () async {
+                              if (!await Gal.requestAccess()) {
+                                if (!context.mounted) return;
+                                await showMessageDialog(
+                                  context,
+                                  t.misskey.permissionDeniedError,
+                                );
+                                return;
+                              }
+                              if (!context.mounted) return;
+                              await futureWithDialog(
+                                context,
+                                ref
+                                    .read(cacheManagerProvider)
+                                    .getSingleFile(files[index.value].url)
+                                    .then((file) => Gal.putImage(file.path)),
+                                message: t.misskey.saved,
+                              );
+                            },
+                            child: ListTile(
+                              leading: const Icon(Icons.download),
+                              title: Text(t.misskey.save),
+                            ),
+                          ),
+                          PopupMenuItem(
+                            onTap: () async {
                               final file = files[index.value];
                               final result = await futureWithDialog(
                                 context,
@@ -288,8 +315,8 @@ class ImageGalleryDialog extends HookConsumerWidget {
                               }
                             },
                             child: ListTile(
-                              leading: const Icon(Icons.download),
-                              title: Text(t.misskey.download),
+                              leading: const Icon(Icons.download_outlined),
+                              title: Text(t.misskey.saveAs),
                             ),
                           ),
                           PopupMenuItem(

--- a/lib/view/dialog/video_dialog.dart
+++ b/lib/view/dialog/video_dialog.dart
@@ -4,6 +4,7 @@ import 'package:chewie/chewie.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:gal/gal.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -17,6 +18,7 @@ import '../../util/future_with_dialog.dart';
 import '../../util/launch_url.dart';
 import '../../util/show_toast.dart';
 import '../widget/image_widget.dart';
+import 'message_dialog.dart';
 
 class VideoDialog extends HookConsumerWidget {
   const VideoDialog({
@@ -123,6 +125,31 @@ class VideoDialog extends HookConsumerWidget {
                           title: Text(t.aria.showNote),
                         ),
                       ),
+                    PopupMenuItem(
+                      onTap: () async {
+                        if (!await Gal.requestAccess()) {
+                          if (!context.mounted) return;
+                          await showMessageDialog(
+                            context,
+                            t.misskey.permissionDeniedError,
+                          );
+                          return;
+                        }
+                        if (!context.mounted) return;
+                        await futureWithDialog(
+                          context,
+                          ref
+                              .read(cacheManagerProvider)
+                              .getSingleFile(url.toString())
+                              .then((file) => Gal.putVideo(file.path)),
+                          message: t.misskey.saved,
+                        );
+                      },
+                      child: ListTile(
+                        leading: const Icon(Icons.download_outlined),
+                        title: Text(t.misskey.save),
+                      ),
+                    ),
                     PopupMenuItem(
                       onTap: () async {
                         final result = await futureWithDialog(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import flutter_image_compress_macos
 import flutter_inappwebview_macos
 import flutter_local_notifications
 import flutter_secure_storage_darwin
+import gal
 import image_editor_common
 import isar_community_flutter_libs
 import just_audio
@@ -41,6 +42,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
+  GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   ImageEditorPlugin.register(with: registry.registrar(forPlugin: "ImageEditorPlugin"))
   IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -22,14 +22,16 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.social-networking</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To download files, please allow access to your photo library.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -947,6 +947,22 @@ packages:
       url: "https://github.com/poppingmoon/fvp"
     source: git
     version: "0.35.2"
+  gal:
+    dependency: "direct main"
+    description:
+      name: gal
+      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  gal_linux:
+    dependency: "direct main"
+    description:
+      name: gal_linux
+      sha256: "0040d61843134cc5a93e4597080a86f2ba073217957e28b2a684b4d8b050873c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,8 @@ dependencies:
     git:
       url: https://github.com/poppingmoon/fvp
       ref: 40be5996125c6ee95714a8be64d69fa49ad35724
+  gal: ^2.3.2
+  gal_linux: ^0.1.2
   go_router: ^17.0.1
   highlighting:
     git:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <fvp/fvp_plugin_c_api.h>
+#include <gal/gal_plugin_c_api.h>
 #include <isar_community_flutter_libs/isar_flutter_libs_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FvpPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FvpPluginCApi"));
+  GalPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GalPluginCApi"));
   IsarFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_inappwebview_windows
   flutter_secure_storage_windows
   fvp
+  gal
   isar_community_flutter_libs
   screen_retriever_windows
   share_plus


### PR DESCRIPTION
Restored a function to save images or videos via [`gal`](https://pub.dev/packages/gal), which was replaced by [`file_picker`](https://pub.dev/packages/file_picker) in #746.

With this PR, both options are available. The `gal` option saves a file quickly, while the `file_picker` option allows changing the file name and path.