### PR TITLE
fix: update account on tab switch in post form

### DIFF
--- a/lib/view/widget/post_form.dart
+++ b/lib/view/widget/post_form.dart
@@ -1347,6 +1347,10 @@ class _AccountSwitchButton extends HookConsumerWidget {
       duration: const Duration(milliseconds: 100),
       initialValue: 1.0,
     );
+    useEffect(() {
+      accountIndex.value = max(0, accounts.indexOf(this.account));
+      return;
+    }, [this.account]);
     const threshold = 20.0;
 
     return ClipRect(


### PR DESCRIPTION
Fixed an issue where the account in the post form does not update when switching tabs.

Follow up for #885