### PR TITLE
fix: hide preview for quoted note url

### DIFF
--- a/lib/view/widget/note_detailed_widget.dart
+++ b/lib/view/widget/note_detailed_widget.dart
@@ -352,12 +352,17 @@ class _NoteDetailedContent extends HookConsumerWidget {
     final parsed = appearNote.text != null
         ? ref.watch(parsedMfmProvider(appearNote.text!))
         : null;
-    final renoteUrl = note.uri?.toString() ?? note.url?.toString();
     final urls = useMemoized(
       () => parsed != null
-          ? extractUrl(parsed).where((url) => url != renoteUrl).toList()
+          ? extractUrl(parsed)
+                .where(
+                  (url) =>
+                      url != appearNote.renote?.url?.toString() &&
+                      url != appearNote.renote?.uri?.toString(),
+                )
+                .toList()
           : null,
-      [parsed],
+      [parsed, appearNote.renote],
     );
     final (avatarScale, showTicker, showAllReactions) = ref.watch(
       generalSettingsNotifierProvider.select(

--- a/lib/view/widget/note_widget.dart
+++ b/lib/view/widget/note_widget.dart
@@ -412,12 +412,17 @@ class _NoteContent extends HookConsumerWidget {
     final parsed = appearNote.text != null
         ? ref.watch(parsedMfmProvider(appearNote.text!))
         : null;
-    final renoteUrl = note.uri?.toString() ?? note.url?.toString();
     final urls = useMemoized(
       () => parsed != null
-          ? extractUrl(parsed).where((url) => url != renoteUrl).toList()
+          ? extractUrl(parsed)
+                .where(
+                  (url) =>
+                      url != appearNote.renote?.url?.toString() &&
+                      url != appearNote.renote?.uri?.toString(),
+                )
+                .toList()
           : null,
-      [parsed],
+      [parsed, appearNote.renote],
     );
     final collapseReason =
         appearNote.cw == null && !(expandLongNote ?? alwaysExpandLongNote)


### PR DESCRIPTION
Changed to hide the url preview for the same url as the quoted note.