### PR TITLE
fix: return persisted value if failed to fetch

### DIFF
--- a/lib/provider/api/endpoints_notifier_provider.dart
+++ b/lib/provider/api/endpoints_notifier_provider.dart
@@ -8,12 +8,23 @@ import 'misskey_provider.dart';
 
 part 'endpoints_notifier_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 @JsonPersist()
 class EndpointsNotifier extends _$EndpointsNotifier {
   @override
-  FutureOr<List<String>> build(String host) {
+  FutureOr<List<String>> build(String host) async {
     persist(ref.watch(riverpodStorageProvider.future));
-    return ref.watch(misskeyProvider(Account(host: host))).endpoints();
+    try {
+      final endpoints = await ref
+          .watch(misskeyProvider(Account(host: host)))
+          .endpoints();
+      ref.keepAlive();
+      return endpoints;
+    } catch (_) {
+      if (state.value case final endpoints?) {
+        return endpoints;
+      }
+      rethrow;
+    }
   }
 }

--- a/lib/provider/api/endpoints_notifier_provider.g.dart
+++ b/lib/provider/api/endpoints_notifier_provider.g.dart
@@ -22,7 +22,7 @@ final class EndpointsNotifierProvider
   }) : super(
          retry: null,
          name: r'endpointsNotifierProvider',
-         isAutoDispose: false,
+         isAutoDispose: true,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
@@ -52,7 +52,7 @@ final class EndpointsNotifierProvider
   }
 }
 
-String _$endpointsNotifierHash() => r'a191db0165b927b837cff7afbe75ea0151ff1209';
+String _$endpointsNotifierHash() => r'd602a9d3629ba5ef8cd55e590ad6bd3a8404feb5';
 
 @JsonPersist()
 final class EndpointsNotifierFamily extends $Family
@@ -70,7 +70,7 @@ final class EndpointsNotifierFamily extends $Family
         name: r'endpointsNotifierProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
-        isAutoDispose: false,
+        isAutoDispose: true,
       );
 
   @JsonPersist()

--- a/lib/provider/api/i_notifier_provider.dart
+++ b/lib/provider/api/i_notifier_provider.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/experimental/persist.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/experimental/json_persist.dart';
@@ -10,7 +11,7 @@ import 'misskey_provider.dart';
 
 part 'i_notifier_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 @JsonPersist()
 class INotifier extends _$INotifier {
   @override
@@ -18,12 +19,27 @@ class INotifier extends _$INotifier {
     if (account.isGuest) {
       return null;
     }
+    listenSelf((prev, next) {
+      if (next.value?.pinnedNotes case final pinnedNotes?) {
+        if (prev?.value?.pinnedNotes case final previousNotes?) {
+          if (const ListEquality<Note>().equals(pinnedNotes, previousNotes)) {
+            return;
+          }
+        }
+        ref.read(notesNotifierProvider(account).notifier).addAll(pinnedNotes);
+      }
+    });
     persist(ref.watch(riverpodStorageProvider.future));
-    final i = await _misskey.i.i();
-    ref
-        .read(notesNotifierProvider(account).notifier)
-        .addAll(i.pinnedNotes ?? []);
-    return i;
+    try {
+      final i = await _misskey.i.i();
+      ref.keepAlive();
+      return i;
+    } catch (_) {
+      if (state.value case final i?) {
+        return i;
+      }
+      rethrow;
+    }
   }
 
   Misskey get _misskey => ref.read(misskeyProvider(account));

--- a/lib/provider/api/i_notifier_provider.g.dart
+++ b/lib/provider/api/i_notifier_provider.g.dart
@@ -22,7 +22,7 @@ final class INotifierProvider
   }) : super(
          retry: null,
          name: r'iNotifierProvider',
-         isAutoDispose: false,
+         isAutoDispose: true,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
@@ -52,7 +52,7 @@ final class INotifierProvider
   }
 }
 
-String _$iNotifierHash() => r'f12894c41f9a91b7f35a76f471fe49b0b125de6e';
+String _$iNotifierHash() => r'0e98e606414f96dd4835325f0eb0932420304655';
 
 @JsonPersist()
 final class INotifierFamily extends $Family
@@ -70,7 +70,7 @@ final class INotifierFamily extends $Family
         name: r'iNotifierProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
-        isAutoDispose: false,
+        isAutoDispose: true,
       );
 
   @JsonPersist()

--- a/lib/provider/api/meta_notifier_provider.dart
+++ b/lib/provider/api/meta_notifier_provider.dart
@@ -9,12 +9,21 @@ import 'misskey_provider.dart';
 
 part 'meta_notifier_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 @JsonPersist()
 class MetaNotifier extends _$MetaNotifier {
   @override
-  FutureOr<MetaResponse> build(String host) {
+  FutureOr<MetaResponse> build(String host) async {
     persist(ref.watch(riverpodStorageProvider.future));
-    return ref.read(misskeyProvider(Account(host: host))).meta();
+    try {
+      final meta = await ref.read(misskeyProvider(Account(host: host))).meta();
+      ref.keepAlive();
+      return meta;
+    } catch (_) {
+      if (state.value case final meta?) {
+        return meta;
+      }
+      rethrow;
+    }
   }
 }

--- a/lib/provider/api/meta_notifier_provider.g.dart
+++ b/lib/provider/api/meta_notifier_provider.g.dart
@@ -22,7 +22,7 @@ final class MetaNotifierProvider
   }) : super(
          retry: null,
          name: r'metaNotifierProvider',
-         isAutoDispose: false,
+         isAutoDispose: true,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
@@ -52,7 +52,7 @@ final class MetaNotifierProvider
   }
 }
 
-String _$metaNotifierHash() => r'90bbbee141b53b46d01eeca89138979483a7d308';
+String _$metaNotifierHash() => r'0e44aa07a24d7ae899624001044a8994d860aa0a';
 
 @JsonPersist()
 final class MetaNotifierFamily extends $Family
@@ -70,7 +70,7 @@ final class MetaNotifierFamily extends $Family
         name: r'metaNotifierProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
-        isAutoDispose: false,
+        isAutoDispose: true,
       );
 
   @JsonPersist()

--- a/lib/provider/emojis_notifier_provider.dart
+++ b/lib/provider/emojis_notifier_provider.dart
@@ -12,19 +12,27 @@ import 'riverpod_storage_provider.dart';
 
 part 'emojis_notifier_provider.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 @JsonPersist()
 class EmojisNotifier extends _$EmojisNotifier {
   @override
   FutureOr<Map<String, Emoji>> build(String host) async {
     ref.onDispose(() => _timer?.cancel());
     persist(ref.watch(riverpodStorageProvider.future));
-    final response = await _fetchEmojis();
-    _recentlyFetched = true;
-    _timer = Timer(const Duration(minutes: 10), () {
-      _recentlyFetched = false;
-    });
-    return {for (final emoji in response) emoji.name: emoji};
+    try {
+      final response = await _fetchEmojis();
+      ref.keepAlive();
+      _recentlyFetched = true;
+      _timer = Timer(const Duration(minutes: 10), () {
+        _recentlyFetched = false;
+      });
+      return {for (final emoji in response) emoji.name: emoji};
+    } catch (_) {
+      if (state.value case final emojis?) {
+        return emojis;
+      }
+      rethrow;
+    }
   }
 
   Misskey get _misskey => ref.read(misskeyProvider(Account(host: host)));

--- a/lib/provider/emojis_notifier_provider.g.dart
+++ b/lib/provider/emojis_notifier_provider.g.dart
@@ -22,7 +22,7 @@ final class EmojisNotifierProvider
   }) : super(
          retry: null,
          name: r'emojisNotifierProvider',
-         isAutoDispose: false,
+         isAutoDispose: true,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
@@ -52,7 +52,7 @@ final class EmojisNotifierProvider
   }
 }
 
-String _$emojisNotifierHash() => r'5875eb71caeccaa56af45ec213531c4b05e4fe6f';
+String _$emojisNotifierHash() => r'3392eb9baa282b38c56ff6211d8d0aeb436896b0';
 
 @JsonPersist()
 final class EmojisNotifierFamily extends $Family
@@ -70,7 +70,7 @@ final class EmojisNotifierFamily extends $Family
         name: r'emojisNotifierProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
-        isAutoDispose: false,
+        isAutoDispose: true,
       );
 
   @JsonPersist()


### PR DESCRIPTION
Changed to return the values retrieved from storage using Riverpod's offline persistence when API calls fail.