### PR TITLE
ci: run slang in check-build-diff job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,9 @@ jobs:
       - name: Run build_runner
         run: dart run build_runner build -d
 
+      - name: Run slang
+        run: dart run slang
+
       - name: Suggest changes
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 31
-/// Strings: 70104 (2261 per locale)
+/// Strings: 70116 (2261 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_de_DE.g.dart
+++ b/lib/i18n/strings_de_DE.g.dart
@@ -117,6 +117,8 @@ class _TranslationsAriaDeDe extends TranslationsAriaEnUs {
 	@override String get enableSpellCheck => 'Rechtschreibprüfung aktivieren';
 	@override String get endpoint => 'Endpunkt';
 	@override String get exitPlayConfirm => 'Diesen Play verlassen?';
+	@override String get expandNote => 'Notiz ausklappen';
+	@override String get expandUser => 'Benutzer ausklappen';
 	@override String get extraMentionsWarning => 'Diese Notiz enthält Erwähnungen, die nicht in der Zielnotiz der Antwort enthalten sind';
 	@override String get fileNotFound => 'Datei existiert nicht';
 	@override String get findServer => 'Einen Misskey-Server finden';

--- a/lib/i18n/strings_es_ES.g.dart
+++ b/lib/i18n/strings_es_ES.g.dart
@@ -102,6 +102,7 @@ class _TranslationsAriaEsEs extends TranslationsAriaEnUs {
 	@override String get enableSpellCheck => 'Activar el corrector ortográfico';
 	@override String get endpoint => 'Endpoint';
 	@override String get exitPlayConfirm => '¿Estás seguro de salir de Play?';
+	@override String get expandNote => 'Mostrar nota';
 	@override String get extraMentionsWarning => 'Esta nota incluye menciones que no están incluidas en la nota a responder';
 	@override String get fileNotFound => 'Archivo no encontrado';
 	@override String get findServer => 'Encuentra un servidor Misskey';

--- a/lib/i18n/strings_id_ID.g.dart
+++ b/lib/i18n/strings_id_ID.g.dart
@@ -97,6 +97,7 @@ class _TranslationsAriaIdId extends TranslationsAriaEnUs {
 	@override String get enablePredictiveBack => 'Nyalakan animasi untuk predictive back';
 	@override String get enableSpellCheck => 'Nyalakan pemeriksaan ejaan';
 	@override String get endpoint => 'Endpoint';
+	@override String get expandNote => 'Tampilkan note';
 	@override String get extraMentionsWarning => 'Note ini memiliki mention yang tidak tercantum di target balasan note';
 	@override String get fileNotFound => 'Berkas tidak ditemukan';
 	@override String get findServer => 'Cari server Misskey';

--- a/lib/i18n/strings_it_IT.g.dart
+++ b/lib/i18n/strings_it_IT.g.dart
@@ -106,6 +106,7 @@ class _TranslationsAriaItIt extends TranslationsAriaEnUs {
 	@override String get enableSpellCheck => 'Abilita controllo ortografico';
 	@override String get endpoint => 'Endpoint';
 	@override String get exitPlayConfirm => 'Sei sicuro di voler uscire dal gioco?';
+	@override String get expandNote => 'Espandi nota';
 	@override String get extraMentionsWarning => 'La presente nota include menzioni che non sono incluse nella nota di risposta';
 	@override String get fileNotFound => 'File non trovato';
 	@override String get findServer => 'Trova un server Misskey';

--- a/lib/i18n/strings_ja_JP.g.dart
+++ b/lib/i18n/strings_ja_JP.g.dart
@@ -116,6 +116,8 @@ class _TranslationsAriaJaJp extends TranslationsAriaEnUs {
 	@override String get enableSpellCheck => 'スペルチェックを有効にする';
 	@override String get endpoint => 'エンドポイント';
 	@override String get exitPlayConfirm => 'Playを終了しますか？';
+	@override String get expandNote => 'ノートを展開する';
+	@override String get expandUser => 'ユーザーを展開する';
 	@override String get extraMentionsWarning => '返信元のノートには含まれていないメンションがあります';
 	@override String get fileNotFound => 'ファイルが見つかりません';
 	@override String get findServer => 'Misskeyサーバーを見つける';

--- a/lib/i18n/strings_ja_KS.g.dart
+++ b/lib/i18n/strings_ja_KS.g.dart
@@ -116,6 +116,8 @@ class _TranslationsAriaJaKs extends TranslationsAriaEnUs {
 	@override String get enableSpellCheck => 'スペルチェックを有効にするで';
 	@override String get endpoint => 'エンドポイント';
 	@override String get exitPlayConfirm => 'Playをやめてええか？';
+	@override String get expandNote => 'ノートを開くで';
+	@override String get expandUser => 'ユーザー展開しとく';
 	@override String get extraMentionsWarning => '返信元のノートには入ってへんメンションがあるで';
 	@override String get fileNotFound => 'ファイルがあらへん';
 	@override String get findServer => 'Misskeyサーバーを探す';
@@ -186,7 +188,7 @@ class _TranslationsAriaJaKs extends TranslationsAriaEnUs {
 	@override String get openInExternalBrowser => '外部ブラウザで開くで';
 	@override String get openInInternalBrowser => '内部ブラウザで開くで';
 	@override String get openMenu => 'メニューを開くで';
-	@override String get openNote => 'ノートを開くで';
+	@override String get openNote => 'ノート展開しとく';
 	@override String get openNotificationSettings => '通知の設定を開く';
 	@override TextSpan openScratchpadAndRunCode({required InlineSpan scratchpad}) => TextSpan(children: [
 		const TextSpan(text: 'ブラウザで'),

--- a/lib/i18n/strings_ko_GS.g.dart
+++ b/lib/i18n/strings_ko_GS.g.dart
@@ -109,6 +109,7 @@ class _TranslationsAriaKoGs extends TranslationsAriaEnUs {
 	@override String get enableEmojiFadeIn => '커스텀 이모지에 페이드인 효과 키래이';
 	@override String get enableFederation => '연합 키라';
 	@override String get endpoint => '엔드포인트';
+	@override String get expandNote => '노트 열으라';
 	@override String get extraMentionsWarning => '원래 노트엔 읎던 멘션이 달맀는디. 그거 맞제?';
 	@override String get fileNotFound => '고런 파일 읎다';
 	@override String get findServer => 'Misskey 써버를 찾아보자야';

--- a/lib/i18n/strings_ko_KR.g.dart
+++ b/lib/i18n/strings_ko_KR.g.dart
@@ -93,6 +93,7 @@ class _TranslationsAriaKoKr extends TranslationsAriaEnUs {
 	@override String get enableEmojiFadeIn => '커스텀 이모지에 페이드인 애니메이션 활성화';
 	@override String get enableFederation => '연합 활성화하기';
 	@override String get endpoint => 'Endpoint';
+	@override String get expandNote => '노트 펼치기';
 	@override String get extraMentionsWarning => '이 노트에는 대상 답글에 포함되지 않은 멘션이 포함되어 있습니다.';
 	@override String get fileNotFound => '파일을 찾을 수 없음';
 	@override String get findServer => 'Misskey 서버 찾아보기';

--- a/lib/i18n/strings_zh_CN.g.dart
+++ b/lib/i18n/strings_zh_CN.g.dart
@@ -117,6 +117,7 @@ class _TranslationsAriaZhCn extends TranslationsAriaEnUs {
 	@override String get enableSpellCheck => '启用拼写检查';
 	@override String get endpoint => '端点';
 	@override String get exitPlayConfirm => '确定要退出这个 Play 吗？';
+	@override String get expandNote => '展开帖子';
 	@override String get extraMentionsWarning => '该贴的提及包含非回复对象';
 	@override String get fileNotFound => '未找到文件';
 	@override String get findServer => '查找 Misskey 服务器';


### PR DESCRIPTION
Fixed an issue where the ci does not fail when the slang generator has not been run.

ref: https://github.com/poppingmoon/aria/issues/896#issuecomment-4479704946