### PR TITLE
fix: allow invalid birthday

### DIFF
--- a/lib/view/page/settings/profile_page.dart
+++ b/lib/view/page/settings/profile_page.dart
@@ -447,13 +447,18 @@ class ProfilePage extends HookConsumerWidget {
                 width: maxContentWidth,
                 child: ListTile(
                   title: Text(t.misskey.birthday),
-                  subtitle: Text(
-                    i.birthday != null
-                        ? DateFormat.yMMMd(
-                            Localizations.localeOf(context).toLanguageTag(),
-                          ).format(i.birthday!)
-                        : t.misskey.notSet,
-                  ),
+                  subtitle: Text(switch (i.birthday) {
+                    final birthday? => switch (DateTime.tryParse(birthday)) {
+                      final date?
+                          when DateFormat('yyyy-MM-dd').format(date) ==
+                              birthday =>
+                        DateFormat.yMd(
+                          Localizations.localeOf(context).toLanguageTag(),
+                        ).format(date),
+                      _ => birthday.replaceAll('-', '/'),
+                    },
+                    _ => t.misskey.notSet,
+                  }),
                   trailing: i.birthday != null
                       ? IconButton(
                           tooltip: t.misskey.delete,
@@ -472,7 +477,10 @@ class ProfilePage extends HookConsumerWidget {
                   onTap: () async {
                     final date = await showDatePicker(
                       context: context,
-                      initialDate: i.birthday,
+                      initialDate: switch (i.birthday) {
+                        final birthday? => DateTime.tryParse(birthday),
+                        _ => null,
+                      },
                       firstDate: DateTime(0),
                       lastDate: DateTime(9999, 12, 31),
                       initialEntryMode: DatePickerEntryMode.input,

--- a/lib/view/page/user/user_home.dart
+++ b/lib/view/page/user/user_home.dart
@@ -93,11 +93,29 @@ class _UserHome extends ConsumerWidget {
   final Account account;
   final UserDetailed user;
 
-  int _calcAge(DateTime birthday) {
+  int? _calcAge(String birthday) {
+    final date = switch (DateTime.tryParse(birthday)) {
+      final date? when DateFormat('yyyy-MM-dd').format(date) == birthday => (
+        year: date.year,
+        month: date.month,
+        day: date.day,
+      ),
+      _ => switch (birthday.split('-').map(int.tryParse).toList()) {
+        [final int year, final int month, final int day] => (
+          year: year,
+          month: month,
+          day: day,
+        ),
+        _ => null,
+      },
+    };
+    if (date == null) {
+      return null;
+    }
     final now = DateTime.now();
-    final yearDiff = now.year - birthday.year;
-    final monthDiff = now.month - birthday.month;
-    if (monthDiff < 0 || (monthDiff == 0 && now.day < birthday.day)) {
+    final yearDiff = now.year - date.year;
+    final monthDiff = now.month - date.month;
+    if (monthDiff < 0 || (monthDiff == 0 && now.day < date.day)) {
       return yearDiff - 1;
     } else {
       return yearDiff;
@@ -120,11 +138,16 @@ class _UserHome extends ConsumerWidget {
     );
     final style = DefaultTextStyle.of(context).style;
     final remoteUrl = user.uri ?? user.url;
-    final birthday = user.birthday != null
-        ? DateFormat.yMMMd(
+    final birthday = switch (user.birthday) {
+      final birthday? => switch (DateTime.tryParse(birthday)) {
+        final date? when DateFormat('yyyy-MM-dd').format(date) == birthday =>
+          DateFormat.yMd(
             Localizations.localeOf(context).toLanguageTag(),
-          ).format(user.birthday!)
-        : null;
+          ).format(date),
+        _ => birthday.replaceAll('-', '/'),
+      },
+      _ => null,
+    };
 
     return CustomScrollView(
       slivers: [
@@ -555,7 +578,13 @@ class _UserHome extends ConsumerWidget {
                                 Padding(
                                   padding: const EdgeInsets.all(4.0),
                                   child: Text(
-                                    '$birthday (${t.misskey.yearsOld(age: _calcAge(date))})',
+                                    [
+                                      '$birthday (',
+                                      t.misskey.yearsOld(
+                                        age: _calcAge(date) ?? '?',
+                                      ),
+                                      ')',
+                                    ].join(),
                                   ),
                                 ),
                               ],

--- a/lib/view/page/user/user_page.dart
+++ b/lib/view/page/user/user_page.dart
@@ -54,6 +54,10 @@ class UserPage extends HookConsumerWidget {
             (!account.isGuest &&
                 account.username == user.username &&
                 user.host == null));
+    final birthday = switch (user?.birthday) {
+      final birthday? => DateTime.tryParse(birthday),
+      _ => null,
+    };
 
     return DefaultTabController(
       length: userId != null
@@ -123,8 +127,13 @@ class UserPage extends HookConsumerWidget {
                 ],
               ],
             ),
-            if (user?.birthday?.day == now.day &&
-                user?.birthday?.month == now.month)
+            if ((birthday?.day == now.day && birthday?.month == now.month) ||
+                (birthday?.day == 29 &&
+                    birthday?.month == 2 &&
+                    now.day == 1 &&
+                    now.month == 3 &&
+                    (now.year % 4 != 0 ||
+                        (now.year % 100 == 0 && now.year % 400 != 0))))
               Align(
                 alignment: const Alignment(0.0, -0.5),
                 child: ConfettiWidget(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1364,8 +1364,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: cca00d86bf0ad1039f673381428fa3941a7e79c0
-      resolved-ref: cca00d86bf0ad1039f673381428fa3941a7e79c0
+      ref: aa1a4277c381fe4db7bbb074693c1d4dacab56b8
+      resolved-ref: aa1a4277c381fe4db7bbb074693c1d4dacab56b8
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: cca00d86bf0ad1039f673381428fa3941a7e79c0
+      ref: aa1a4277c381fe4db7bbb074693c1d4dacab56b8
   multi_split_view: ^3.6.1
   package_info_plus: ^9.0.0
   path: ^1.9.1


### PR DESCRIPTION
Changed to display invalid birthdays like `0000-00-00` as is.

Also updated to show the confetti on May 1 for users born on February 29 in non-leap years.

ref: [misskey-dev/misskey#5375](https://redirect.github.com/misskey-dev/misskey/issues/5375)
ref: [misskey-dev/misskey#17072](https://redirect.github.com/misskey-dev/misskey/pull/17072)
ref: [misskey-dev/misskey#17105](https://redirect.github.com/misskey-dev/misskey/pull/17105)