### PR TITLE
build: add llvm-18-dev to build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,14 +63,16 @@ parts:
       - curl
       - git
       - libsecret-1-dev
+      - lld-18
+      - llvm-18-dev
       - ninja-build
       - unzip
     stage-packages:
       - libsecret-1-0
       - zenity
     override-build: |
-      VERSION=$(grep flutter .fvmrc | cut -d ":" -f2|cut -d "\"" -f2)
-      git clone https://github.com/flutter/flutter.git --branch $VERSION
+      VERSION=$(grep flutter .fvmrc | cut -d ":" -f2 | cut -d "\"" -f2)
+      git clone https://github.com/flutter/flutter.git --branch $VERSION --depth 1
       export PATH="$(pwd)/flutter/bin:$PATH"
       curl https://sh.rustup.rs -sSf | sh -s -- -y
       flutter pub get


### PR DESCRIPTION
An attempt to fix the Snapcraft build failing with `ERROR: Target dart_build failed: Error: Failed to find any of [ld.lld, ld] in LocalDirectory: '/usr/lib/llvm-18/bin'`.

Thanks to @Npepperlinux for the information.