### PR TITLE
fix: merge current draft if next draft is empty

### DIFF
--- a/lib/extension/note_draft_extension.dart
+++ b/lib/extension/note_draft_extension.dart
@@ -34,7 +34,10 @@ extension NoteDraftExtension on NoteDraft {
       poll == null;
 
   bool get canPost =>
-      ((text?.isNotEmpty ?? false) || poll != null || renoteId != null) &&
+      ((text?.isNotEmpty ?? false) ||
+          (fileIds?.isNotEmpty ?? false) ||
+          poll != null ||
+          renoteId != null) &&
       switch (poll) {
         final poll? =>
           poll.choices.length >= 2 &&

--- a/lib/provider/post_notifier_provider.dart
+++ b/lib/provider/post_notifier_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:mfm_parser/mfm_parser.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -81,7 +82,7 @@ class PostNotifier extends _$PostNotifier {
           reply != next.reply ||
           renote != next.renote ||
           channel != next.channel) {
-        state = next.copyWith(
+        state = state.copyWith(
           userId: i?.id ?? next.userId,
           user: i?.toUserLite() ?? next.user,
           reply: reply,
@@ -95,15 +96,18 @@ class PostNotifier extends _$PostNotifier {
       return note?.toNoteDraft() ?? _getDefaultDraft(null);
     }
     ref.listen(timelineTabSettingsProvider, (prev, next) async {
-      if (prev != null && prev.account == account) {
+      if (prev == null) return;
+      if (prev.account == account && _saveScheduled) {
         await _saveDraft(prev);
       }
       if (next != null && next.account == account) {
         final draft = await _loadDraft(next);
-        if (draft != null) {
-          state = draft;
+        if (!(draft?.canPost ?? false) &&
+            state.canPost &&
+            prev.account == account) {
+          state = _merge(draft ?? _getDefaultDraft(next));
         } else {
-          state = _getDefaultDraft(next);
+          state = draft ?? _getDefaultDraft(next);
         }
       }
     });
@@ -151,9 +155,9 @@ class PostNotifier extends _$PostNotifier {
     final localOnly =
         channelId != null ||
         (visibility != NoteVisibility.specified &&
-                settings.rememberNoteVisibility
-            ? settings.localOnly
-            : settings.defaultNoteLocalOnly);
+            (settings.rememberNoteVisibility
+                ? settings.localOnly
+                : settings.defaultNoteLocalOnly));
     final reactionAcceptance = settings.reactionAcceptance;
     return NoteDraft(
       id: '',
@@ -164,6 +168,66 @@ class PostNotifier extends _$PostNotifier {
       channelId: channelId,
       localOnly: localOnly,
       reactionAcceptance: reactionAcceptance,
+    );
+  }
+
+  NoteDraft _merge(NoteDraft draft) {
+    final visibility = draft.channelId != null
+        ? NoteVisibility.public
+        : NoteVisibility.min(
+            state.visibility ?? NoteVisibility.public,
+            draft.visibility ?? NoteVisibility.public,
+          );
+    final localOnly =
+        draft.channelId != null ||
+        (visibility != NoteVisibility.specified &&
+            ((state.localOnly ?? false) || (draft.localOnly ?? false)));
+    final reply = switch (state.reply) {
+      final reply?
+          when (reply.visibility ?? NoteVisibility.public).priority <=
+                  visibility.priority &&
+              (reply.user.host == null || !localOnly) =>
+        reply,
+      _ => null,
+    };
+    final renote = switch (state.renote) {
+      final renote?
+          when (renote.visibility ?? NoteVisibility.public).priority <=
+                  visibility.priority &&
+              (renote.user.host == null || !localOnly) &&
+              ((renote.channel?.allowRenoteToExternal ?? true) ||
+                  draft.channelId == renote.channelId) =>
+        renote,
+      _ => null,
+    };
+    return state.copyWith(
+      text: state.text ?? draft.text,
+      cw: state.cw ?? draft.cw,
+      replyId: reply?.id,
+      reply: reply,
+      renoteId: renote?.id,
+      renote: renote,
+      fileIds: state.fileIds?.isNotEmpty ?? false
+          ? state.fileIds
+          : draft.fileIds,
+      files: state.fileIds?.isNotEmpty ?? false
+          ? const ListEquality<String>().equals(
+                  state.files?.map((file) => file.id).toList(),
+                  state.fileIds,
+                )
+                ? state.files
+                : null
+          : const ListEquality<String>().equals(
+              draft.files?.map((file) => file.id).toList(),
+              draft.fileIds,
+            )
+          ? draft.files
+          : null,
+      hashtag: state.hashtag ?? draft.hashtag,
+      poll: state.poll ?? draft.poll,
+      channelId: draft.channelId,
+      channel: draft.channel?.id == draft.channelId ? draft.channel : null,
+      localOnly: localOnly,
     );
   }
 
@@ -333,9 +397,13 @@ class PostNotifier extends _$PostNotifier {
     _timer?.cancel();
     final draft = state;
     final tabSettings = _tabSettings;
-    state = _getDefaultDraft(
-      tabSettings,
-    ).copyWith(hashtag: keepHashtag ? draft.hashtag : null);
+    final defaultDraft = _getDefaultDraft(tabSettings);
+    state = defaultDraft.copyWith(
+      hashtag: keepHashtag ? draft.hashtag : null,
+      channel: defaultDraft.channelId == draft.channel?.id
+          ? draft.channel
+          : null,
+    );
 
     final repo = await ref.read(noteDraftRepositoryProvider.future);
     if (draft.replyId != null || draft.renoteId != null) {
@@ -595,20 +663,27 @@ class PostNotifier extends _$PostNotifier {
       ...additionalMentions.map((mention) => mention.acct),
       if (!isMentionOnly) state.text ?? '' else '',
     ].join(' ');
+    final channelId =
+        reply.channelId ??
+        (visibility != NoteVisibility.specified && reply.user.host == null
+            ? state.channelId
+            : null);
     state = state.copyWith(
       visibility: visibility,
       visibleUserIds: visibleUserIds,
       localOnly:
-          visibility != NoteVisibility.specified &&
-          ((state.localOnly ?? false) || reply.localOnly),
+          channelId != null ||
+          (visibility != NoteVisibility.specified &&
+              reply.user.host == null &&
+              ((state.localOnly ?? false) || reply.localOnly)),
       cw: keepCw ? (reply.cw ?? state.cw) : state.cw,
       replyId: reply.id,
       reply: reply,
-      channelId: visibility != NoteVisibility.specified
-          ? reply.channelId ?? state.channelId
-          : null,
-      channel: visibility != NoteVisibility.specified
-          ? reply.channel ?? state.channel
+      channelId: channelId,
+      channel: reply.channel?.id == channelId
+          ? reply.channel
+          : state.channel?.id == channelId
+          ? state.channel
           : null,
       text: text,
     );
@@ -664,18 +739,25 @@ class PostNotifier extends _$PostNotifier {
       state.visibility ?? NoteVisibility.public,
       renote.visibility ?? NoteVisibility.public,
     );
+    final channelId =
+        renote.channelId ??
+        (visibility != NoteVisibility.specified && renote.user.host == null
+            ? state.channelId
+            : null);
     state = state.copyWith(
       visibility: visibility,
       localOnly:
-          visibility != NoteVisibility.specified &&
-          ((state.localOnly ?? false) || renote.localOnly),
+          channelId != null ||
+          (visibility != NoteVisibility.specified &&
+              renote.user.host == null &&
+              ((state.localOnly ?? false) || renote.localOnly)),
       renoteId: renote.id,
       renote: renote,
-      channelId: visibility != NoteVisibility.specified
-          ? renote.channelId ?? state.channelId
-          : null,
-      channel: visibility != NoteVisibility.specified
-          ? renote.channel ?? state.channel
+      channelId: channelId,
+      channel: renote.channel?.id == channelId
+          ? renote.channel
+          : state.channel?.id == channelId
+          ? state.channel
           : null,
     );
     _scheduleSave();

--- a/lib/provider/post_notifier_provider.dart
+++ b/lib/provider/post_notifier_provider.dart
@@ -95,22 +95,6 @@ class PostNotifier extends _$PostNotifier {
       final note = ref.read(noteNotifierProvider(account, noteId));
       return note?.toNoteDraft() ?? _getDefaultDraft(null);
     }
-    ref.listen(timelineTabSettingsProvider, (prev, next) async {
-      if (prev == null) return;
-      if (prev.account == account && _saveScheduled) {
-        await _saveDraft(prev);
-      }
-      if (next != null && next.account == account) {
-        final draft = await _loadDraft(next);
-        if (!(draft?.canPost ?? false) &&
-            state.canPost &&
-            prev.account == account) {
-          state = _merge(draft ?? _getDefaultDraft(next));
-        } else {
-          state = draft ?? _getDefaultDraft(next);
-        }
-      }
-    });
     final tabSettings = _tabSettings;
     final defaultDraft = _getDefaultDraft(tabSettings);
     if (tabSettings?.account == account) {
@@ -390,6 +374,20 @@ class PostNotifier extends _$PostNotifier {
   void fromNote(Note note) {
     state = note.toNoteDraft();
     _scheduleSave();
+  }
+
+  Future<void> switchTab(TabSettings prev, TabSettings next) async {
+    if (prev.account == account && _saveScheduled) {
+      await _saveDraft(prev);
+    }
+    if (next.account == account) {
+      final draft = await _loadDraft(next);
+      if (!(draft?.canPost ?? false) && state.canPost) {
+        state = _merge(draft ?? _getDefaultDraft(next));
+      } else {
+        state = draft ?? _getDefaultDraft(next);
+      }
+    }
   }
 
   Future<void> reset({bool keepHashtag = false}) async {

--- a/lib/provider/post_notifier_provider.dart
+++ b/lib/provider/post_notifier_provider.dart
@@ -108,15 +108,16 @@ class PostNotifier extends _$PostNotifier {
       }
     });
     final tabSettings = _tabSettings;
+    final defaultDraft = _getDefaultDraft(tabSettings);
     if (tabSettings?.account == account) {
       Future(() async {
         final draft = await _loadDraft(tabSettings);
-        if (draft != null) {
+        if (draft != null && state == defaultDraft) {
           state = draft;
         }
       });
     }
-    return _getDefaultDraft(tabSettings);
+    return defaultDraft;
   }
 
   String get _key => '$account/draft';

--- a/lib/provider/post_notifier_provider.g.dart
+++ b/lib/provider/post_notifier_provider.g.dart
@@ -58,7 +58,7 @@ final class PostNotifierProvider
   }
 }
 
-String _$postNotifierHash() => r'1cb161516ff67c9d5e5694ba6b4a1836e197f9f6';
+String _$postNotifierHash() => r'c689ff82eec0e1ac3913d2f0fb77a8bfcd0bddc2';
 
 final class PostNotifierFamily extends $Family
     with

--- a/lib/provider/post_notifier_provider.g.dart
+++ b/lib/provider/post_notifier_provider.g.dart
@@ -58,7 +58,7 @@ final class PostNotifierProvider
   }
 }
 
-String _$postNotifierHash() => r'751753d28f1b2969230a9778ed08820be54eec1f';
+String _$postNotifierHash() => r'e3e8a1b594d948e283106158d6c42fd09073fa07';
 
 final class PostNotifierFamily extends $Family
     with

--- a/lib/provider/post_notifier_provider.g.dart
+++ b/lib/provider/post_notifier_provider.g.dart
@@ -58,7 +58,7 @@ final class PostNotifierProvider
   }
 }
 
-String _$postNotifierHash() => r'c689ff82eec0e1ac3913d2f0fb77a8bfcd0bddc2';
+String _$postNotifierHash() => r'751753d28f1b2969230a9778ed08820be54eec1f';
 
 final class PostNotifierFamily extends $Family
     with

--- a/lib/view/dialog/note_drafts_dialog.dart
+++ b/lib/view/dialog/note_drafts_dialog.dart
@@ -309,16 +309,27 @@ class _LocalNoteDraftWidget extends ConsumerWidget {
             ],
           ),
         ),
-        NoteWidget(
-          account: draft.account,
-          noteId: '',
-          withHardMute: false,
-          showFooter: false,
-          note: draft.draft.toNote(),
-          borderRadius: const BorderRadius.vertical(
-            bottom: Radius.circular(8.0),
+        if (draft.draft.isRenote)
+          NoteWidget(
+            account: draft.account,
+            noteId: draft.draft.renoteId!,
+            withHardMute: false,
+            showFooter: false,
+            borderRadius: const BorderRadius.vertical(
+              bottom: Radius.circular(8.0),
+            ),
+          )
+        else
+          NoteWidget(
+            account: draft.account,
+            noteId: '',
+            withHardMute: false,
+            showFooter: false,
+            note: draft.draft.toNote(),
+            borderRadius: const BorderRadius.vertical(
+              bottom: Radius.circular(8.0),
+            ),
           ),
-        ),
       ],
     );
   }
@@ -427,16 +438,27 @@ class _NoteDraftWidget extends ConsumerWidget {
             ],
           ),
         ),
-        NoteWidget(
-          account: account,
-          noteId: '',
-          withHardMute: false,
-          showFooter: false,
-          note: draft.toNote(),
-          borderRadius: const BorderRadius.vertical(
-            bottom: Radius.circular(8.0),
+        if (draft.isRenote)
+          NoteWidget(
+            account: account,
+            noteId: draft.renoteId!,
+            withHardMute: false,
+            showFooter: false,
+            borderRadius: const BorderRadius.vertical(
+              bottom: Radius.circular(8.0),
+            ),
+          )
+        else
+          NoteWidget(
+            account: account,
+            noteId: '',
+            withHardMute: false,
+            showFooter: false,
+            note: draft.toNote(),
+            borderRadius: const BorderRadius.vertical(
+              bottom: Radius.circular(8.0),
+            ),
           ),
-        ),
       ],
     );
   }

--- a/lib/view/page/timelines_page.dart
+++ b/lib/view/page/timelines_page.dart
@@ -77,6 +77,7 @@ class TimelinesPage extends HookConsumerWidget {
       keys: [numTabs],
     );
     final showPostForm = useState(false);
+    final postFormAccount = useState<Account?>(null);
     useEffect(() {
       int previousIndex = tabIndex;
       int index = tabIndex;
@@ -100,10 +101,17 @@ class TimelinesPage extends HookConsumerWidget {
         ref
             .read(timelineTabIndexNotifierProvider.notifier)
             .updateIndex(nextIndex);
-        final previousAccount = tabs[index].account;
+        final previousTab = tabs[index];
+        final previousAccount = previousTab.account;
         final nextTab = tabs[nextIndex];
         final nextAccount = nextTab.account;
         index = nextIndex;
+        if (postFormAccount.value ?? previousAccount case final previousAccount
+            when previousAccount == nextAccount) {
+          ref
+              .read(postNotifierProvider(previousAccount).notifier)
+              .switchTab(previousTab, nextTab);
+        }
         if (previousAccount != nextAccount) {
           if (previousAccount.host != nextAccount.host) {
             ref
@@ -113,6 +121,7 @@ class TimelinesPage extends HookConsumerWidget {
           if (!nextAccount.isGuest) {
             ref.invalidate(iNotifierProvider(nextAccount));
           }
+          postFormAccount.value = null;
         }
         if (nextAccount.isGuest) {
           showPostForm.value = false;
@@ -250,6 +259,8 @@ class TimelinesPage extends HookConsumerWidget {
                                       account: tabSettings.account,
                                       focusNode: postFormFocusNode,
                                       onHide: () => showPostForm.value = false,
+                                      onAccountChanged: (account) =>
+                                          postFormAccount.value = account,
                                     ),
                                   ),
                                 ),
@@ -329,11 +340,13 @@ class _PostForm extends HookConsumerWidget {
     required this.account,
     required this.focusNode,
     required this.onHide,
+    required this.onAccountChanged,
   });
 
   final Account account;
   final FocusNode focusNode;
   final void Function() onHide;
+  final void Function(Account account) onAccountChanged;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -387,7 +400,10 @@ class _PostForm extends HookConsumerWidget {
               hashtagFocusNode: hashtagFocusNode,
               onHide: onHide,
               onExpand: (account) => context.push('/$account/post'),
-              onAccountChanged: (newAccount) => account.value = newAccount,
+              onAccountChanged: (newAccount) {
+                account.value = newAccount;
+                onAccountChanged(newAccount);
+              },
               showPostButton: true,
               maxLines: 6,
               thumbnailSize: 100.0,


### PR DESCRIPTION
Changed to preserve the content of the draft when switching between tabs within the same account.

If the next tab already has a draft that is not empty, the current draft will not be transferred.

Fix #877 