### PR TITLE
fix: collapse long draft

### DIFF
--- a/lib/provider/note_collapse_reason_provider.dart
+++ b/lib/provider/note_collapse_reason_provider.dart
@@ -76,6 +76,10 @@ enum CollapseReason { long, large }
   return (null, (maxLength: length, maxNewLines: newLines));
 }
 
+CollapseReason? checkShouldCollapse(List<MfmNode> nodes) {
+  return _checkShouldCollapse(nodes).$1;
+}
+
 @riverpod
 CollapseReason? noteCollapseReason(Ref ref, Account account, String noteId) {
   final text = ref.watch(
@@ -83,7 +87,7 @@ CollapseReason? noteCollapseReason(Ref ref, Account account, String noteId) {
   );
   if (text != null) {
     final nodes = ref.watch(parsedMfmProvider(text));
-    return _checkShouldCollapse(nodes).$1;
+    return checkShouldCollapse(nodes);
   } else {
     return null;
   }

--- a/lib/provider/note_collapse_reason_provider.g.dart
+++ b/lib/provider/note_collapse_reason_provider.g.dart
@@ -68,7 +68,7 @@ final class NoteCollapseReasonProvider
 }
 
 String _$noteCollapseReasonHash() =>
-    r'38e25a3fc4f445958352f1264437ef25414b5fcd';
+    r'4d4851e077aadf6dcf0cc8d951c96a1f87596293';
 
 final class NoteCollapseReasonFamily extends $Family
     with $FunctionalFamilyOverride<CollapseReason?, (Account, String)> {

--- a/lib/view/dialog/post_confirmation_dialog.dart
+++ b/lib/view/dialog/post_confirmation_dialog.dart
@@ -146,6 +146,7 @@ class PostConfirmationDialog extends ConsumerWidget {
                   account: account,
                   noteId: draft.renoteId!,
                   showFooter: false,
+                  expandLongNote: true,
                   backgroundColor: Colors.transparent,
                 )
               else
@@ -154,6 +155,7 @@ class PostConfirmationDialog extends ConsumerWidget {
                   noteId: '',
                   note: note,
                   showFooter: false,
+                  expandLongNote: true,
                   backgroundColor: Colors.transparent,
                 ),
               Align(

--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -176,6 +176,7 @@ class PostPage extends HookConsumerWidget {
                               noteId: '',
                               note: draft.toNote(),
                               showFooter: false,
+                              expandLongNote: true,
                               borderRadius: BorderRadius.circular(8.0),
                             ),
                     ),

--- a/lib/view/page/settings/note_display_page.dart
+++ b/lib/view/page/settings/note_display_page.dart
@@ -1664,6 +1664,7 @@ class _NotePreview extends HookWidget {
           files: [],
         ),
       ),
+      expandLongNote: true,
       borderRadius: const BorderRadius.vertical(top: Radius.circular(8.0)),
     );
   }

--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -415,7 +415,14 @@ class _NoteContent extends HookConsumerWidget {
       [parsed],
     );
     final collapseReason = appearNote.cw == null && !alwaysExpandLongNote
-        ? ref.watch(noteCollapseReasonProvider(account, appearNote.id))
+        ? appearNote.id.isNotEmpty
+              ? ref.watch(noteCollapseReasonProvider(account, appearNote.id))
+              : switch (appearNote.text) {
+                  final text? => checkShouldCollapse(
+                    ref.watch(parsedMfmProvider(text)),
+                  ),
+                  _ => null,
+                }
         : null;
     final isCollapsed = useState(collapseReason != null);
     final colors = ref.watch(

--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -52,6 +52,7 @@ class NoteWidget extends HookConsumerWidget {
     this.focusPostForm,
     this.note,
     this.showFooter,
+    this.expandLongNote,
     this.backgroundColor,
     this.margin = EdgeInsets.zero,
     this.borderRadius,
@@ -65,6 +66,7 @@ class NoteWidget extends HookConsumerWidget {
   final void Function()? focusPostForm;
   final Note? note;
   final bool? showFooter;
+  final bool? expandLongNote;
   final Color? backgroundColor;
   final EdgeInsetsGeometry margin;
   final BorderRadiusGeometry? borderRadius;
@@ -337,6 +339,7 @@ class NoteWidget extends HookConsumerWidget {
                             clipId: clipId,
                             style: style,
                             showFooter: showFooter,
+                            expandLongNote: expandLongNote,
                             focusPostForm: focusPostForm,
                             listViewKey: listViewKey,
                           ),
@@ -362,6 +365,7 @@ class _NoteContent extends HookConsumerWidget {
     required this.clipId,
     required this.style,
     required this.showFooter,
+    required this.expandLongNote,
     required this.focusPostForm,
     required this.listViewKey,
   });
@@ -373,6 +377,7 @@ class _NoteContent extends HookConsumerWidget {
   final String? clipId;
   final TextStyle style;
   final bool? showFooter;
+  final bool? expandLongNote;
   final void Function()? focusPostForm;
   final GlobalKey? listViewKey;
 
@@ -414,7 +419,8 @@ class _NoteContent extends HookConsumerWidget {
           : null,
       [parsed],
     );
-    final collapseReason = appearNote.cw == null && !alwaysExpandLongNote
+    final collapseReason =
+        appearNote.cw == null && !(expandLongNote ?? alwaysExpandLongNote)
         ? appearNote.id.isNotEmpty
               ? ref.watch(noteCollapseReasonProvider(account, appearNote.id))
               : switch (appearNote.text) {

--- a/lib/view/widget/scheduled_note_widget.dart
+++ b/lib/view/widget/scheduled_note_widget.dart
@@ -134,6 +134,7 @@ class ScheduledNoteWidget extends ConsumerWidget {
           noteId: '',
           withHardMute: false,
           showFooter: false,
+          expandLongNote: true,
           note: draft.toNote(),
           borderRadius: const BorderRadius.vertical(
             bottom: Radius.circular(8.0),

--- a/lib/view/widget/sub_note_content.dart
+++ b/lib/view/widget/sub_note_content.dart
@@ -50,7 +50,14 @@ class SubNoteContent extends HookConsumerWidget {
         ? ref.watch(parsedMfmProvider(note.text!))
         : null;
     final collapseReason = note.cw == null && !alwaysExpandLongNote
-        ? ref.watch(noteCollapseReasonProvider(account, noteId))
+        ? noteId.isNotEmpty
+              ? ref.watch(noteCollapseReasonProvider(account, noteId))
+              : switch (note.text) {
+                  final text? => checkShouldCollapse(
+                    ref.watch(parsedMfmProvider(text)),
+                  ),
+                  _ => null,
+                }
         : null;
     final colors = ref.watch(
       misskeyColorsProvider(Theme.of(context).brightness),


### PR DESCRIPTION
Fixed an issue where long drafts are not collapsed because `noteCollapseReasonProvider` expects the target note to be stored in `NotesNotifier`.