### PR TITLE
fix: use outer context for modal bottom sheet

### DIFF
--- a/lib/view/page/qr_read_page.dart
+++ b/lib/view/page/qr_read_page.dart
@@ -160,7 +160,7 @@ class QrReadPage extends HookConsumerWidget {
                         alignment: AlignmentDirectional.bottomEnd,
                         child: ValueListenableBuilder(
                           valueListenable: controller,
-                          builder: (context, value, _) => Row(
+                          builder: (buttonContext, value, _) => Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
                               IconButton(
@@ -202,9 +202,9 @@ class QrReadPage extends HookConsumerWidget {
                                       return;
                                     }
                                   }
-                                  if (!context.mounted) return;
+                                  if (!buttonContext.mounted) return;
                                   await showMessageDialog(
-                                    context,
+                                    buttonContext,
                                     t.misskey.qr_.noQrCodeFound,
                                   );
                                 },


### PR DESCRIPTION
Fixed an issue where the scan file button shows a modal bottom sheet and its descendants in dark theme regardless of the actual theme mode.