### PR TITLE
fix: allow quoting with files only

### DIFF
--- a/lib/view/dialog/post_confirmation_dialog.dart
+++ b/lib/view/dialog/post_confirmation_dialog.dart
@@ -101,7 +101,7 @@ class PostConfirmationDialog extends ConsumerWidget {
                 child: Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
-                    request.isRenote
+                    request.isRenote && files.isEmpty
                         ? t.aria.renoteConfirm
                         : t.aria.postConfirm,
                     style: theme.textTheme.titleMedium,
@@ -134,7 +134,7 @@ class PostConfirmationDialog extends ConsumerWidget {
                     ),
                   ),
                 ),
-              if (request.isRenote)
+              if (request.isRenote && files.isEmpty)
                 NoteWidget(
                   account: account,
                   noteId: request.renoteId!,

--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -63,7 +63,7 @@ class PostPage extends HookConsumerWidget {
         t.misskey.schedule,
         Icons.send,
       ),
-      NotesCreateRequest(isRenote: true) => (
+      NotesCreateRequest(isRenote: true) when attaches.isEmpty => (
         t.misskey.renote,
         Icons.repeat_rounded,
       ),

--- a/lib/view/widget/post_form.dart
+++ b/lib/view/widget/post_form.dart
@@ -318,7 +318,7 @@ class PostForm extends HookConsumerWidget {
         t.misskey.schedule,
         Icons.send,
       ),
-      NotesCreateRequest(isRenote: true) => (
+      NotesCreateRequest(isRenote: true) when attaches.isEmpty => (
         t.misskey.renote,
         Icons.repeat_rounded,
       ),


### PR DESCRIPTION
Fixed an issue where quoting a note by attaching files only was not possible via the post form.