### PR TITLE
feat: modify push notifications on iOS

### DIFF
--- a/ios/Notification Service Extension/Info.plist
+++ b/ios/Notification Service Extension/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/Notification Service Extension/Notification Service Extension.entitlements
+++ b/ios/Notification Service Extension/Notification Service Extension.entitlements
@@ -2,11 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.poppingmoon.aria.Share-Extension</string>
 		<string>group.com.poppingmoon.aria.Notification-Service-Extension</string>
 	</array>
 </dict>

--- a/ios/Notification Service Extension/NotificationService.swift
+++ b/ios/Notification Service Extension/NotificationService.swift
@@ -1,0 +1,69 @@
+import NotificationSettings
+import UserNotifications
+
+class NotificationService: UNNotificationServiceExtension {
+
+  var contentHandler: ((UNNotificationContent) -> Void)?
+  var bestAttemptContent: UNMutableNotificationContent?
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void,
+  ) {
+    self.contentHandler = contentHandler
+    bestAttemptContent =
+      request.content.mutableCopy() as? UNMutableNotificationContent
+
+    if let bestAttemptContent = bestAttemptContent {
+      let account = request.content.userInfo["account"] as? String
+      if let account = account {
+        bestAttemptContent.subtitle = account
+        bestAttemptContent.threadIdentifier = account
+      }
+
+      let notification: [String: Any]? =
+        switch request.content.userInfo["payload"] {
+        case let payload as [String: Any]:
+          payload
+        case let message as String:
+          if let account = account,
+            let keySet = try? NotificationSettingsStorage.loadKeySet(
+              account: account
+            ),
+            let keySet = try? WebPushKeySet(string: keySet),
+            let message = Data(base64Encoded: message),
+            let payload = try? WebPush.decryptMessage(
+              keySet: keySet,
+              message: message,
+            )
+          {
+            try? JSONSerialization.jsonObject(with: payload)
+              as? [String: Any]
+          } else {
+            nil
+          }
+        default:
+          nil
+        }
+
+      if let notification = notification {
+        bestAttemptContent.userInfo["payload"] = notification
+        Task {
+          await NotificationUpdater(bestAttemptContent: bestAttemptContent)
+            .update(notification: notification)
+          contentHandler(bestAttemptContent)
+        }
+      } else {
+        contentHandler(bestAttemptContent)
+      }
+    }
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    if let contentHandler = contentHandler,
+      let bestAttemptContent = bestAttemptContent
+    {
+      contentHandler(bestAttemptContent)
+    }
+  }
+}

--- a/ios/Notification Service Extension/NotificationUpdater.swift
+++ b/ios/Notification Service Extension/NotificationUpdater.swift
@@ -1,0 +1,438 @@
+import CoreServices
+import NotificationSettings
+import UserNotifications
+
+struct NotificationUpdater {
+  let bestAttemptContent: UNMutableNotificationContent
+
+  func update(notification: [String: Any]) async {
+    switch notification["type"] as? String {
+    case "notification":
+      guard let body = notification["body"] as? [String: Any] else {
+        return
+      }
+      switch body["type"] as? String {
+      case "follow":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.youWereFollowed",
+          arguments: nil,
+        )
+        if let user = body["user"] as? [String: Any] {
+          if let name = getNameOrUsername(user: user) {
+            bestAttemptContent.body = name
+          }
+          if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+            let avatarUrl = user["avatarUrl"] as? String
+          {
+            try? await addImage(url: avatarUrl)
+          }
+        }
+      case "mention":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.youGotMention",
+          arguments: [
+            (body["user"] as? [String: Any]).flatMap { user in
+              getNameOrUsername(user: user)
+            } ?? ""
+          ],
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+          let user = body["user"] as? [String: Any],
+          let avatarUrl = user["avatarUrl"] as? String
+        {
+          try? await addImage(url: avatarUrl)
+        }
+      case "reply":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.youGotReply",
+          arguments: [
+            (body["user"] as? [String: Any]).flatMap { user in
+              getNameOrUsername(user: user)
+            } ?? ""
+          ],
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+          let user = body["user"] as? [String: Any],
+          let avatarUrl = user["avatarUrl"] as? String
+        {
+          try? await addImage(url: avatarUrl)
+        }
+      case "renote":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.youRenoted",
+          arguments: [
+            (body["user"] as? [String: Any]).flatMap { user in
+              getNameOrUsername(user: user)
+            } ?? ""
+          ],
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+          let user = body["user"] as? [String: Any],
+          let avatarUrl = user["avatarUrl"] as? String
+        {
+          try? await addImage(url: avatarUrl)
+        }
+      case "quote":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.youGotQuote",
+          arguments: [
+            (body["user"] as? [String: Any]).flatMap { user in
+              getNameOrUsername(user: user)
+            } ?? ""
+          ],
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+          let user = body["user"] as? [String: Any],
+          let avatarUrl = user["avatarUrl"] as? String
+        {
+          try? await addImage(url: avatarUrl)
+        }
+      case "note":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.newNote",
+          arguments: [
+            (body["user"] as? [String: Any]).flatMap { user in
+              getNameOrUsername(user: user)
+            } ?? ""
+          ],
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+          let user = body["user"] as? [String: Any],
+          let avatarUrl = user["avatarUrl"] as? String
+        {
+          try? await addImage(url: avatarUrl)
+        }
+      case "reaction":
+        bestAttemptContent.title = [
+          (body["reaction"] as? String)?.split(separator: "@").first?
+            .replacingOccurrences(of: ":", with: ""),
+          (body["user"] as? [String: Any]).flatMap { user in
+            getNameOrUsername(user: user)
+          },
+        ].compactMap { $0 }.joined(separator: " ")
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true {
+          if NotificationSettingsStorage.getShowEmojiInReactionNotification()
+            ?? false
+          {
+            if let reaction = body["reaction"] as? String {
+              if reaction.starts(with: ":") {
+                let emoji = reaction.replacingOccurrences(of: ":", with: "")
+                if let host =
+                  (bestAttemptContent.userInfo["account"] as? String)?
+                  .split(separator: "@").last
+                {
+                  let url =
+                    ((body["emojis"] as? [String: Any])?[emoji]
+                    ?? ((body["reactionEmojis"] as? [String: Any])?[emoji])
+                    as? String)
+                    .map { url in
+                      "https://\(host)/proxy/image.webp?url=\(url)&emoji=1"
+                    }
+                    ?? "https://\(host)/emoji/\(emoji).webp"
+                  try? await addImage(url: url)
+                }
+              } else {
+                let emoji =
+                  !reaction.contains("\u{200D}")
+                  ? reaction.replacingOccurrences(of: "\u{FE0F}", with: "")
+                  : reaction
+                let unicode = emoji.unicodeScalars.map { scalar in
+                  String(format: "%x", scalar.value)
+                }.joined(separator: "-")
+                let url =
+                  "https://raw.githubusercontent.com/jdecked/twemoji/main/"
+                  + "assets/72x72/\(unicode).png"
+                try? await addImage(url: url)
+              }
+            }
+          } else if let user = body["user"] as? [String: Any],
+            let avatarUrl = user["avatarUrl"] as? String
+          {
+            try? await addImage(url: avatarUrl)
+          }
+        }
+      case "receiveFollowRequest":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.youReceivedFollowRequest",
+          arguments: nil,
+        )
+        if let user = body["user"] as? [String: Any] {
+          if let name = getNameOrUsername(user: user) {
+            bestAttemptContent.body = name
+          }
+          if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+            let avatarUrl = user["avatarUrl"] as? String
+          {
+            try? await addImage(url: avatarUrl)
+          }
+        }
+      case "followRequestAccepted":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.yourFollowRequestAccepted",
+          arguments: nil,
+        )
+        if let user = body["user"] as? [String: Any] {
+          if let name = getNameOrUsername(user: user) {
+            bestAttemptContent.body = name
+          }
+          if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+            let avatarUrl = user["avatarUrl"] as? String
+          {
+            try? await addImage(url: avatarUrl)
+          }
+        }
+      case "achievementEarned":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.achievementEarned",
+          arguments: nil,
+        )
+        if let achievement = body["achievement"] as? String {
+          bestAttemptContent.body = NSString.localizedUserNotificationString(
+            forKey: "_achievements._types._\(achievement).title",
+            arguments: nil,
+          )
+        }
+      case "login":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.login",
+          arguments: nil,
+        )
+      case "exportCompleted":
+        if let exportedEntity = body["exportedEntity"] as? String {
+          bestAttemptContent.title = NSString.localizedUserNotificationString(
+            forKey:
+              "_notification.exportOf\(exportedEntity.capitalized)Completed",
+            arguments: nil,
+          )
+        }
+      case "pollEnded":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.pollEnded",
+          arguments: nil,
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+      case "roleAssigned":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.roleAssigned",
+          arguments: nil,
+        )
+        if let role = body["role"] as? [String: Any] {
+          if let name = role["name"] as? String {
+            bestAttemptContent.body = name
+          }
+          if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+            let iconUrl = role["iconUrl"] as? String
+          {
+            try? await addImage(url: iconUrl)
+          }
+        }
+      case "chatRoomInvitationReceived":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.chatRoomInvitationReceived",
+          arguments: nil,
+        )
+        if let invitation = body["invitation"] as? [String: Any],
+          let room = invitation["room"] as? [String: Any],
+          let name = room["name"] as? String
+        {
+          bestAttemptContent.body = name
+        }
+      case "createToken":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.createToken",
+          arguments: nil,
+        )
+        bestAttemptContent.body = NSString.localizedUserNotificationString(
+          forKey: "_notification.createTokenDescription",
+          arguments: nil,
+        )
+      case "scheduledNotePosted":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.scheduledNotePosted",
+          arguments: nil,
+        )
+        if let note = body["note"] as? [String: Any],
+          let text = note["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+      case "scheduledNotePostFailed":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.scheduledNotePostFailed",
+          arguments: nil,
+        )
+      case "scheduleNote":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.scheduledNotePostFailed",
+          arguments: nil,
+        )
+        if let errorType = body["errorType"] as? String {
+          bestAttemptContent.body = errorType
+        }
+      case "scheduledNoteError":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.scheduledNotePostFailed",
+          arguments: nil,
+        )
+        if let draft = body["draft"] as? [String: Any],
+          let reason = draft["reason"] as? String
+        {
+          bestAttemptContent.body = reason
+        }
+      case "noteScheduled":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.noteScheduled",
+          arguments: nil,
+        )
+        if let draft = body["draft"] as? [String: Any],
+          let data = draft["data"] as? [String: Any],
+          let text = data["text"] as? String
+        {
+          bestAttemptContent.body = text
+        }
+      case "app":
+        if let header = body["header"] as? String {
+          bestAttemptContent.title = header
+          if let body = body["body"] as? String {
+            bestAttemptContent.body = body
+          }
+        } else if let body = body["body"] as? String {
+          bestAttemptContent.title = body
+        }
+        if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+          let icon = body["icon"] as? String
+        {
+          try? await addImage(url: icon)
+        }
+      case "test":
+        bestAttemptContent.title = NSString.localizedUserNotificationString(
+          forKey: "_notification.testNotification",
+          arguments: nil,
+        )
+        bestAttemptContent.body = NSString.localizedUserNotificationString(
+          forKey: "_notification.notificationWillBeDisplayedLikeThis",
+          arguments: nil,
+        )
+      default:
+        return
+      }
+    case "newChatMessage":
+      guard let body = notification["body"] as? [String: Any] else {
+        return
+      }
+      if body["toRoomId"] != nil {
+        bestAttemptContent.title = [
+          (body["toRoom"] as? [String: Any]).flatMap { toRoom in
+            toRoom["name"] as? String
+          },
+          (body["user"] as? [String: Any]).flatMap { user in
+            getNameOrUsername(user: user)
+          },
+        ].compactMap { $0 }.joined(separator: ": ")
+      } else if let user = body["user"] as? [String: Any],
+        let name = getNameOrUsername(user: user)
+      {
+        bestAttemptContent.title = name
+      }
+      if let text = body["text"] as? String {
+        bestAttemptContent.body = text
+      }
+      if NotificationSettingsStorage.getShowImageInNotification() ?? true,
+        let fromUser = body["fromUser"] as? [String: Any],
+        let avatarUrl = fromUser["avatarUrl"] as? String
+      {
+        try? await addImage(url: avatarUrl)
+      }
+    default:
+      return
+    }
+  }
+
+  func getNameOrUsername(user: [String: Any]) -> String? {
+    user["name"] as? String ?? user["username"] as? String
+  }
+
+  func addImage(url: String) async throws {
+    guard let url = URL(string: url) else {
+      return
+    }
+    if #available(iOS 15.0, *) {
+      let (path, response) = try await URLSession.shared.download(
+        from: url
+      )
+      let fileName = UUID().uuidString.appending(
+        response.suggestedFilename ?? url.lastPathComponent
+      )
+      let target =
+        if #available(iOS 16.0, *) {
+          URL(filePath: NSTemporaryDirectory().appending(fileName))
+        } else {
+          URL(fileURLWithPath: NSTemporaryDirectory().appending(fileName))
+        }
+      try FileManager.default.moveItem(at: path, to: target)
+      if let response = response as? HTTPURLResponse,
+        200..<300 ~= response.statusCode
+      {
+
+        let attachment = try UNNotificationAttachment(
+          identifier: fileName,
+          url: target,
+        )
+        bestAttemptContent.attachments.append(attachment)
+      }
+    } else {
+      let (data, response) = try await URLSession.shared.data(from: url)
+      if let response = response as? HTTPURLResponse,
+        200..<300 ~= response.statusCode
+      {
+        let fileName =
+          UUID().uuidString.appending(
+            response.suggestedFilename ?? url.lastPathComponent
+          )
+        let path = URL(
+          fileURLWithPath: NSTemporaryDirectory().appending(fileName)
+        )
+        try data.write(to: path)
+        let attachment = try UNNotificationAttachment(
+          identifier: fileName,
+          url: path,
+        )
+        bestAttemptContent.attachments.append(attachment)
+      }
+    }
+  }
+}

--- a/ios/Notification Service Extension/WebPush.swift
+++ b/ios/Notification Service Extension/WebPush.swift
@@ -1,0 +1,83 @@
+import CryptoKit
+import Foundation
+
+enum WebPushError: Error {
+  case messageSize
+}
+
+struct WebPush {
+  // https://datatracker.ietf.org/doc/html/rfc8291
+  static func decryptMessage(keySet: WebPushKeySet, message: Data) throws
+    -> Data
+  {
+    guard message.count > 20 else {
+      throw WebPushError.messageSize
+    }
+    let salt = message[0..<16]
+    let rs = message[16..<20].reduce(0) { acc, value in
+      (acc << 8) + Int(value)
+    }
+    let idlen = Int(message[20])
+    guard message.count > 21 + idlen else {
+      throw WebPushError.messageSize
+    }
+    let keyid = message[21..<21 + idlen]
+    let ciphertext = message.dropFirst(21 + idlen)
+
+    let uaPublic = keySet.privateKey.publicKey
+    let uaPublicRaw = uaPublic.x963Representation
+    let uaPrivate = keySet.privateKey
+
+    let asPublicRaw = keyid
+    let asPublic = try P256.KeyAgreement.PublicKey(
+      x963Representation: asPublicRaw,
+    )
+
+    let ecdhSecret = try uaPrivate.sharedSecretFromKeyAgreement(with: asPublic)
+
+    let keyInfo = Data(
+      "WebPush: info".utf8 + [0] + uaPublicRaw + asPublicRaw
+    )
+
+    let ikm = ecdhSecret.hkdfDerivedSymmetricKey(
+      using: SHA256.self,
+      salt: keySet.auth,
+      sharedInfo: keyInfo,
+      outputByteCount: 32,
+    )
+
+    let prk = SymmetricKey(
+      data: HMAC<SHA256>.authenticationCode(
+        for: ikm.withUnsafeBytes { Data($0) },
+        using: SymmetricKey(data: salt),
+      )
+    )
+
+    let cekInfo = Data("Content-Encoding: aes128gcm".utf8 + [0, 1])
+    let cek = HMAC<SHA256>.authenticationCode(for: cekInfo, using: prk)
+      .prefix(16)
+
+    let nonceInfo = Data("Content-Encoding: nonce".utf8 + [0, 1])
+    let nonce = HMAC<SHA256>.authenticationCode(for: nonceInfo, using: prk)
+      .prefix(12)
+
+    let records = stride(
+      from: ciphertext.startIndex,
+      to: ciphertext.endIndex,
+      by: rs,
+    ).map { i in
+      ciphertext[i..<min(i + rs, ciphertext.endIndex)]
+    }
+    let encryptionKey = SymmetricKey(data: Data(cek))
+
+    let plaintext = try records.enumerated().map { seq, record in
+      var combined = nonce + record
+      combined[11] ^= UInt8(seq)
+      let sealedBox = try AES.GCM.SealedBox(combined: combined)
+      let decryptedRecord = try AES.GCM.open(sealedBox, using: encryptionKey)
+      return decryptedRecord.dropLast(1)
+    }.joined()
+
+    return Data(plaintext)
+  }
+}

--- a/ios/Notification Service Extension/WebPushKeySet.swift
+++ b/ios/Notification Service Extension/WebPushKeySet.swift
@@ -1,0 +1,61 @@
+import CryptoKit
+import Foundation
+
+enum WebPushKeySetError: Error {
+  case format
+  case auth
+  case privateKey
+}
+
+struct WebPushKeySet {
+  let privateKey: P256.KeyAgreement.PrivateKey
+  let auth: Data
+
+  init(string: String) throws {
+    let keys = string.split(separator: "+")
+    guard keys.count == 3 else {
+      throw WebPushKeySetError.format
+    }
+
+    guard let auth = Data(base64UrlEncoded: String(keys[1])) else {
+      throw WebPushKeySetError.auth
+    }
+    self.auth = auth
+
+    guard let privateKey = Data(base64UrlEncoded: String(keys[2])) else {
+      throw WebPushKeySetError.privateKey
+    }
+    if #available(iOS 14.0, *) {
+      self.privateKey = try P256.KeyAgreement.PrivateKey(
+        derRepresentation: privateKey
+      )
+    } else {
+      let octetStringTag = 4
+      let privateKeyLength = 32
+      let pattern = [UInt8(octetStringTag), UInt8(privateKeyLength)]
+      guard let range = privateKey.firstRange(of: pattern),
+        range.upperBound + privateKeyLength <= privateKey.count
+      else {
+        throw WebPushKeySetError.privateKey
+      }
+      self.privateKey = try P256.KeyAgreement.PrivateKey(
+        rawRepresentation: privateKey[
+          range.upperBound..<range.upperBound + privateKeyLength
+        ]
+      )
+    }
+  }
+}
+
+extension Data {
+  init?(base64UrlEncoded: String) {
+    let base64Encoded =
+      base64UrlEncoded
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+      .appending(
+        String(repeating: "=", count: (4 - base64UrlEncoded.count % 4) % 4)
+      )
+    self.init(base64Encoded: base64Encoded)
+  }
+}

--- a/ios/NotificationSettings/NotificationSettings.swift
+++ b/ios/NotificationSettings/NotificationSettings.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Security
+
+public enum NotificationSettingsStorageError: Error {
+  case save
+  case load
+  case delete
+}
+
+public struct NotificationSettingsStorage {
+  private static let service = "web_push_key_set"
+  private static let group =
+    "group.com.poppingmoon.aria.Notification-Service-Extension"
+
+  public static func saveKeySet(account: String, keySet: String) throws {
+    let data = Data(keySet.utf8)
+    let query =
+      [
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrService: service,
+        kSecAttrAccount: account,
+        kSecAttrAccessGroup: group,
+        kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
+        kSecValueData: data,
+      ] as CFDictionary
+    let status = SecItemAdd(query, nil)
+    switch status {
+    case errSecSuccess:
+      return
+    case errSecDuplicateItem:
+      let status = SecItemUpdate(query, [kSecValueData: data] as CFDictionary)
+      if status == errSecSuccess {
+        return
+      }
+      fallthrough
+    default:
+      throw NotificationSettingsStorageError.save
+    }
+  }
+
+  public static func loadKeySet(account: String) throws -> String? {
+    let query =
+      [
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrService: service,
+        kSecAttrAccount: account,
+        kSecAttrAccessGroup: group,
+        kSecReturnData: true,
+      ] as CFDictionary
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query, &item)
+    switch status {
+    case errSecSuccess:
+      guard let data = item as? Data else {
+        return nil
+      }
+      return String(data: data, encoding: String.Encoding.utf8)
+    case errSecItemNotFound:
+      return nil
+    default:
+      throw NotificationSettingsStorageError.load
+    }
+  }
+
+  public static func deleteKeySet(account: String) throws {
+    let query =
+      [
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrService: service,
+        kSecAttrAccount: account,
+        kSecAttrAccessGroup: group,
+      ] as CFDictionary
+    let status = SecItemDelete(query)
+    switch status {
+    case errSecSuccess:
+      return
+    default:
+      throw NotificationSettingsStorageError.delete
+    }
+  }
+
+  public static func setShowImageInNotification(showImageInNotification: Bool) {
+    UserDefaults(suiteName: group)?.set(
+      showImageInNotification,
+      forKey: "showImageInNotification",
+    )
+  }
+
+  public static func getShowImageInNotification() -> Bool? {
+    UserDefaults(suiteName: group)?.object(forKey: "showImageInNotification")
+      as? Bool
+  }
+
+  public static func setShowEmojiInReactionNotification(
+    showEmojiInReactionNotification: Bool
+  ) {
+    UserDefaults(suiteName: group)?.set(
+      showEmojiInReactionNotification,
+      forKey: "showEmojiInReactionNotification",
+    )
+  }
+
+  public static func getShowEmojiInReactionNotification() -> Bool? {
+    UserDefaults(suiteName: group)?.object(
+      forKey: "showEmojiInReactionNotification",
+    ) as? Bool
+  }
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,11 @@
 		F5034F582BAB800F0047F058 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = F5034F572BAB800F0047F058 /* Base */; };
 		F5034F5C2BAB800F0047F058 /* Share Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F5034F522BAB800E0047F058 /* Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F519BE1C2F1C856A00B05DF7 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = F519BE1B2F1C856900B05DF7 /* InfoPlist.xcstrings */; };
+		F550C6C12FA1815D0020C3BE /* Notification Service Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F550C6BA2FA1815D0020C3BE /* Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F550C7AE2FA408470020C3BE /* NotificationSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F550C7A82FA408460020C3BE /* NotificationSettings.framework */; };
+		F550C7AF2FA408470020C3BE /* NotificationSettings.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F550C7A82FA408460020C3BE /* NotificationSettings.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F550C7B42FA40C530020C3BE /* NotificationSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F550C7A82FA408460020C3BE /* NotificationSettings.framework */; };
+		F550C7B52FA40C530020C3BE /* NotificationSettings.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F550C7A82FA408460020C3BE /* NotificationSettings.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F56CD7882CA62A62006EA6B3 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = F56CD7872CA62A62006EA6B3 /* Localizable.xcstrings */; };
 		F5C1038B2E899DDC007FB760 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = F5C1038A2E899DDC007FB760 /* AppIcon.icon */; };
 /* End PBXBuildFile section */
@@ -41,6 +46,27 @@
 			remoteGlobalIDString = F5034F512BAB800E0047F058;
 			remoteInfo = "Share Extension";
 		};
+		F550C6BF2FA1815D0020C3BE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F550C6B92FA1815D0020C3BE;
+			remoteInfo = "Notification Service Extension";
+		};
+		F550C7AC2FA408470020C3BE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F550C7A72FA408460020C3BE;
+			remoteInfo = NotificationSettings;
+		};
+		F550C7B62FA40C530020C3BE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F550C7A72FA408460020C3BE;
+			remoteInfo = NotificationSettings;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -50,6 +76,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				F550C7AF2FA408470020C3BE /* NotificationSettings.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -61,8 +88,20 @@
 			dstSubfolderSpec = 13;
 			files = (
 				F5034F5C2BAB800F0047F058 /* Share Extension.appex in Embed Foundation Extensions */,
+				F550C6C12FA1815D0020C3BE /* Notification Service Extension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F550C79E2FA35C7C0020C3BE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F550C7B52FA40C530020C3BE /* NotificationSettings.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -102,10 +141,48 @@
 		F5034F622BAB8D880047F058 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		F5034F632BAB8D920047F058 /* Share Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Share Extension.entitlements"; sourceTree = "<group>"; };
 		F519BE1B2F1C856900B05DF7 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		F550C6BA2FA1815D0020C3BE /* Notification Service Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Notification Service Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F550C7A82FA408460020C3BE /* NotificationSettings.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NotificationSettings.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F56CD7872CA62A62006EA6B3 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		F5C1038A2E899DDC007FB760 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		F884DCE036FBBCE5A065E21E /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		F550C6C52FA1815D0020C3BE /* Exceptions for "Notification Service Extension" folder in "Notification Service Extension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = F550C6B92FA1815D0020C3BE /* Notification Service Extension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		F550C6BB2FA1815D0020C3BE /* Notification Service Extension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F550C6C52FA1815D0020C3BE /* Exceptions for "Notification Service Extension" folder in "Notification Service Extension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Notification Service Extension";
+			sourceTree = "<group>";
+		};
+		F550C7A92FA408460020C3BE /* NotificationSettings */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = NotificationSettings;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
@@ -113,6 +190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				F550C7AE2FA408470020C3BE /* NotificationSettings.framework in Frameworks */,
 				0EAF780C61D751393ADD9791 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -130,6 +208,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				96241FCDA3C7666CC197C50E /* Pods_Share_Extension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F550C6B72FA1815D0020C3BE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F550C7B42FA40C530020C3BE /* NotificationSettings.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F550C7A52FA408460020C3BE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -190,6 +283,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				F5034F532BAB800F0047F058 /* Share Extension */,
+				F550C6BB2FA1815D0020C3BE /* Notification Service Extension */,
+				F550C7A92FA408460020C3BE /* NotificationSettings */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				81EC5DF4174BDEA5846BD75D /* Pods */,
@@ -204,6 +299,8 @@
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
 				F5034F522BAB800E0047F058 /* Share Extension.appex */,
+				F550C6BA2FA1815D0020C3BE /* Notification Service Extension.appex */,
+				F550C7A82FA408460020C3BE /* NotificationSettings.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -236,6 +333,16 @@
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		F550C7A32FA408460020C3BE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		331C8080294A63A400263BE5 /* RunnerTests */ = {
@@ -275,6 +382,8 @@
 			);
 			dependencies = (
 				F5034F5B2BAB800F0047F058 /* PBXTargetDependency */,
+				F550C6C02FA1815D0020C3BE /* PBXTargetDependency */,
+				F550C7AD2FA408470020C3BE /* PBXTargetDependency */,
 			);
 			name = Runner;
 			packageProductDependencies = (
@@ -302,6 +411,49 @@
 			productReference = F5034F522BAB800E0047F058 /* Share Extension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		F550C6B92FA1815D0020C3BE /* Notification Service Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F550C6C62FA1815D0020C3BE /* Build configuration list for PBXNativeTarget "Notification Service Extension" */;
+			buildPhases = (
+				F550C6B62FA1815D0020C3BE /* Sources */,
+				F550C6B72FA1815D0020C3BE /* Frameworks */,
+				F550C6B82FA1815D0020C3BE /* Resources */,
+				F550C79E2FA35C7C0020C3BE /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F550C7B72FA40C530020C3BE /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				F550C6BB2FA1815D0020C3BE /* Notification Service Extension */,
+			);
+			name = "Notification Service Extension";
+			productName = "Notification Service Extension";
+			productReference = F550C6BA2FA1815D0020C3BE /* Notification Service Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		F550C7A72FA408460020C3BE /* NotificationSettings */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F550C7B02FA408470020C3BE /* Build configuration list for PBXNativeTarget "NotificationSettings" */;
+			buildPhases = (
+				F550C7A32FA408460020C3BE /* Headers */,
+				F550C7A42FA408460020C3BE /* Sources */,
+				F550C7A52FA408460020C3BE /* Frameworks */,
+				F550C7A62FA408460020C3BE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F550C7A92FA408460020C3BE /* NotificationSettings */,
+			);
+			name = NotificationSettings;
+			productName = NotificationSettings;
+			productReference = F550C7A82FA408460020C3BE /* NotificationSettings.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -309,7 +461,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1530;
+				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
@@ -323,6 +475,12 @@
 					};
 					F5034F512BAB800E0047F058 = {
 						CreatedOnToolsVersion = 15.3;
+					};
+					F550C6B92FA1815D0020C3BE = {
+						CreatedOnToolsVersion = 26.4.1;
+					};
+					F550C7A72FA408460020C3BE = {
+						CreatedOnToolsVersion = 26.4.1;
 					};
 				};
 			};
@@ -345,6 +503,8 @@
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
 				F5034F512BAB800E0047F058 /* Share Extension */,
+				F550C6B92FA1815D0020C3BE /* Notification Service Extension */,
+				F550C7A72FA408460020C3BE /* NotificationSettings */,
 			);
 		};
 /* End PBXProject section */
@@ -376,6 +536,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				F5034F582BAB800F0047F058 /* Base in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F550C6B82FA1815D0020C3BE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F550C7A62FA408460020C3BE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -524,6 +698,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F550C6B62FA1815D0020C3BE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F550C7A42FA408460020C3BE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -536,6 +724,21 @@
 			isa = PBXTargetDependency;
 			target = F5034F512BAB800E0047F058 /* Share Extension */;
 			targetProxy = F5034F5A2BAB800F0047F058 /* PBXContainerItemProxy */;
+		};
+		F550C6C02FA1815D0020C3BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F550C6B92FA1815D0020C3BE /* Notification Service Extension */;
+			targetProxy = F550C6BF2FA1815D0020C3BE /* PBXContainerItemProxy */;
+		};
+		F550C7AD2FA408470020C3BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F550C7A72FA408460020C3BE /* NotificationSettings */;
+			targetProxy = F550C7AC2FA408470020C3BE /* PBXContainerItemProxy */;
+		};
+		F550C7B72FA40C530020C3BE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F550C7A72FA408460020C3BE /* NotificationSettings */;
+			targetProxy = F550C7B62FA40C530020C3BE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -990,6 +1193,285 @@
 			};
 			name = Profile;
 		};
+		F550C6C22FA1815D0020C3BE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Notification Service Extension/Notification Service Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Notification Service Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Notification Service Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.poppingmoon.aria.Notification-Service-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F550C6C32FA1815D0020C3BE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Notification Service Extension/Notification Service Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Notification Service Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Notification Service Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.poppingmoon.aria.Notification-Service-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F550C6C42FA1815D0020C3BE /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Notification Service Extension/Notification Service Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Notification Service Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Notification Service Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.poppingmoon.aria.Notification-Service-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Profile;
+		};
+		F550C7B12FA408470020C3BE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.poppingmoon.aria.NotificationSettings;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F550C7B22FA408470020C3BE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.poppingmoon.aria.NotificationSettings;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F550C7B32FA408470020C3BE /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.poppingmoon.aria.NotificationSettings;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1029,6 +1511,26 @@
 				F5034F5E2BAB800F0047F058 /* Debug */,
 				F5034F5F2BAB800F0047F058 /* Release */,
 				F5034F602BAB800F0047F058 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F550C6C62FA1815D0020C3BE /* Build configuration list for PBXNativeTarget "Notification Service Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F550C6C22FA1815D0020C3BE /* Debug */,
+				F550C6C32FA1815D0020C3BE /* Release */,
+				F550C6C42FA1815D0020C3BE /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F550C7B02FA408470020C3BE /* Build configuration list for PBXNativeTarget "NotificationSettings" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F550C7B12FA408470020C3BE /* Debug */,
+				F550C7B22FA408470020C3BE /* Release */,
+				F550C7B32FA408470020C3BE /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage",
       "state" : {
-        "revision" : "34cf2423a2c4088d06a3b08655603b5bc3eeeb3a",
-        "version" : "5.21.2"
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TimOliver/TOCropViewController",
       "state" : {
-        "revision" : "a634cb7cdfd580006e79a6e74e64417fe9e9783b",
-        "version" : "2.7.4"
+        "revision" : "d4a6d8100f4b886fdbc8ae399bf144ff3e9afb7e",
+        "version" : "2.8.0"
       }
     }
   ],

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,17 +1,166 @@
 import Flutter
+import NotificationSettings
 import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    didFinishLaunchingWithOptions launchOptions: [UIApplication
+      .LaunchOptionsKey: Any]?,
   ) -> Bool {
-    UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return super.application(
+      application,
+      didFinishLaunchingWithOptions: launchOptions,
+    )
   }
 
-  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+  func didInitializeImplicitFlutterEngine(
+    _ engineBridge: FlutterImplicitEngineBridge,
+  ) {
+    UNUserNotificationCenter.current().delegate =
+      self as UNUserNotificationCenterDelegate
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    let methodChannel = FlutterMethodChannel(
+      name: "com.poppingmoon.aria/notification_settings",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger(),
+    )
+    methodChannel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "saveKeySet":
+        guard let args = call.arguments as? [String: Any],
+          let account = args["account"] as? String,
+          let keySet = args["keySet"] as? String
+        else {
+          result(
+            FlutterError(
+              code: "INVALID_ARGUMENT",
+              message: "Argument `account` or `keySet` is missing.",
+              details: nil,
+            ),
+          )
+          return
+        }
+        do {
+          try NotificationSettingsStorage.saveKeySet(
+            account: account,
+            keySet: keySet,
+          )
+        } catch {
+          let error = error as NSError
+          result(
+            FlutterError(
+              code: String(error.code),
+              message: error.localizedDescription,
+              details: error.localizedFailureReason,
+            ),
+          )
+          return
+        }
+        result(nil)
+      case "loadKeySet":
+        guard let args = call.arguments as? [String: Any],
+          let account = args["account"] as? String
+        else {
+          result(
+            FlutterError(
+              code: "INVALID_ARGUMENT",
+              message: "Argument `account` is missing.",
+              details: nil,
+            ),
+          )
+          return
+        }
+        do {
+          let keySet = try NotificationSettingsStorage.loadKeySet(
+            account: account
+          )
+          result(keySet)
+        } catch {
+          let error = error as NSError
+          result(
+            FlutterError(
+              code: String(error.code),
+              message: error.localizedDescription,
+              details: error.localizedFailureReason,
+            ),
+          )
+        }
+      case "deleteKeySet":
+        guard let args = call.arguments as? [String: Any],
+          let account = args["account"] as? String
+        else {
+          result(
+            FlutterError(
+              code: "INVALID_ARGUMENT",
+              message: "Argument `account` is missing.",
+              details: nil,
+            ),
+          )
+          return
+        }
+        do {
+          try NotificationSettingsStorage.deleteKeySet(account: account)
+        } catch {
+          let error = error as NSError
+          result(
+            FlutterError(
+              code: String(error.code),
+              message: error.localizedDescription,
+              details: error.localizedFailureReason,
+            ),
+          )
+          return
+        }
+        result(nil)
+      case "setShowImageInNotification":
+        guard let args = call.arguments as? [String: Any],
+          let showImageInNotification = args["showImageInNotification"] as? Bool
+        else {
+          result(
+            FlutterError(
+              code: "INVALID_ARGUMENT",
+              message: "Argument `showImageInNotification` is missing.",
+              details: nil,
+            ),
+          )
+          return
+        }
+        NotificationSettingsStorage.setShowImageInNotification(
+          showImageInNotification: showImageInNotification
+        )
+        result(nil)
+      case "getShowImageInNotification":
+        let showImageInNotification =
+          NotificationSettingsStorage.getShowImageInNotification()
+        result(showImageInNotification)
+      case "setShowEmojiInReactionNotification":
+        guard let args = call.arguments as? [String: Any],
+          let showEmojiInReactionNotification = args[
+            "showEmojiInReactionNotification"
+          ] as? Bool
+        else {
+          result(
+            FlutterError(
+              code: "INVALID_ARGUMENT",
+              message:
+                "Argument `setShowEmojiInReactionNotification` is missing.",
+              details: nil,
+            ),
+          )
+          return
+        }
+        NotificationSettingsStorage.setShowEmojiInReactionNotification(
+          showEmojiInReactionNotification: showEmojiInReactionNotification
+        )
+        result(nil)
+      case "getShowEmojiInReactionNotification":
+        let showEmojiInReactionNotification =
+          NotificationSettingsStorage.getShowEmojiInReactionNotification()
+        result(showEmojiInReactionNotification)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
   }
 }

--- a/lib/constant/misskey_web_push_proxy_url.dart
+++ b/lib/constant/misskey_web_push_proxy_url.dart
@@ -1,2 +1,0 @@
-const misskeyWebPushProxyUrl =
-    'https://misskey-web-push-proxy.poppingmoon.workers.dev';

--- a/lib/constant/web_push_proxy_url.dart
+++ b/lib/constant/web_push_proxy_url.dart
@@ -1,0 +1,1 @@
+const webPushProxyUrl = 'https://web-push-proxy.poppingmoon.workers.dev';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -748,10 +748,22 @@ class Aria extends HookConsumerWidget {
       }
     } else if (defaultTargetPlatform == TargetPlatform.iOS) {
       Future<void> onMessageOpenedApp(ApnsRemoteMessage message) async {
+        dynamic stringifyKeys(dynamic value) {
+          return switch (value) {
+            final Map<dynamic, dynamic> value => value.map(
+              (key, value) => MapEntry(key.toString(), stringifyKeys(value)),
+            ),
+            final List<dynamic> value => value.map(stringifyKeys).toList(),
+            _ => value,
+          };
+        }
+
         if (message.payload['data'] case final Map<dynamic, dynamic> data) {
           if (data['payload'] case final Map<dynamic, dynamic> payload) {
             final notification = PushNotification.fromJson(
-              payload.map((key, value) => MapEntry(key.toString(), value)),
+              payload.map(
+                (key, value) => MapEntry(key.toString(), stringifyKeys(value)),
+              ),
             );
             ref
                 .read(pushNotificationNotifierProvider.notifier)

--- a/lib/provider/notification_settings_repository_provider.dart
+++ b/lib/provider/notification_settings_repository_provider.dart
@@ -1,0 +1,10 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../repository/notification_settings_repository.dart';
+
+part 'notification_settings_repository_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+NotificationSettingsRepository notificationSettingsRepository(Ref ref) {
+  return const NotificationSettingsRepository();
+}

--- a/lib/provider/notification_settings_repository_provider.g.dart
+++ b/lib/provider/notification_settings_repository_provider.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification_settings_repository_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(notificationSettingsRepository)
+final notificationSettingsRepositoryProvider =
+    NotificationSettingsRepositoryProvider._();
+
+final class NotificationSettingsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          NotificationSettingsRepository,
+          NotificationSettingsRepository,
+          NotificationSettingsRepository
+        >
+    with $Provider<NotificationSettingsRepository> {
+  NotificationSettingsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'notificationSettingsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$notificationSettingsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<NotificationSettingsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NotificationSettingsRepository create(Ref ref) {
+    return notificationSettingsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NotificationSettingsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NotificationSettingsRepository>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$notificationSettingsRepositoryHash() =>
+    r'ee6c18a3a58a15d9558dcb9a59996a351037ba39';

--- a/lib/provider/push_subscription_notifier_provider.dart
+++ b/lib/provider/push_subscription_notifier_provider.dart
@@ -4,7 +4,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unifiedpush/unifiedpush.dart';
 import 'package:webpush_encryption/webpush_encryption.dart';
 
-import '../constant/misskey_web_push_proxy_url.dart';
 import '../model/account.dart';
 import 'api/misskey_provider.dart';
 import 'dio_provider.dart';
@@ -25,39 +24,16 @@ class PushSubscriptionNotifier extends _$PushSubscriptionNotifier {
   String get _isProxyKey => '$account/push-subscription-is-proxy';
 
   Future<void> subscribe({
-    required String id,
-    String? fcmToken,
-    String? apnsToken,
     WebPushKeySet? keySet,
     required SwRegisterResponse response,
   }) async {
     final endpoint = response.endpoint;
-    final isProxy = endpoint.startsWith(misskeyWebPushProxyUrl);
     if (keySet != null) {
-      if (isProxy) {
-        final jwk = await (await keySet.privateKey.privKey).exportJsonWebKey();
-        await ref
-            .read(dioProvider)
-            .post<Map<String, dynamic>>(
-              '$misskeyWebPushProxyUrl/subscriptions',
-              data: {
-                'id': id,
-                if (fcmToken != null) 'fcmToken': fcmToken,
-                if (apnsToken != null) 'apnsToken': apnsToken,
-                'auth': keySet.publicKey.auth,
-                'publicKey': keySet.publicKey.p256dh,
-                'privateKey': jwk['d'],
-                'vapidKey': response.key,
-              },
-            );
-      } else {
-        await ref
-            .read(webPushKeySetNotifierProvider(account).notifier)
-            .save(keySet);
-      }
+      await ref
+          .read(webPushKeySetNotifierProvider(account).notifier)
+          .save(keySet);
     }
     await ref.read(sharedPreferencesProvider).setString(_key, endpoint);
-    await ref.read(sharedPreferencesProvider).setBool(_isProxyKey, isProxy);
     state = endpoint;
   }
 
@@ -82,7 +58,9 @@ class PushSubscriptionNotifier extends _$PushSubscriptionNotifier {
       await ref.read(webPushKeySetNotifierProvider(account).notifier).delete();
     }
     await ref.read(sharedPreferencesProvider).remove(_key);
-    await ref.read(sharedPreferencesProvider).remove(_isProxyKey);
+    if (ref.read(sharedPreferencesProvider).containsKey(_isProxyKey)) {
+      await ref.read(sharedPreferencesProvider).remove(_isProxyKey);
+    }
     state = null;
   }
 }

--- a/lib/provider/push_subscription_notifier_provider.g.dart
+++ b/lib/provider/push_subscription_notifier_provider.g.dart
@@ -60,7 +60,7 @@ final class PushSubscriptionNotifierProvider
 }
 
 String _$pushSubscriptionNotifierHash() =>
-    r'f5c3380f0dfbf57b9723b4551e8ee46882588d76';
+    r'04966a4c91b04bfe8dcf8179e18654a482109fad';
 
 final class PushSubscriptionNotifierFamily extends $Family
     with

--- a/lib/provider/web_push_key_set_notifier_provider.dart
+++ b/lib/provider/web_push_key_set_notifier_provider.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:webpush_encryption/webpush_encryption.dart';
 
 import '../model/account.dart';
+import 'notification_settings_repository_provider.dart';
 import 'shared_preferences_provider.dart';
 
 part 'web_push_key_set_notifier_provider.g.dart';
@@ -12,22 +14,42 @@ part 'web_push_key_set_notifier_provider.g.dart';
 class WebPushKeySetNotifier extends _$WebPushKeySetNotifier {
   @override
   FutureOr<WebPushKeySet?> build(Account account) {
-    final keySetBase64 = ref.watch(sharedPreferencesProvider).getString(_key);
-    if (keySetBase64 == null) {
-      return null;
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return ref
+          .watch(notificationSettingsRepositoryProvider)
+          .loadKeySet(account);
+    } else {
+      final keySetBase64 = ref.watch(sharedPreferencesProvider).getString(_key);
+      if (keySetBase64 == null) {
+        return null;
+      }
+      return WebPushKeySet.deserialize(keySetBase64);
     }
-    return WebPushKeySet.deserialize(keySetBase64);
   }
 
   String get _key => '$account/webPushKeySet';
 
   Future<void> save(WebPushKeySet keySet) async {
-    await ref.read(sharedPreferencesProvider).setString(_key, keySet.serialize);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await ref
+          .read(notificationSettingsRepositoryProvider)
+          .saveKeySet(account, keySet);
+    } else {
+      await ref
+          .read(sharedPreferencesProvider)
+          .setString(_key, keySet.serialize);
+    }
     state = AsyncValue.data(keySet);
   }
 
   Future<void> delete() async {
-    await ref.read(sharedPreferencesProvider).remove(_key);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      await ref
+          .read(notificationSettingsRepositoryProvider)
+          .deleteKeySet(account);
+    } else {
+      await ref.read(sharedPreferencesProvider).remove(_key);
+    }
     state = const AsyncValue.data(null);
   }
 }

--- a/lib/provider/web_push_key_set_notifier_provider.g.dart
+++ b/lib/provider/web_push_key_set_notifier_provider.g.dart
@@ -51,7 +51,7 @@ final class WebPushKeySetNotifierProvider
 }
 
 String _$webPushKeySetNotifierHash() =>
-    r'd1740faccd1248acc40b5045ef15f1dbcb215252';
+    r'5582a01c27d964dc71aa350d577764d827c26764';
 
 final class WebPushKeySetNotifierFamily extends $Family
     with

--- a/lib/repository/notification_settings_repository.dart
+++ b/lib/repository/notification_settings_repository.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/services.dart';
+import 'package:webpush_encryption/webpush_encryption.dart';
+
+import '../model/account.dart';
+
+class NotificationSettingsRepository {
+  const NotificationSettingsRepository();
+
+  static const _channel = MethodChannel(
+    'com.poppingmoon.aria/notification_settings',
+  );
+
+  Future<void> saveKeySet(Account account, WebPushKeySet keySet) async {
+    await _channel.invokeMethod('saveKeySet', {
+      'account': account.toString(),
+      'keySet': keySet.serialize,
+    });
+  }
+
+  Future<WebPushKeySet?> loadKeySet(Account account) async {
+    final value = await _channel.invokeMethod<String>('loadKeySet', {
+      'account': account.toString(),
+    });
+    if (value != null) {
+      return WebPushKeySet.deserialize(value);
+    }
+    return null;
+  }
+
+  Future<void> deleteKeySet(Account account) async {
+    await _channel.invokeMethod('deleteKeySet', {
+      'account': account.toString(),
+    });
+  }
+
+  Future<void> setShowImageInNotification(bool showImageInNotification) async {
+    await _channel.invokeMethod('setShowImageInNotification', {
+      'showImageInNotification': showImageInNotification,
+    });
+  }
+
+  Future<bool?> getShowImageInNotification() {
+    return _channel.invokeMethod('getShowImageInNotification');
+  }
+
+  Future<void> setShowEmojiInReactionNotification(
+    bool showEmojiInReactionNotification,
+  ) async {
+    await _channel.invokeMethod('setShowEmojiInReactionNotification', {
+      'showEmojiInReactionNotification': showEmojiInReactionNotification,
+    });
+  }
+
+  Future<bool?> getShowEmojiInReactionNotification() {
+    return _channel.invokeMethod('getShowEmojiInReactionNotification');
+  }
+}

--- a/lib/view/page/settings/appearance_page.dart
+++ b/lib/view/page/settings/appearance_page.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../constant/max_content_width.dart';
 import '../../../i18n/strings.g.dart';
 import '../../../provider/general_settings_notifier_provider.dart';
+import '../../../provider/notification_settings_repository_provider.dart';
+import '../../../util/future_with_dialog.dart';
 import '../../widget/general_settings_scaffold.dart';
 
 class AppearancePage extends HookConsumerWidget {
@@ -14,6 +17,34 @@ class AppearancePage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(generalSettingsNotifierProvider);
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      useEffect(() {
+        Future(() async {
+          final showImageInNotification = await ref
+              .read(notificationSettingsRepositoryProvider)
+              .getShowImageInNotification();
+          if (showImageInNotification != null &&
+              showImageInNotification != settings.showImageInNotification) {
+            await ref
+                .read(generalSettingsNotifierProvider.notifier)
+                .setShowImageInNotification(showImageInNotification);
+          }
+          final showEmojiInReactionNotification = await ref
+              .read(notificationSettingsRepositoryProvider)
+              .getShowEmojiInReactionNotification();
+          if (showEmojiInReactionNotification != null &&
+              showEmojiInReactionNotification !=
+                  settings.showEmojiInReactionNotification) {
+            await ref
+                .read(generalSettingsNotifierProvider.notifier)
+                .setShowEmojiInReactionNotification(
+                  showEmojiInReactionNotification,
+                );
+          }
+        });
+        return;
+      }, []);
+    }
 
     return GeneralSettingsScaffold(
       appBar: AppBar(title: Text(t.misskey.appearance)),
@@ -316,7 +347,8 @@ class AppearancePage extends HookConsumerWidget {
                 ),
               ),
             ),
-            if (defaultTargetPlatform == TargetPlatform.android) ...[
+            if (defaultTargetPlatform
+                case TargetPlatform.android || TargetPlatform.iOS) ...[
               const SizedBox(height: 16.0),
               Center(
                 child: Container(
@@ -337,9 +369,19 @@ class AppearancePage extends HookConsumerWidget {
                   child: SwitchListTile(
                     title: Text(t.aria.showImageInNotification),
                     value: settings.showImageInNotification,
-                    onChanged: (value) => ref
-                        .read(generalSettingsNotifierProvider.notifier)
-                        .setShowImageInNotification(value),
+                    onChanged: (value) => Future.wait([
+                      ref
+                          .read(generalSettingsNotifierProvider.notifier)
+                          .setShowImageInNotification(value),
+                      if (defaultTargetPlatform == TargetPlatform.iOS)
+                        futureWithDialog(
+                          context,
+                          ref
+                              .read(notificationSettingsRepositoryProvider)
+                              .setShowImageInNotification(value),
+                          overlay: false,
+                        ),
+                    ]),
                     shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.vertical(
                         top: Radius.circular(8.0),
@@ -355,9 +397,19 @@ class AppearancePage extends HookConsumerWidget {
                   child: SwitchListTile(
                     title: Text(t.aria.showEmojiInReactionNotification),
                     value: settings.showEmojiInReactionNotification,
-                    onChanged: (value) => ref
-                        .read(generalSettingsNotifierProvider.notifier)
-                        .setShowEmojiInReactionNotification(value),
+                    onChanged: (value) => Future.wait([
+                      ref
+                          .read(generalSettingsNotifierProvider.notifier)
+                          .setShowEmojiInReactionNotification(value),
+                      if (defaultTargetPlatform == TargetPlatform.iOS)
+                        futureWithDialog(
+                          context,
+                          ref
+                              .read(notificationSettingsRepositoryProvider)
+                              .setShowEmojiInReactionNotification(value),
+                          overlay: false,
+                        ),
+                    ]),
                     shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.vertical(
                         bottom: Radius.circular(8.0),

--- a/lib/view/page/settings/notifications_settings_page.dart
+++ b/lib/view/page/settings/notifications_settings_page.dart
@@ -8,11 +8,10 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:unifiedpush/unifiedpush.dart';
 import 'package:unifiedpush_ui/unifiedpush_ui.dart';
-import 'package:uuid/uuid.dart';
 import 'package:webpush_encryption/webpush_encryption.dart';
 
 import '../../../constant/max_content_width.dart';
-import '../../../constant/misskey_web_push_proxy_url.dart';
+import '../../../constant/web_push_proxy_url.dart';
 import '../../../i18n/strings.g.dart';
 import '../../../model/account.dart';
 import '../../../provider/api/i_notifier_provider.dart';
@@ -32,11 +31,8 @@ class NotificationsSettingsPage extends ConsumerWidget {
   final Account account;
 
   Future<void> _subscribe(WidgetRef ref) async {
-    final id = const Uuid().v4();
     final String endpoint;
     ({String auth, String publicKey})? publicKeySet;
-    String? fcmToken;
-    String? apnsToken;
 
     // Request permissions and get the endpoint and the token.
     if (defaultTargetPlatform == TargetPlatform.android) {
@@ -98,7 +94,6 @@ class NotificationsSettingsPage extends ConsumerWidget {
         return;
       }
 
-      endpoint = '$misskeyWebPushProxyUrl/subscriptions/$id';
       final completer = Completer<String>();
 
       void callback() {
@@ -110,12 +105,13 @@ class NotificationsSettingsPage extends ConsumerWidget {
 
       callback();
       connector.token.addListener(callback);
-      apnsToken = await futureWithDialog(
+      final apnsToken = await futureWithDialog(
         ref.context,
         completer.future.timeout(const Duration(seconds: 10)),
       );
       connector.token.removeListener(callback);
       if (apnsToken == null) return;
+      endpoint = '$webPushProxyUrl/apns/$account/$apnsToken';
     }
 
     WebPushKeySet? keySet;
@@ -159,13 +155,7 @@ class NotificationsSettingsPage extends ConsumerWidget {
       ref.context,
       ref
           .read(pushSubscriptionNotifierProvider(account).notifier)
-          .subscribe(
-            id: id,
-            fcmToken: fcmToken,
-            apnsToken: apnsToken,
-            keySet: keySet,
-            response: response,
-          ),
+          .subscribe(keySet: keySet, response: response),
     );
 
     if (defaultTargetPlatform == TargetPlatform.android) {


### PR DESCRIPTION
Added a Notification Service Extension to iOS to modify push notifications when they are received.

Previously, push notifications on iOS were accomplished by decrypting Web Push messages sent from a Misskey server before sending them to APNs. Aria used [Misskey Web Push Proxy](https://github.com/poppingmoon/misskey-web-push-proxy) for decryption and to send requests.

By using the extension, we no longer need to decrypt them in the middle because it can decrypt messages on the device. This PR replaces the proxy with [Web Push Proxy](https://github.com/poppingmoon/web-push-proxy), which simply forwards encrypted Web Push messages via APNs. The extension also enables attaching images to the notifications.

The idea to use a Notification Service Extension for decryption is based on pooza/capsicum#336.

ref: #406