### PR TITLE
fix: await loading when reloading emojis

### DIFF
--- a/lib/provider/emojis_notifier_provider.dart
+++ b/lib/provider/emojis_notifier_provider.dart
@@ -71,15 +71,17 @@ class EmojisNotifier extends _$EmojisNotifier {
   }
 
   Future<void> reloadEmojis({bool force = false}) async {
-    if (force ||
-        (!state.isLoading &&
-            ((state.value?.isEmpty ?? true) || !_recentlyFetched))) {
-      final emojis = await _fetchEmojis();
-      state = AsyncData({for (final emoji in emojis) emoji.name: emoji});
-      _recentlyFetched = true;
-      _timer = Timer(const Duration(minutes: 10), () {
-        _recentlyFetched = false;
-      });
+    if (force || (state.value?.isEmpty ?? true) || !_recentlyFetched) {
+      if (state.isLoading) {
+        await future;
+      } else {
+        final emojis = await _fetchEmojis();
+        state = AsyncData({for (final emoji in emojis) emoji.name: emoji});
+        _recentlyFetched = true;
+        _timer = Timer(const Duration(minutes: 10), () {
+          _recentlyFetched = false;
+        });
+      }
     }
   }
 

--- a/lib/provider/emojis_notifier_provider.g.dart
+++ b/lib/provider/emojis_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class EmojisNotifierProvider
   }
 }
 
-String _$emojisNotifierHash() => r'814f4ba365e11b59627df5c8687d29f999bc0828';
+String _$emojisNotifierHash() => r'435830bddf419cf81d54c762750299c769810203';
 
 @JsonPersist()
 final class EmojisNotifierFamily extends $Family


### PR DESCRIPTION
Changed to await loading in `reloadEmojis` if `EmojisNotifier` is currently loading.

This fixes an issue where tapping a link navigates to the wrong location in the app.