### PR TITLE
fix: add timeout for fetching image for notification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -693,7 +693,8 @@ class Aria extends HookConsumerWidget {
             try {
               file = await ref
                   .read(cacheManagerProvider)
-                  .getSingleFile(url.toString());
+                  .getSingleFile(url.toString())
+                  .timeout(const Duration(seconds: 10));
             } catch (_) {}
           }
 


### PR DESCRIPTION
Changed to quit fetching an image for Android notifications after 10 seconds.