### PR TITLE
fix: override creation time for note preview

### DIFF
--- a/lib/view/dialog/post_confirmation_dialog.dart
+++ b/lib/view/dialog/post_confirmation_dialog.dart
@@ -86,6 +86,7 @@ class PostConfirmationDialog extends ConsumerWidget {
     final canScheduleNote = i?.canScheduleNote ?? false;
     final note = draft
         .copyWith(
+          createdAt: DateTime.now(),
           userId: i?.id ?? draft.userId,
           user: i?.toUserLite() ?? draft.user,
           channel: channel,

--- a/lib/view/page/post_page.dart
+++ b/lib/view/page/post_page.dart
@@ -175,7 +175,9 @@ class PostPage extends HookConsumerWidget {
                               key: const ValueKey('note'),
                               account: account.value,
                               noteId: '',
-                              note: draft.toNote(),
+                              note: draft
+                                  .copyWith(createdAt: DateTime.now())
+                                  .toNote(),
                               showFooter: false,
                               expandLongNote: true,
                               borderRadius: BorderRadius.circular(8.0),


### PR DESCRIPTION
Changed to always show the current date in the note preview.