### PR TITLE
fix: use zh-TW when device locale is zh-Hant

### DIFF
--- a/lib/extension/app_locale_utils_extension.dart
+++ b/lib/extension/app_locale_utils_extension.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../i18n/strings.g.dart';
+
+extension AppLocaleUtilsExtension on AppLocaleUtils {
+  AppLocale findDeviceLocale() {
+    final deviceLocale = WidgetsBinding.instance.platformDispatcher.locale;
+    if (deviceLocale.languageCode == 'zh' &&
+        deviceLocale.scriptCode == 'Hant') {
+      return AppLocale.zhTw;
+    }
+    return parseLocaleParts(
+      languageCode: deviceLocale.languageCode,
+      scriptCode: deviceLocale.scriptCode,
+      countryCode: deviceLocale.countryCode,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:window_manager/window_manager.dart';
 
 import 'constant/colors.dart';
 import 'constant/shortcuts.dart';
+import 'extension/app_locale_utils_extension.dart';
 import 'extension/user_extension.dart';
 import 'gen/assets.gen.dart';
 import 'hook/on_window_move_hook.dart';
@@ -114,11 +115,9 @@ class Aria extends HookConsumerWidget {
   Future<void> _init(WidgetRef ref) async {
     final generalSettings = ref.read(generalSettingsNotifierProvider);
     Future(() {
-      if (generalSettings.locale case final locale?) {
-        LocaleSettings.setLocale(locale);
-      } else {
-        LocaleSettings.useDeviceLocale();
-      }
+      final locale =
+          generalSettings.locale ?? AppLocaleUtils.instance.findDeviceLocale();
+      LocaleSettings.instance.setLocale(locale);
     }).ignore();
     if (generalSettings.keepScreenOn) {
       WakelockPlus.enable().ignore();
@@ -189,11 +188,13 @@ class Aria extends HookConsumerWidget {
           }
 
           final currentLocale = LocaleSettings.currentLocale;
-          if (generalSettings.locale case final locale?
-              when locale != currentLocale) {
+          if (generalSettings.locale case final locale?) {
+            if (locale != currentLocale) {
+              await LocaleSettings.setLocale(locale);
+            }
+          } else if (AppLocaleUtils.instance.findDeviceLocale()
+              case final locale when locale != currentLocale) {
             await LocaleSettings.setLocale(locale);
-          } else if (AppLocaleUtils.findDeviceLocale() != currentLocale) {
-            await LocaleSettings.useDeviceLocale();
           }
 
           final channel = switch (notification) {

--- a/lib/view/page/settings/languages_page.dart
+++ b/lib/view/page/settings/languages_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../constant/max_content_width.dart';
+import '../../../extension/app_locale_utils_extension.dart';
 import '../../../i18n/strings.g.dart';
 import '../../../model/account.dart';
 import '../../../provider/general_settings_notifier_provider.dart';
@@ -28,11 +29,8 @@ class LanguagesPage extends ConsumerWidget {
           groupValue: locale,
           onChanged: (value) {
             ref.read(generalSettingsNotifierProvider.notifier).setLocale(value);
-            if (value == null) {
-              LocaleSettings.useDeviceLocale();
-            } else {
-              LocaleSettings.setLocale(value);
-            }
+            final locale = value ?? AppLocaleUtils.instance.findDeviceLocale();
+            LocaleSettings.setLocale(locale);
           },
           child: ListView(
             children: [


### PR DESCRIPTION
Fixed an issue where Simplified Chinese was displayed when the app language is "System", the system language is Traditional Chinese, and the country is not Taiwan.