### PR TITLE
chore: add Flathub link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Aria
 
 [![misskey.io](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmisskey.io%2Fusers%2F9qaqpdbgn1nk03sc%2Ffollowers&query=%24.totalItems&logo=misskey&logoColor=fff&label=misskey.io&color=86b300)](https://misskey.io/@aria_app)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/poppingmoon/aria/pulls)
 [![Crowdin](https://badges.crowdin.net/aria-for-misskey/localized.svg)](https://crowdin.com/project/aria-for-misskey)
 [![CI](https://github.com/poppingmoon/aria/actions/workflows/ci.yml/badge.svg)](https://github.com/poppingmoon/aria/actions/workflows/ci.yml)
 [![Build](https://github.com/poppingmoon/aria/actions/workflows/build.yml/badge.svg)](https://github.com/poppingmoon/aria/actions/workflows/build.yml)
@@ -16,11 +16,12 @@ A [Misskey](https://github.com/misskey-dev/misskey) client app forked from
 | Android                    | iOS                      | Windows                 | macOS                    | Linux                    |
 | -------------------------- | ------------------------ | ----------------------- | ------------------------ | ------------------------ |
 | [Google Play][Google Play] | [App Store][App Store]   | [EXE installer][GitHub] | [App Store][App Store]   | [Snap Store][Snap Store] |
-| [F-Droid][F-Droid]         | [TestFlight][TestFlight] | [ZIP][GitHub]           | [TestFlight][TestFlight] | [TAR][GitHub]            |
-| [APK][GitHub]              | [IPA][GitHub]            |                         | [DMG Installer][GitHub]  |                          |
+| [F-Droid][F-Droid]         | [TestFlight][TestFlight] | [ZIP][GitHub]           | [TestFlight][TestFlight] | [Flathub][Flathub]       |
+| [APK][GitHub]              | [IPA][GitHub]            |                         | [DMG Installer][GitHub]  | [TAR][GitHub]            |
 
 [App Store]: https://apps.apple.com/app/aria-for-misskey/id6499410880
 [F-Droid]: https://f-droid.org/packages/com.poppingmoon.aria
+[Flathub]: https://flathub.org/apps/com.poppingmoon.aria
 [GitHub]: https://github.com/poppingmoon/aria/releases/latest
 [Google Play]: https://play.google.com/store/apps/details?id=com.poppingmoon.aria
 [Snap Store]: https://snapcraft.io/aria


### PR DESCRIPTION
Aria has been published on [Flathub](https://flathub.org/apps/com.poppingmoon.aria).

Fix #578