### PR TITLE
feat: add navigation to target channel from renote header

### DIFF
--- a/lib/view/widget/note_sheet.dart
+++ b/lib/view/widget/note_sheet.dart
@@ -668,6 +668,12 @@ class _RenoteSheet extends ConsumerWidget {
             title: Text(t.misskey.renoteDetails),
             onTap: () => context.push('/$account/notes/${note.id}'),
           ),
+        if (note.channelId case final channelId?)
+          ListTile(
+            leading: const Icon(Icons.tv),
+            title: Text(t.misskey.viewRenotedChannel),
+            onTap: () => context.push('/$account/channels/$channelId'),
+          ),
         ListTile(
           leading: const Icon(Icons.link),
           title: Text(t.misskey.copyLinkRenote),


### PR DESCRIPTION
Added a button to the note sheet opened from the renote header that navigates to the channel to which the note is renoted.

ref: [misskey-dev/misskey#17280](https://redirect.github.com/misskey-dev/misskey/pull/17280)