### PR TITLE
fix: use parent context if unmounted

### DIFF
--- a/lib/view/dialog/icon_select_dialog.dart
+++ b/lib/view/dialog/icon_select_dialog.dart
@@ -44,7 +44,7 @@ class IconSelectDialog extends HookConsumerWidget {
         child: account != null && showEmojiPicker.value
             ? EmojiPicker(
                 account: account!,
-                onTapEmoji: (emoji, _) {
+                onTapEmoji: (ref, emoji, _) {
                   if (emoji.startsWith(':')) {
                     final url = ref.read(emojiUrlProvider(account!, emoji)).$2;
                     context.pop(ImageIcon(url: url));

--- a/lib/view/widget/emoji_picker.dart
+++ b/lib/view/widget/emoji_picker.dart
@@ -36,10 +36,10 @@ Future<String?> pickEmoji(
   bool post = false,
   void Function(String emoji)? onTapEmoji,
 }) {
-  Future<void> onTap(BuildContext context, String emoji, bool keepOpen) async {
+  Future<void> onTap(WidgetRef ref, String emoji, bool keepOpen) async {
     if (confirmBeforePop && emoji.startsWith(':')) {
       final confirmed = await showDialog<bool>(
-        context: context,
+        context: ref.context,
         builder: (context) => EmojiPage(
           account: account,
           name: emoji.substring(1, emoji.length - 1).replaceAll('@.', ''),
@@ -59,9 +59,9 @@ Future<String?> pickEmoji(
       }
     }
     onTapEmoji?.call(emoji);
-    if (!context.mounted) return;
+    if (!ref.context.mounted) return;
     if (!keepOpen) {
-      context.pop(emoji);
+      ref.context.pop(emoji);
     }
   }
 
@@ -75,7 +75,7 @@ Future<String?> pickEmoji(
         ),
         child: EmojiPicker(
           account: account,
-          onTapEmoji: (emoji, keepOpen) => onTap(context, emoji, keepOpen),
+          onTapEmoji: onTap,
           reaction: reaction,
           targetNote: targetNote,
           post: post,
@@ -92,7 +92,7 @@ Future<String?> pickEmoji(
         expand: false,
         builder: (context, scrollController) => EmojiPicker(
           account: account,
-          onTapEmoji: (emoji, keepOpen) => onTap(context, emoji, keepOpen),
+          onTapEmoji: onTap,
           scrollController: scrollController,
           reaction: reaction,
           targetNote: targetNote,
@@ -120,7 +120,7 @@ class EmojiPicker extends HookConsumerWidget {
   });
 
   final Account account;
-  final void Function(String emoji, bool popEmoji) onTapEmoji;
+  final void Function(WidgetRef ref, String emoji, bool popEmoji) onTapEmoji;
   final ScrollController? scrollController;
   final bool reaction;
   final Note? targetNote;
@@ -228,7 +228,7 @@ class EmojiPicker extends HookConsumerWidget {
                     account: account,
                     emoji: emoji.emoji,
                     onTap: enabled
-                        ? () => onTapEmoji(emoji.emoji, keepOpen)
+                        ? () => onTapEmoji(ref, emoji.emoji, keepOpen)
                         : null,
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
@@ -247,7 +247,7 @@ class EmojiPicker extends HookConsumerWidget {
                     account: account,
                     emoji: emoji,
                     style: style.apply(fontSizeFactor: fontScaleFactor),
-                    onTap: () => onTapEmoji(emoji, keepOpen),
+                    onTap: () => onTapEmoji(ref, emoji, keepOpen),
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
                       builder: (context) =>
@@ -279,7 +279,9 @@ class EmojiPicker extends HookConsumerWidget {
                   return _CustomEmoji(
                     account: account,
                     emoji: emoji,
-                    onTap: enabled ? () => onTapEmoji(emoji, keepOpen) : null,
+                    onTap: enabled
+                        ? () => onTapEmoji(ref, emoji, keepOpen)
+                        : null,
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
                       builder: (context) => EmojiSheet(
@@ -309,7 +311,7 @@ class EmojiPicker extends HookConsumerWidget {
                     account: account,
                     emoji: emoji,
                     style: style.apply(fontSizeFactor: fontScaleFactor),
-                    onTap: () => onTapEmoji(emoji, keepOpen),
+                    onTap: () => onTapEmoji(ref, emoji, keepOpen),
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
                       builder: (context) => EmojiSheet(
@@ -359,7 +361,9 @@ class EmojiPicker extends HookConsumerWidget {
                   return _CustomEmoji(
                     account: account,
                     emoji: emoji,
-                    onTap: enabled ? () => onTapEmoji(emoji, keepOpen) : null,
+                    onTap: enabled
+                        ? () => onTapEmoji(ref, emoji, keepOpen)
+                        : null,
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
                       builder: (context) => EmojiSheet(
@@ -388,7 +392,7 @@ class EmojiPicker extends HookConsumerWidget {
                     account: account,
                     emoji: emoji,
                     style: style.apply(fontSizeFactor: fontScaleFactor),
-                    onTap: () => onTapEmoji(emoji, keepOpen),
+                    onTap: () => onTapEmoji(ref, emoji, keepOpen),
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
                       builder: (context) => EmojiSheet(
@@ -448,7 +452,7 @@ class EmojiPicker extends HookConsumerWidget {
                           account: account,
                           emoji: emoji.emoji,
                           onTap: enabled
-                              ? () => onTapEmoji(emoji.emoji, keepOpen)
+                              ? () => onTapEmoji(ref, emoji.emoji, keepOpen)
                               : null,
                           onLongPress: () => showModalBottomSheet<void>(
                             context: context,
@@ -495,7 +499,7 @@ class EmojiPicker extends HookConsumerWidget {
                             account: account,
                             emoji: emoji,
                             style: style.apply(fontSizeFactor: fontScaleFactor),
-                            onTap: () => onTapEmoji(emoji, keepOpen),
+                            onTap: () => onTapEmoji(ref, emoji, keepOpen),
                           ),
                         )
                         .toList(),

--- a/lib/view/widget/note_footer.dart
+++ b/lib/view/widget/note_footer.dart
@@ -40,6 +40,7 @@ class NoteFooter extends ConsumerWidget {
     this.clipId,
     this.disableHeader = false,
     this.focusPostForm,
+    this.listViewKey,
   });
 
   final Account account;
@@ -48,6 +49,7 @@ class NoteFooter extends ConsumerWidget {
   final String? clipId;
   final bool disableHeader;
   final void Function()? focusPostForm;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -139,18 +141,24 @@ class NoteFooter extends ConsumerWidget {
                       appearNote.reactionAcceptance !=
                           ReactionAcceptance.likeOnly &&
                       appearNote.myReaction == null)
-                    _LikeButton(account: account, note: appearNote),
+                    _LikeButton(
+                      account: account,
+                      note: appearNote,
+                      listViewKey: listViewKey,
+                    ),
                   if (appearNote.myReaction == null)
                     _AddReactionButton(
                       account: account,
                       note: appearNote,
                       style: style,
+                      listViewKey: listViewKey,
                     )
                   else
                     _RemoveReactionButton(
                       account: account,
                       note: appearNote,
                       style: style,
+                      listViewKey: listViewKey,
                     ),
                   if (showClipButton)
                     _ClipButton(
@@ -415,10 +423,15 @@ class _QuoteButton extends ConsumerWidget {
 }
 
 class _LikeButton extends ConsumerWidget {
-  const _LikeButton({required this.account, required this.note});
+  const _LikeButton({
+    required this.account,
+    required this.note,
+    required this.listViewKey,
+  });
 
   final Account account;
   final Note note;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -435,14 +448,17 @@ class _LikeButton extends ConsumerWidget {
                   .read(generalSettingsNotifierProvider)
                   .confirmBeforeReact) {
                 final confirmed = await confirmReaction(
-                  context,
+                  ref.context,
                   account: account,
                   emoji: emoji,
                   note: note,
                 );
                 if (!confirmed) return;
               }
-              if (!context.mounted) return;
+              final context = ref.context.mounted
+                  ? ref.context
+                  : listViewKey?.currentContext;
+              if (context == null || !context.mounted) return;
               await futureWithDialog(
                 context,
                 ref
@@ -462,11 +478,13 @@ class _AddReactionButton extends ConsumerWidget {
     required this.account,
     required this.note,
     required this.style,
+    required this.listViewKey,
   });
 
   final Account account;
   final Note note;
   final TextStyle? style;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -505,6 +523,12 @@ class _AddReactionButton extends ConsumerWidget {
         onPressed: !account.isGuest
             ? () async {
                 if (note.id.isEmpty) return;
+                final confirmBeforeReact = ref
+                    .read(generalSettingsNotifierProvider)
+                    .confirmBeforeReact;
+                final notifier = ref.read(
+                  notesNotifierProvider(account).notifier,
+                );
                 final emoji =
                     note.reactionAcceptance == ReactionAcceptance.likeOnly
                     ? '❤'
@@ -514,11 +538,12 @@ class _AddReactionButton extends ConsumerWidget {
                         reaction: true,
                         targetNote: note,
                       );
-                if (!context.mounted) return;
+                final context = ref.context.mounted
+                    ? ref.context
+                    : listViewKey?.currentContext;
+                if (context == null || !context.mounted) return;
                 if (emoji != null) {
-                  if (ref
-                      .read(generalSettingsNotifierProvider)
-                      .confirmBeforeReact) {
+                  if (confirmBeforeReact) {
                     final confirmed = await confirmReaction(
                       context,
                       account: account,
@@ -530,9 +555,7 @@ class _AddReactionButton extends ConsumerWidget {
                   if (!context.mounted) return;
                   await futureWithDialog(
                     context,
-                    ref
-                        .read(notesNotifierProvider(account).notifier)
-                        .react(note.id, emoji),
+                    notifier.react(note.id, emoji),
                     overlay: false,
                   );
                 }
@@ -567,11 +590,13 @@ class _RemoveReactionButton extends ConsumerWidget {
     required this.account,
     required this.note,
     required this.style,
+    required this.listViewKey,
   });
 
   final Account account;
   final Note note;
   final TextStyle? style;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -606,11 +631,14 @@ class _RemoveReactionButton extends ConsumerWidget {
         onPressed: () async {
           if (note.id.isEmpty) return;
           final confirmed = await confirm(
-            context,
+            ref.context,
             message: t.misskey.cancelReactionConfirm,
           );
           if (!confirmed) return;
-          if (!context.mounted) return;
+          final context = ref.context.mounted
+              ? ref.context
+              : listViewKey?.currentContext;
+          if (context == null || !context.mounted) return;
           await futureWithDialog(
             context,
             ref.read(notesNotifierProvider(account).notifier).unreact(note.id),

--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -53,6 +53,7 @@ class NoteWidget extends HookConsumerWidget {
     this.backgroundColor,
     this.margin = EdgeInsets.zero,
     this.borderRadius,
+    this.listViewKey,
   });
 
   final Account account;
@@ -65,6 +66,7 @@ class NoteWidget extends HookConsumerWidget {
   final Color? backgroundColor;
   final EdgeInsetsGeometry margin;
   final BorderRadiusGeometry? borderRadius;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -320,6 +322,7 @@ class NoteWidget extends HookConsumerWidget {
                             style: style,
                             showFooter: showFooter,
                             focusPostForm: focusPostForm,
+                            listViewKey: listViewKey,
                           ),
                         ),
                       ],
@@ -344,6 +347,7 @@ class _NoteContent extends HookConsumerWidget {
     required this.style,
     required this.showFooter,
     required this.focusPostForm,
+    required this.listViewKey,
   });
 
   final Account account;
@@ -354,6 +358,7 @@ class _NoteContent extends HookConsumerWidget {
   final TextStyle style;
   final bool? showFooter;
   final void Function()? focusPostForm;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -591,6 +596,7 @@ class _NoteContent extends HookConsumerWidget {
             appearNote: appearNote,
             clipId: clipId,
             focusPostForm: focusPostForm,
+            listViewKey: listViewKey,
           ),
       ],
     );

--- a/lib/view/widget/timeline_list_view.dart
+++ b/lib/view/widget/timeline_list_view.dart
@@ -416,6 +416,7 @@ class TimelineListView extends HookConsumerWidget {
                           hide:
                               index < 5 &&
                               partialPreviousNoteIds.contains(note.id),
+                          listViewKey: centerKey,
                         ),
                       ),
                     );
@@ -502,6 +503,7 @@ class TimelineListView extends HookConsumerWidget {
                                       ? const Radius.circular(8.0)
                                       : Radius.zero,
                                 ),
+                          listViewKey: centerKey,
                         ),
                       ),
                     );

--- a/lib/view/widget/timeline_note.dart
+++ b/lib/view/widget/timeline_note.dart
@@ -26,6 +26,7 @@ class TimelineNote extends HookConsumerWidget {
     this.margin = EdgeInsets.zero,
     this.borderRadius,
     this.hide = false,
+    this.listViewKey,
   });
 
   final TabSettings tabSettings;
@@ -34,6 +35,7 @@ class TimelineNote extends HookConsumerWidget {
   final EdgeInsetsGeometry margin;
   final BorderRadiusGeometry? borderRadius;
   final bool hide;
+  final GlobalKey? listViewKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -61,6 +63,7 @@ class TimelineNote extends HookConsumerWidget {
         focusPostForm: focusPostForm,
         margin: margin,
         borderRadius: borderRadius,
+        listViewKey: listViewKey,
       );
     }
     if ((tabSettings.withFiles && appearNote.fileIds.isEmpty) || hide) {
@@ -146,6 +149,7 @@ class TimelineNote extends HookConsumerWidget {
       focusPostForm: focusPostForm,
       margin: margin,
       borderRadius: borderRadius,
+      listViewKey: listViewKey,
     );
   }
 }


### PR DESCRIPTION
Changed to use `BuildContext` from `TimelineListView` when `NoteFooter` is unmounted after a button is tapped and before an API call is done.

While adding a reaction with `NoteFooter`, the note can go out of the visible area if new notes are received through streaming. When the note leaves, the widget gets disposed, and its `BuildContext` is no longer usable. This causes issues; for example, after picking an emoji, the note may already be gone, and the user cannot add the reaction.

This PR fixes this by passing a `GlobalKey` built in `TimelineListView` to child `NoteFooter` widgets. During operations triggered by the `NoteFooter` buttons, if the local `BuildContext` is unmounted, `GlobalKey.currentContext` is used instead. Because the parent `TimelineListView` is kept alive, that context remains valid even if an individual `NoteFooter` is disposed.