### PR TITLE
fix: cancel timer when disposed

### DIFF
--- a/lib/view/page/user/user_page.dart
+++ b/lib/view/page/user/user_page.dart
@@ -194,12 +194,15 @@ class _Confetti extends HookConsumerWidget {
           this.delay ??
           const Duration(seconds: 5) *
               min(Random().nextDouble(), Random().nextDouble());
-      Future.delayed(delay, () => controller.play());
-      Future.delayed(
+      final timer = Timer(delay, () => controller.play());
+      final longTimer = Timer(
         delay * 2 + const Duration(seconds: 1),
         () => controller.play(),
       );
-      return;
+      return () {
+        timer.cancel();
+        longTimer.cancel();
+      };
     }, []);
 
     return Align(

--- a/lib/view/widget/chat_message_widget.dart
+++ b/lib/view/widget/chat_message_widget.dart
@@ -513,7 +513,7 @@ class _EmojiWidgetWithEffect extends HookWidget {
     final isNewReaction = useRef(this.isNewReaction);
     useEffect(() {
       if (isNewReaction.value) {
-        Future.delayed(const Duration(milliseconds: 50), () {
+        final timer = Timer(const Duration(milliseconds: 50), () {
           if (!context.mounted) return;
           if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
           if (context.findRenderObject() case final RenderBox renderBox) {
@@ -537,8 +537,9 @@ class _EmojiWidgetWithEffect extends HookWidget {
           }
         });
         isNewReaction.value = false;
+        return timer.cancel;
       }
-      return;
+      return null;
     }, []);
 
     return EmojiWidget(

--- a/lib/view/widget/mfm/bounce.dart
+++ b/lib/view/widget/mfm/bounce.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:vector_math/vector_math.dart';
@@ -48,8 +50,8 @@ class Bounce extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final offset = useAnimation(_offsetTween.animate(controller));
     final scale = useAnimation(_scaleTween.animate(controller));

--- a/lib/view/widget/mfm/jelly.dart
+++ b/lib/view/widget/mfm/jelly.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:vector_math/vector_math.dart';
@@ -54,8 +56,8 @@ class Jelly extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final scale = useAnimation(_scaleTween.animate(controller));
 

--- a/lib/view/widget/mfm/jump.dart
+++ b/lib/view/widget/mfm/jump.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
@@ -42,8 +44,8 @@ class Jump extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final offset = useAnimation(_offsetTween.animate(controller));
 

--- a/lib/view/widget/mfm/rainbow.dart
+++ b/lib/view/widget/mfm/rainbow.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:colorfilter_generator/addons.dart';
 import 'package:colorfilter_generator/colorfilter_generator.dart';
 import 'package:flutter/material.dart';
@@ -25,8 +27,8 @@ class Rainbow extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final hue = useAnimation(Tween(begin: 0.0, end: 2.0).animate(controller));
 

--- a/lib/view/widget/mfm/shake.dart
+++ b/lib/view/widget/mfm/shake.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -305,8 +306,8 @@ class Shake extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final offset = useAnimation(_offsetTween.animate(controller));
     final angle = useAnimation(_angleTween.animate(controller));

--- a/lib/view/widget/mfm/spin.dart
+++ b/lib/view/widget/mfm/spin.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -32,11 +33,11 @@ class Spin extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(
+      final timer = Timer(
         delay,
         () => controller.repeat(reverse: direction == _SpinDirection.alternate),
       );
-      return;
+      return timer.cancel;
     }, [speed, delay]);
     final angle = useAnimation(
       Tween(

--- a/lib/view/widget/mfm/tada.dart
+++ b/lib/view/widget/mfm/tada.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -74,8 +75,8 @@ class Tada extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final scale = useAnimation(_scaleTween.animate(controller));
     final angle = useAnimation(_angleTween.animate(controller));

--- a/lib/view/widget/mfm/twitch.dart
+++ b/lib/view/widget/mfm/twitch.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
@@ -166,8 +168,8 @@ class Twitch extends HookWidget {
       if (delay.isNegative) {
         controller.forward(from: -delay.inMilliseconds / speed.inMilliseconds);
       }
-      Future.delayed(delay, () => controller.repeat());
-      return;
+      final timer = Timer(delay, () => controller.repeat());
+      return timer.cancel;
     }, [speed, delay]);
     final offset = useAnimation(_offsetTween.animate(controller));
 

--- a/lib/view/widget/reaction_button.dart
+++ b/lib/view/widget/reaction_button.dart
@@ -260,7 +260,7 @@ class _EmojiWidgetWithEffect extends HookWidget {
     final previousCount = useRef(count);
     useEffect(() {
       if (count > previousCount.value || forceShowEffect.value) {
-        Future.delayed(const Duration(milliseconds: 50), () {
+        final timer = Timer(const Duration(milliseconds: 50), () {
           if (!context.mounted) return;
           if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
           if (context.findRenderObject() case final RenderBox renderBox) {
@@ -284,10 +284,13 @@ class _EmojiWidgetWithEffect extends HookWidget {
             Future.delayed(const Duration(milliseconds: 1100), entry.remove);
           }
         });
+        previousCount.value = count;
+        forceShowEffect.value = false;
+        return timer.cancel;
       }
       previousCount.value = count;
       forceShowEffect.value = false;
-      return;
+      return null;
     }, [count]);
 
     return EmojiWidget(


### PR DESCRIPTION
Replaced `Future.delayed` with `Timer` to prevent the callback from being called after the widget is disposed.