### PR TITLE
fix: apply scale to fallback text of custom emojis

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -537,9 +537,9 @@ class _Mfm extends StatelessWidget {
                         ),
                       )
                     : null,
-                fallbackTextStyle: config.style.copyWith(
-                  height: simple ? 1.0 : null,
-                ),
+                fallbackTextStyle: config.style
+                    .apply(fontSizeFactor: config.scale)
+                    .copyWith(height: simple ? 1.0 : null),
                 fallbackToImage: false,
                 enableFadeIn: enableEmojiFadeIn,
               ),


### PR DESCRIPTION
Fixed an issue where the fallback text was not scaled when a custom emoji was enclosed in `x2`.