### PR TITLE
fix: hide empty links in server overview

### DIFF
--- a/lib/view/page/login_page.dart
+++ b/lib/view/page/login_page.dart
@@ -125,11 +125,13 @@ class LoginPage extends HookConsumerWidget {
         .split('/')
         .first;
     final server = servers.firstWhereOrNull((server) => server.url == host);
-    final iconUrl =
-        server?.meta?['iconUrl'] as String? ??
-        (server != null && server.icon
-            ? 'https://instanceapp.misskey.page/instance-icons/${server.url}.webp'
-            : null);
+    final iconUrl = switch (server?.meta) {
+      {'iconUrl': final String iconUrl} when iconUrl.isNotEmpty => iconUrl,
+      _ when server != null && server.icon =>
+        'https://instanceapp.misskey.page/instance-icons/${server.url}.webp',
+      _ when server != null => 'https://${server.url}/favicon.ico',
+      _ => null,
+    };
     useEffect(() {
       controller.addListener(
         () =>

--- a/lib/view/page/server/server_overview.dart
+++ b/lib/view/page/server/server_overview.dart
@@ -20,6 +20,7 @@ import '../../widget/error_message.dart';
 import '../../widget/haptic_feedback_refresh_indicator.dart';
 import '../../widget/image_widget.dart';
 import '../../widget/key_value_widget.dart';
+import '../../widget/url_sheet.dart';
 
 class ServerOverview extends ConsumerWidget {
   const ServerOverview({super.key, required this.account, required this.host});
@@ -83,14 +84,23 @@ class ServerOverview extends ConsumerWidget {
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(8.0),
                         child: ImageWidget(
-                          url:
-                              (meta?.iconUrl ??
-                                      instance?.iconUrl ??
-                                      instance?.faviconUrl ??
-                                      serverUrl.replace(
-                                        pathSegments: ['favicon.ico'],
-                                      ))
+                          url: switch ((
+                            meta?.iconUrl,
+                            instance?.iconUrl,
+                            instance?.faviconUrl,
+                          )) {
+                            (final iconUrl?, _, _) when iconUrl.hasAuthority =>
+                              iconUrl.toString(),
+                            (_, final iconUrl?, _) when iconUrl.hasAuthority =>
+                              iconUrl.toString(),
+                            (_, _, final faviconUrl?)
+                                when faviconUrl.hasAuthority =>
+                              faviconUrl.toString(),
+                            _ =>
+                              serverUrl
+                                  .replace(pathSegments: ['favicon.ico'])
                                   .toString(),
+                          },
                           height: 64.0,
                           width: 64.0,
                         ),
@@ -159,19 +169,23 @@ class ServerOverview extends ConsumerWidget {
               title: Text(t.misskey.aboutMisskey),
               onTap: () => context.push('/about-misskey'),
             ),
-            if (meta.repositoryUrl != null || (meta.providesTarball ?? false))
+            if (meta.repositoryUrl ??
+                    ((meta.providesTarball ?? false)
+                        ? serverUrl.replace(
+                            pathSegments: [
+                              'tarball',
+                              'misskey-${meta.version}.tar.gz',
+                            ],
+                          )
+                        : null)
+                case final sourceCode?)
               ListTile(
                 leading: const Icon(Icons.code),
                 title: Text(t.misskey.sourceCode),
-                onTap: () => launchUrl(
-                  ref,
-                  meta.repositoryUrl ??
-                      serverUrl.replace(
-                        pathSegments: [
-                          'tarball',
-                          'misskey-${meta.version}.tar.gz',
-                        ],
-                      ),
+                onTap: () => launchUrl(ref, sourceCode),
+                onLongPress: () => showModalBottomSheet<void>(
+                  context: context,
+                  builder: (context) => UrlSheet(url: sourceCode.toString()),
                 ),
               ),
           ],
@@ -180,6 +194,7 @@ class ServerOverview extends ConsumerWidget {
             padding: const EdgeInsets.all(16.0),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 8.0,
               children: [
                 Expanded(
                   child: KeyValueWidget(
@@ -196,11 +211,16 @@ class ServerOverview extends ConsumerWidget {
               ],
             ),
           ),
-          if (meta case MetaResponse(:final impressumUrl?))
+          if (meta?.impressumUrl case final impressumUrl?
+              when impressumUrl.hasAuthority)
             ListTile(
               leading: const Icon(Icons.shield),
               title: Text(t.misskey.impressum),
               onTap: () => launchUrl(ref, impressumUrl),
+              onLongPress: () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => UrlSheet(url: impressumUrl.toString()),
+              ),
             ),
           if (meta != null && meta.serverRules.isNotEmpty)
             ExpansionTile(
@@ -242,23 +262,38 @@ class ServerOverview extends ConsumerWidget {
                   )
                   .toList(),
             ),
-          if (meta case MetaResponse(:final tosUrl?))
+          if (meta?.tosUrl case final tosUrl? when tosUrl.hasAuthority)
             ListTile(
               leading: const Icon(Icons.verified),
               title: Text(t.misskey.termsOfService),
               onTap: () => launchUrl(ref, tosUrl),
+              onLongPress: () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => UrlSheet(url: tosUrl.toString()),
+              ),
             ),
-          if (meta case MetaResponse(:final privacyPolicyUrl?))
+          if (meta?.privacyPolicyUrl case final privacyPolicyUrl?
+              when privacyPolicyUrl.hasAuthority)
             ListTile(
               leading: const Icon(Icons.policy),
               title: Text(t.misskey.privacyPolicy),
               onTap: () => launchUrl(ref, privacyPolicyUrl),
+              onLongPress: () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) =>
+                    UrlSheet(url: privacyPolicyUrl.toString()),
+              ),
             ),
-          if (meta case MetaResponse(:final feedbackUrl?))
+          if (meta?.feedbackUrl case final feedbackUrl?
+              when feedbackUrl.isNotEmpty)
             ListTile(
               leading: const Icon(Icons.message),
               title: Text(t.misskey.feedback),
               onTap: () => launchUrl(ref, Uri.parse(feedbackUrl)),
+              onLongPress: () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => UrlSheet(url: feedbackUrl),
+              ),
             ),
           if (stats != null) ...[
             const Divider(),
@@ -277,6 +312,7 @@ class ServerOverview extends ConsumerWidget {
               child: switch (stats) {
                 AsyncValue(value: final stats?) => Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 8.0,
                   children: [
                     Expanded(
                       child: KeyValueWidget(

--- a/lib/view/page/token_login_page.dart
+++ b/lib/view/page/token_login_page.dart
@@ -58,11 +58,13 @@ class TokenLoginPage extends HookConsumerWidget {
         .first;
     final queryFocusNode = useFocusNode();
     final server = servers.firstWhereOrNull((server) => server.url == host);
-    final iconUrl =
-        server?.meta?['iconUrl'] as String? ??
-        (server != null && server.icon
-            ? 'https://instanceapp.misskey.page/instance-icons/${server.url}.webp'
-            : null);
+    final iconUrl = switch (server?.meta) {
+      {'iconUrl': final String iconUrl} when iconUrl.isNotEmpty => iconUrl,
+      _ when server != null && server.icon =>
+        'https://instanceapp.misskey.page/instance-icons/${server.url}.webp',
+      _ when server != null => 'https://${server.url}/favicon.ico',
+      _ => null,
+    };
     final tokenController = useTextEditingController();
     final token = useState('');
     final tokenFocusNode = useFocusNode();

--- a/lib/view/widget/misskey_server_background.dart
+++ b/lib/view/widget/misskey_server_background.dart
@@ -49,7 +49,6 @@ class MisskeyServerBackground extends HookConsumerWidget {
     final opacityController = useAnimationController(
       duration: const Duration(seconds: 1),
     );
-    final opacity = useAnimation(opacityController);
     final backgroundImageUrl = useState<String?>(null);
     useEffect(() {
       Future<void> listener() async {
@@ -83,7 +82,10 @@ class MisskeyServerBackground extends HookConsumerWidget {
       children: [
         if (backgroundImageUrl case ValueNotifier(:final value?))
           Positioned.fill(
-            child: ImageWidget(url: value, fit: BoxFit.cover, opacity: opacity),
+            child: FadeTransition(
+              opacity: opacityController,
+              child: ImageWidget(url: value, fit: BoxFit.cover),
+            ),
           ),
         child,
       ],


### PR DESCRIPTION
Changed to hide buttons in the server overview if the corresponding url is empty.