### PR TITLE
refactor: remove non-null assertions in pagination

### DIFF
--- a/lib/provider/api/announcements_notifier_provider.dart
+++ b/lib/provider/api/announcements_notifier_provider.dart
@@ -40,18 +40,18 @@ class AnnouncementsNotifier extends _$AnnouncementsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchAnnouncements(
-        untilId: value.items.lastOrNull?.id,
-        offset: value.items.length,
+        untilId: value?.items.lastOrNull?.id,
+        offset: value?.items.length,
       );
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/announcements_notifier_provider.g.dart
+++ b/lib/provider/api/announcements_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class AnnouncementsNotifierProvider
 }
 
 String _$announcementsNotifierHash() =>
-    r'c832a2bf4f15158981987084a305c4f905c2403d';
+    r'9248860322e2b1ee7b8539a746088e007dcb583a';
 
 final class AnnouncementsNotifierFamily extends $Family
     with

--- a/lib/provider/api/attached_notes_notifier_provider.dart
+++ b/lib/provider/api/attached_notes_notifier_provider.dart
@@ -39,17 +39,17 @@ class AttachedNotesNotifier extends _$AttachedNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/attached_notes_notifier_provider.g.dart
+++ b/lib/provider/api/attached_notes_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class AttachedNotesNotifierProvider
 }
 
 String _$attachedNotesNotifierHash() =>
-    r'0c8d766cd0a5fc3ef4165149b9b50d2d1ce0ff88';
+    r'b9f5670814d51b60fe50e1a26bae3dd194c96d65';
 
 final class AttachedNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/blockings_notifier_provider.dart
+++ b/lib/provider/api/blockings_notifier_provider.dart
@@ -35,19 +35,19 @@ class BlockingsNotifier extends _$BlockingsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchBlockings(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/blockings_notifier_provider.g.dart
+++ b/lib/provider/api/blockings_notifier_provider.g.dart
@@ -51,7 +51,7 @@ final class BlockingsNotifierProvider
   }
 }
 
-String _$blockingsNotifierHash() => r'eada842e68beb95cad93a758d9b05e7b29349cef';
+String _$blockingsNotifierHash() => r'30a0ddcdccdee724bf25679c945f27644a284387';
 
 final class BlockingsNotifierFamily extends $Family
     with

--- a/lib/provider/api/chat_invitations_notifier_provider.dart
+++ b/lib/provider/api/chat_invitations_notifier_provider.dart
@@ -37,19 +37,19 @@ class ChatInvitationsNotifier extends _$ChatInvitationsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchInvitations(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/chat_invitations_notifier_provider.g.dart
+++ b/lib/provider/api/chat_invitations_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class ChatInvitationsNotifierProvider
 }
 
 String _$chatInvitationsNotifierHash() =>
-    r'a4f25b360791879dd02365fe9fa1e288a1af6994';
+    r'0443a6a60ca9dc1de43ac5715034025837ef4734';
 
 final class ChatInvitationsNotifierFamily extends $Family
     with

--- a/lib/provider/api/chat_memberships_notifier_provider.dart
+++ b/lib/provider/api/chat_memberships_notifier_provider.dart
@@ -37,19 +37,19 @@ class ChatMembershipsNotifier extends _$ChatMembershipsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchMemberships(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/chat_memberships_notifier_provider.g.dart
+++ b/lib/provider/api/chat_memberships_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class ChatMembershipsNotifierProvider
 }
 
 String _$chatMembershipsNotifierHash() =>
-    r'8810581a3f17f6171cf844b2fa2d592b307f7543';
+    r'c2197d2e90feb464261d2cb75e8a6e2d974ae130';
 
 final class ChatMembershipsNotifierFamily extends $Family
     with

--- a/lib/provider/api/chat_messages_notifier_provider.dart
+++ b/lib/provider/api/chat_messages_notifier_provider.dart
@@ -55,19 +55,19 @@ class ChatMessagesNotifier extends _$ChatMessagesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchMessages(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/chat_messages_notifier_provider.g.dart
+++ b/lib/provider/api/chat_messages_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class ChatMessagesNotifierProvider
 }
 
 String _$chatMessagesNotifierHash() =>
-    r'964b7f41e18ce6ad7ba8e26a8b9c524714ecae96';
+    r'ed48b77d9a7a671c81229efacb7001200e131d03';
 
 final class ChatMessagesNotifierFamily extends $Family
     with

--- a/lib/provider/api/chat_room_invitations_notifier_provider.dart
+++ b/lib/provider/api/chat_room_invitations_notifier_provider.dart
@@ -44,19 +44,19 @@ class ChatRoomInvitationsNotifier extends _$ChatRoomInvitationsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchInvitations(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/chat_room_invitations_notifier_provider.g.dart
+++ b/lib/provider/api/chat_room_invitations_notifier_provider.g.dart
@@ -57,7 +57,7 @@ final class ChatRoomInvitationsNotifierProvider
 }
 
 String _$chatRoomInvitationsNotifierHash() =>
-    r'a0ae4c31a559478bcec07ac19b6c2605a350527e';
+    r'033fb67da287f795e8980865effced8c38364909';
 
 final class ChatRoomInvitationsNotifierFamily extends $Family
     with

--- a/lib/provider/api/chat_room_members_notifier_provider.dart
+++ b/lib/provider/api/chat_room_members_notifier_provider.dart
@@ -42,19 +42,19 @@ class ChatRoomMembersNotifier extends _$ChatRoomMembersNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchMemberships(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/chat_room_members_notifier_provider.g.dart
+++ b/lib/provider/api/chat_room_members_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class ChatRoomMembersNotifierProvider
 }
 
 String _$chatRoomMembersNotifierHash() =>
-    r'4220ee6b811c83e17f2b31b0f17948701251af52';
+    r'3ab5e192a014deb3928777f7ac0ced25d51c5fb9';
 
 final class ChatRoomMembersNotifierFamily extends $Family
     with

--- a/lib/provider/api/children_notes_notifier_provider.dart
+++ b/lib/provider/api/children_notes_notifier_provider.dart
@@ -38,17 +38,17 @@ class ChildrenNotesNotifier extends _$ChildrenNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/children_notes_notifier_provider.g.dart
+++ b/lib/provider/api/children_notes_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class ChildrenNotesNotifierProvider
 }
 
 String _$childrenNotesNotifierHash() =>
-    r'a7b8772227ffef5c4b28b3609b45ec1c726b4ec3';
+    r'0edc382791636b8066d877c1a9c66096d3ca4fdd';
 
 final class ChildrenNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/clip_notes_notifier_provider.dart
+++ b/lib/provider/api/clip_notes_notifier_provider.dart
@@ -36,17 +36,17 @@ class ClipNotesNotifier extends _$ClipNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/clip_notes_notifier_provider.g.dart
+++ b/lib/provider/api/clip_notes_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class ClipNotesNotifierProvider
   }
 }
 
-String _$clipNotesNotifierHash() => r'30f5bdc1f6a0b1de87ba3ebfa919d1de329f6dbf';
+String _$clipNotesNotifierHash() => r'e9b048e518b3149090f1a321916a798e982916cd';
 
 final class ClipNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/clips_notifier_provider.dart
+++ b/lib/provider/api/clips_notifier_provider.dart
@@ -58,17 +58,17 @@ class ClipsNotifier extends _$ClipsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchClips(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchClips(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/clips_notifier_provider.g.dart
+++ b/lib/provider/api/clips_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class ClipsNotifierProvider
   }
 }
 
-String _$clipsNotifierHash() => r'f52864d1b6ada7abeb5f25b42f6ce93059bf5c08';
+String _$clipsNotifierHash() => r'd55044bed0bfeadd5ab69fd24b276df06f63559f';
 
 final class ClipsNotifierFamily extends $Family
     with

--- a/lib/provider/api/drive_files_notifier_provider.dart
+++ b/lib/provider/api/drive_files_notifier_provider.dart
@@ -55,17 +55,17 @@ class DriveFilesNotifier extends _$DriveFilesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchFiles(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchFiles(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/drive_files_notifier_provider.g.dart
+++ b/lib/provider/api/drive_files_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class DriveFilesNotifierProvider
 }
 
 String _$driveFilesNotifierHash() =>
-    r'7c38accc8a2318a73f5103804b6543e012d4b202';
+    r'd400a30e1a1eb75ec2b581fb6bbfa17d5dfa1136';
 
 final class DriveFilesNotifierFamily extends $Family
     with

--- a/lib/provider/api/drive_folders_notifier_provider.dart
+++ b/lib/provider/api/drive_folders_notifier_provider.dart
@@ -51,17 +51,19 @@ class DriveFoldersNotifier extends _$DriveFoldersNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchFolders(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchFolders(
+        untilId: value?.items.lastOrNull?.id,
+      );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/drive_folders_notifier_provider.g.dart
+++ b/lib/provider/api/drive_folders_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class DriveFoldersNotifierProvider
 }
 
 String _$driveFoldersNotifierHash() =>
-    r'13b29c450726dca832f1c95f1ab3afc5b52cf934';
+    r'748f6f59badfee28fc4dbad2f54b6bc85c096369';
 
 final class DriveFoldersNotifierFamily extends $Family
     with

--- a/lib/provider/api/favorites_notifier_provider.dart
+++ b/lib/provider/api/favorites_notifier_provider.dart
@@ -40,19 +40,19 @@ class FavoritesNotifier extends _$FavoritesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchFavorites(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/favorites_notifier_provider.g.dart
+++ b/lib/provider/api/favorites_notifier_provider.g.dart
@@ -54,7 +54,7 @@ final class FavoritesNotifierProvider
   }
 }
 
-String _$favoritesNotifierHash() => r'1bfdc86f43e7b6d453689086cce38614ec318a87';
+String _$favoritesNotifierHash() => r'9c59ccb245d0d77036303f57fb2c086aa1482b79';
 
 final class FavoritesNotifierFamily extends $Family
     with

--- a/lib/provider/api/featured_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/featured_gallery_posts_notifier_provider.dart
@@ -47,17 +47,17 @@ class FeaturedGalleryPostsNotifier extends _$FeaturedGalleryPostsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPosts(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPosts(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/featured_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/featured_gallery_posts_notifier_provider.g.dart
@@ -57,7 +57,7 @@ final class FeaturedGalleryPostsNotifierProvider
 }
 
 String _$featuredGalleryPostsNotifierHash() =>
-    r'89f504bdc619eaef3b7e203a1327af571dc629fc';
+    r'012cefbab7f28b39898a8577a3146f6caaacdce1';
 
 final class FeaturedGalleryPostsNotifierFamily extends $Family
     with

--- a/lib/provider/api/featured_notes_notifier_provider.dart
+++ b/lib/provider/api/featured_notes_notifier_provider.dart
@@ -39,17 +39,17 @@ class FeaturedNotesNotifier extends _$FeaturedNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/featured_notes_notifier_provider.g.dart
+++ b/lib/provider/api/featured_notes_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class FeaturedNotesNotifierProvider
 }
 
 String _$featuredNotesNotifierHash() =>
-    r'48686a73dcd0b50daba59c479cef79d5c8ec00fb';
+    r'7dcbd2fc298cfc6a0eaa2de2494bcb0c4ecd6b7b';
 
 final class FeaturedNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/featured_plays_notifier_provider.dart
+++ b/lib/provider/api/featured_plays_notifier_provider.dart
@@ -29,20 +29,21 @@ class FeaturedPlaysNotifier extends _$FeaturedPlaysNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPlays(offset: value.items.length);
-      if (response.any((play) => play.id == value.items.firstOrNull?.id)) {
+      final response = await _fetchPlays(offset: value?.items.length);
+      if (value != null &&
+          response.any((play) => play.id == value.items.firstOrNull?.id)) {
         // Pagination for `flash/featured` was not supported
         // until Misskey 2024.10.0.
         return value.copyWith(isLastLoaded: true);
       } else {
         return PaginationState(
-          items: [...value.items, ...response],
+          items: [...?value?.items, ...response],
           isLastLoaded: response.isEmpty,
         );
       }

--- a/lib/provider/api/featured_plays_notifier_provider.g.dart
+++ b/lib/provider/api/featured_plays_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class FeaturedPlaysNotifierProvider
 }
 
 String _$featuredPlaysNotifierHash() =>
-    r'2be58faa0a3ca73d9c094d87882f13b0cdefdac2';
+    r'2849b17814a22fa0e732d790e3e160e6c10695ef';
 
 final class FeaturedPlaysNotifierFamily extends $Family
     with

--- a/lib/provider/api/featured_polls_notifier_provider.dart
+++ b/lib/provider/api/featured_polls_notifier_provider.dart
@@ -36,15 +36,15 @@ class FeaturedPollsNotifier extends _$FeaturedPollsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(offset: value.items.length);
+      final response = await _fetchNotes(offset: value?.items.length);
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/featured_polls_notifier_provider.g.dart
+++ b/lib/provider/api/featured_polls_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class FeaturedPollsNotifierProvider
 }
 
 String _$featuredPollsNotifierHash() =>
-    r'5b1a4b5a43904f7634b471bf90319c2f927afaed';
+    r'126aa47ca5e66debb9e0518ce80defcc1eba0a2e';
 
 final class FeaturedPollsNotifierFamily extends $Family
     with

--- a/lib/provider/api/follow_requests_notifier_provider.dart
+++ b/lib/provider/api/follow_requests_notifier_provider.dart
@@ -35,19 +35,19 @@ class FollowRequestsNotifier extends _$FollowRequestsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchRequests(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/follow_requests_notifier_provider.g.dart
+++ b/lib/provider/api/follow_requests_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class FollowRequestsNotifierProvider
 }
 
 String _$followRequestsNotifierHash() =>
-    r'50f7f4ed6ac46a899e263608bbfca6286ef42232';
+    r'31430fac305bf2398476819c58530231079e41ed';
 
 final class FollowRequestsNotifierFamily extends $Family
     with

--- a/lib/provider/api/following_channels_notifier_provider.dart
+++ b/lib/provider/api/following_channels_notifier_provider.dart
@@ -34,19 +34,19 @@ class FollowingChannelsNotifier extends _$FollowingChannelsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchChannels(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/following_channels_notifier_provider.g.dart
+++ b/lib/provider/api/following_channels_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class FollowingChannelsNotifierProvider
 }
 
 String _$followingChannelsNotifierHash() =>
-    r'c88a531402bb859e0d9eebf98f25a57ff45f17fc';
+    r'a20b0536303ca920b2d80e5a62c877d5973a6aba';
 
 final class FollowingChannelsNotifierFamily extends $Family
     with

--- a/lib/provider/api/gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/gallery_posts_notifier_provider.dart
@@ -48,17 +48,17 @@ class GalleryPostsNotifier extends _$GalleryPostsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPosts(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPosts(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/gallery_posts_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class GalleryPostsNotifierProvider
 }
 
 String _$galleryPostsNotifierHash() =>
-    r'408fa72e668bda56a2a820c8fa6a7a3fd64061ec';
+    r'41cd7755e768b1a44ce1b03b0a9a3634790b52e3';
 
 final class GalleryPostsNotifierFamily extends $Family
     with

--- a/lib/provider/api/liked_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/liked_gallery_posts_notifier_provider.dart
@@ -48,17 +48,17 @@ class LikedGalleryPostsNotifier extends _$LikedGalleryPostsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPosts(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPosts(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/liked_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/liked_gallery_posts_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class LikedGalleryPostsNotifierProvider
 }
 
 String _$likedGalleryPostsNotifierHash() =>
-    r'5eb19e2815f88ae1f236b80cf2d68d732f934f67';
+    r'6e40d799c83c228a5b31b81273edd16bf4ecb999';
 
 final class LikedGalleryPostsNotifierFamily extends $Family
     with

--- a/lib/provider/api/liked_pages_notifier_provider.dart
+++ b/lib/provider/api/liked_pages_notifier_provider.dart
@@ -34,17 +34,17 @@ class LikedPagesNotifier extends _$LikedPagesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPages(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPages(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/liked_pages_notifier_provider.g.dart
+++ b/lib/provider/api/liked_pages_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class LikedPagesNotifierProvider
 }
 
 String _$likedPagesNotifierHash() =>
-    r'd2141ec1e5e2791912a38c33c70638e4043caff1';
+    r'f50eefc4d426854be30ef38e775d1c8de4f86fa0';
 
 final class LikedPagesNotifierFamily extends $Family
     with

--- a/lib/provider/api/liked_plays_notifier_provider.dart
+++ b/lib/provider/api/liked_plays_notifier_provider.dart
@@ -34,17 +34,17 @@ class LikedPlaysNotifier extends _$LikedPlaysNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPlays(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPlays(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/liked_plays_notifier_provider.g.dart
+++ b/lib/provider/api/liked_plays_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class LikedPlaysNotifierProvider
 }
 
 String _$likedPlaysNotifierHash() =>
-    r'eb38fa8f4da77685b3e4e8bd58bcd24394a6b606';
+    r'f89f249bec3147017592896694b90b7194eb81a5';
 
 final class LikedPlaysNotifierFamily extends $Family
     with

--- a/lib/provider/api/mutings_notifier_provider.dart
+++ b/lib/provider/api/mutings_notifier_provider.dart
@@ -33,17 +33,19 @@ class MutingsNotifier extends _$MutingsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchMutings(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchMutings(
+        untilId: value?.items.lastOrNull?.id,
+      );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/mutings_notifier_provider.g.dart
+++ b/lib/provider/api/mutings_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class MutingsNotifierProvider
   }
 }
 
-String _$mutingsNotifierHash() => r'd8c89c831def0bb241b86c533a0d51e99323545b';
+String _$mutingsNotifierHash() => r'a32c49ef4b0abc752f6577f78229ad2ecca5e564';
 
 final class MutingsNotifierFamily extends $Family
     with

--- a/lib/provider/api/my_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/my_gallery_posts_notifier_provider.dart
@@ -48,17 +48,17 @@ class MyGalleryPostsNotifier extends _$MyGalleryPostsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPosts(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPosts(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/my_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/my_gallery_posts_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class MyGalleryPostsNotifierProvider
 }
 
 String _$myGalleryPostsNotifierHash() =>
-    r'0766543bc2ef465e56d9fcc0323f84560f1cf172';
+    r'0a6251ce39518db2154a2a8d327bb157e686a060';
 
 final class MyGalleryPostsNotifierFamily extends $Family
     with

--- a/lib/provider/api/note_drafts_notifier_provider.dart
+++ b/lib/provider/api/note_drafts_notifier_provider.dart
@@ -39,17 +39,17 @@ class NoteDraftsNotifier extends _$NoteDraftsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchDrafts(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchDrafts(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/note_drafts_notifier_provider.g.dart
+++ b/lib/provider/api/note_drafts_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class NoteDraftsNotifierProvider
 }
 
 String _$noteDraftsNotifierHash() =>
-    r'e21985733d8c8717e60d3d71ddaf184367e0ecc6';
+    r'c906225065a92f0977ef0c3ce2b1bb5e1a1c5dce';
 
 final class NoteDraftsNotifierFamily extends $Family
     with

--- a/lib/provider/api/notes_after_renotes_notifier_provider.dart
+++ b/lib/provider/api/notes_after_renotes_notifier_provider.dart
@@ -71,8 +71,8 @@ class NotesAfterRenotesNotifier extends _$NotesAfterRenotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
@@ -82,7 +82,7 @@ class NotesAfterRenotesNotifier extends _$NotesAfterRenotesNotifier {
       final notes = await Future.wait(renotes.map(_fetchNote));
       shouldLoadMore = renotes.isNotEmpty && renotes.length < 5;
       return PaginationState(
-        items: [...value.items, ...notes.nonNulls],
+        items: [...?value?.items, ...notes.nonNulls],
         isLastLoaded: renotes.isEmpty,
       );
     });

--- a/lib/provider/api/notes_after_renotes_notifier_provider.g.dart
+++ b/lib/provider/api/notes_after_renotes_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class NotesAfterRenotesNotifierProvider
 }
 
 String _$notesAfterRenotesNotifierHash() =>
-    r'17875804fac29faf372abe0b5e6147ca2ee19d14';
+    r'3c1104fa5b47bf395e49e0e62f71135aac8783d8';
 
 final class NotesAfterRenotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/notifications_notifier_provider.dart
+++ b/lib/provider/api/notifications_notifier_provider.dart
@@ -175,19 +175,19 @@ class NotificationsNotifier extends _$NotificationsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchNotifications(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/notifications_notifier_provider.g.dart
+++ b/lib/provider/api/notifications_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class NotificationsNotifierProvider
 }
 
 String _$notificationsNotifierHash() =>
-    r'0a84a6525ab2490d109d5019eafe5d081b264f90';
+    r'f9e45212ad6cb26eced89d9f60d8e124b4bbd093';
 
 final class NotificationsNotifierFamily extends $Family
     with

--- a/lib/provider/api/owned_channels_notifier_provider.dart
+++ b/lib/provider/api/owned_channels_notifier_provider.dart
@@ -34,19 +34,19 @@ class OwnedChannelsNotifier extends _$OwnedChannelsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchChannels(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/owned_channels_notifier_provider.g.dart
+++ b/lib/provider/api/owned_channels_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class OwnedChannelsNotifierProvider
 }
 
 String _$ownedChannelsNotifierHash() =>
-    r'eadda957788c207c4572647f59f6a7eeac61e802';
+    r'90408dbcc902117d3888464a42115ad92feaa4e5';
 
 final class OwnedChannelsNotifierFamily extends $Family
     with

--- a/lib/provider/api/owned_chat_rooms_notifier_provider.dart
+++ b/lib/provider/api/owned_chat_rooms_notifier_provider.dart
@@ -35,17 +35,17 @@ class OwnedChatRoomsNotifier extends _$OwnedChatRoomsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchRooms(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchRooms(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/owned_chat_rooms_notifier_provider.g.dart
+++ b/lib/provider/api/owned_chat_rooms_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class OwnedChatRoomsNotifierProvider
 }
 
 String _$ownedChatRoomsNotifierHash() =>
-    r'a8fb559689e9710348dfab294b4824b3f31af599';
+    r'c05494b4ad64ae9551f250f339845663de57612b';
 
 final class OwnedChatRoomsNotifierFamily extends $Family
     with

--- a/lib/provider/api/pages_notifier_provider.dart
+++ b/lib/provider/api/pages_notifier_provider.dart
@@ -34,17 +34,17 @@ class PagesNotifier extends _$PagesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPages(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPages(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/pages_notifier_provider.g.dart
+++ b/lib/provider/api/pages_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class PagesNotifierProvider
   }
 }
 
-String _$pagesNotifierHash() => r'6cccdb20cad731159939d0c23e0382618314846f';
+String _$pagesNotifierHash() => r'b43ddd213c29cb94ff3d2514dac4916f1f5cfea4';
 
 final class PagesNotifierFamily extends $Family
     with

--- a/lib/provider/api/plays_notifier_provider.dart
+++ b/lib/provider/api/plays_notifier_provider.dart
@@ -34,17 +34,17 @@ class PlaysNotifier extends _$PlaysNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPlays(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPlays(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/plays_notifier_provider.g.dart
+++ b/lib/provider/api/plays_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class PlaysNotifierProvider
   }
 }
 
-String _$playsNotifierHash() => r'bb015d7dc17afd5f127455002dada719d92ad200';
+String _$playsNotifierHash() => r'979d9ecfee88a67e44d407ca41f999237f2edc62';
 
 final class PlaysNotifierFamily extends $Family
     with

--- a/lib/provider/api/reactions_notifier_provider.dart
+++ b/lib/provider/api/reactions_notifier_provider.dart
@@ -48,19 +48,19 @@ class ReactionsNotifier extends _$ReactionsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchReactions(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/reactions_notifier_provider.g.dart
+++ b/lib/provider/api/reactions_notifier_provider.g.dart
@@ -54,7 +54,7 @@ final class ReactionsNotifierProvider
   }
 }
 
-String _$reactionsNotifierHash() => r'2e66fa3e42c1d5edad63a7f184bea39025783b78';
+String _$reactionsNotifierHash() => r'd67c3ba9305b7967d90dbc375909935ba854108c';
 
 final class ReactionsNotifierFamily extends $Family
     with

--- a/lib/provider/api/renote_mutings_notifier_provider.dart
+++ b/lib/provider/api/renote_mutings_notifier_provider.dart
@@ -38,19 +38,19 @@ class RenoteMutingsNotifier extends _$RenoteMutingsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchRenoteMutings(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/renote_mutings_notifier_provider.g.dart
+++ b/lib/provider/api/renote_mutings_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class RenoteMutingsNotifierProvider
 }
 
 String _$renoteMutingsNotifierHash() =>
-    r'1a4f49024f4e8f5d427d87719883fb2b6f2a0ec0';
+    r'306c3bc7be165d51f539e215c0cbee9e44973b03';
 
 final class RenoteMutingsNotifierFamily extends $Family
     with

--- a/lib/provider/api/renotes_notifier_provider.dart
+++ b/lib/provider/api/renotes_notifier_provider.dart
@@ -40,17 +40,17 @@ class RenotesNotifier extends _$RenotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/renotes_notifier_provider.g.dart
+++ b/lib/provider/api/renotes_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class RenotesNotifierProvider
   }
 }
 
-String _$renotesNotifierHash() => r'2015a651de24f4a2da5cc75986f37d4bac0c3997';
+String _$renotesNotifierHash() => r'e6a50187df02ecaef010200d1cfd4d5390eeee65';
 
 final class RenotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/role_users_notifier_provider.dart
+++ b/lib/provider/api/role_users_notifier_provider.dart
@@ -37,17 +37,17 @@ class RoleUsersNotifier extends _$RoleUsersNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchUsers(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchUsers(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/role_users_notifier_provider.g.dart
+++ b/lib/provider/api/role_users_notifier_provider.g.dart
@@ -54,7 +54,7 @@ final class RoleUsersNotifierProvider
   }
 }
 
-String _$roleUsersNotifierHash() => r'22616a56e85834765b55410a38565e98dd768368';
+String _$roleUsersNotifierHash() => r'7ead95e97e6bc355dcadfab07fd2a744b8122d6d';
 
 final class RoleUsersNotifierFamily extends $Family
     with

--- a/lib/provider/api/scheduled_notes_notifier_provider.dart
+++ b/lib/provider/api/scheduled_notes_notifier_provider.dart
@@ -141,18 +141,18 @@ class ScheduledNotesNotifier extends _$ScheduledNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchDrafts(
-        untilId: value.items.lastOrNull?.id,
-        offset: value.items.length,
+        untilId: value?.items.lastOrNull?.id,
+        offset: value?.items.length,
       );
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/scheduled_notes_notifier_provider.g.dart
+++ b/lib/provider/api/scheduled_notes_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class ScheduledNotesNotifierProvider
 }
 
 String _$scheduledNotesNotifierHash() =>
-    r'e7827f7c94e65e2501a66df259cc41eb679bccb9';
+    r'4d637c35589b932c478a8e8fe8961275561e8e83';
 
 final class ScheduledNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/search_channels_notifier_provider.dart
+++ b/lib/provider/api/search_channels_notifier_provider.dart
@@ -46,19 +46,19 @@ class SearchChannelsNotifier extends _$SearchChannelsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchChannels(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/search_channels_notifier_provider.g.dart
+++ b/lib/provider/api/search_channels_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class SearchChannelsNotifierProvider
 }
 
 String _$searchChannelsNotifierHash() =>
-    r'58c97152232e15d73b7495ee90b7663e8c685afb';
+    r'd5db1707e8af7dcfb8e7f7c65e28d167e71dc70e';
 
 final class SearchChannelsNotifierFamily extends $Family
     with

--- a/lib/provider/api/search_notes_notifier_provider.dart
+++ b/lib/provider/api/search_notes_notifier_provider.dart
@@ -66,17 +66,17 @@ class SearchNotesNotifier extends _$SearchNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/search_notes_notifier_provider.g.dart
+++ b/lib/provider/api/search_notes_notifier_provider.g.dart
@@ -61,7 +61,7 @@ final class SearchNotesNotifierProvider
 }
 
 String _$searchNotesNotifierHash() =>
-    r'02f553cddb209095727514a347669ee623a00ea5';
+    r'f0814a3b239da44937b72c47f81048086eeee4cc';
 
 final class SearchNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/search_plays_notifier_provider.dart
+++ b/lib/provider/api/search_plays_notifier_provider.dart
@@ -42,17 +42,17 @@ class SearchPlaysNotifier extends _$SearchPlaysNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPlays(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPlays(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/search_plays_notifier_provider.g.dart
+++ b/lib/provider/api/search_plays_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class SearchPlaysNotifierProvider
 }
 
 String _$searchPlaysNotifierHash() =>
-    r'c8b5cc6131718a6c07fe25e7e15807db211b4aee';
+    r'beb98dd2140c77bce316fea3bb1df4f441032fb1';
 
 final class SearchPlaysNotifierFamily extends $Family
     with

--- a/lib/provider/api/search_users_notifier_provider.dart
+++ b/lib/provider/api/search_users_notifier_provider.dart
@@ -56,16 +56,19 @@ class SearchUsersNotifier extends _$SearchUsersNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchUsers(offset: value.items.length);
+      final response = await _fetchUsers(offset: value?.items.length);
       return PaginationState(
         items: Map.fromEntries(
-          [...value.items, ...response].map((user) => MapEntry(user.id, user)),
+          [
+            ...?value?.items,
+            ...response,
+          ].map((user) => MapEntry(user.id, user)),
         ).values.toList(),
         isLastLoaded: response.isEmpty,
       );

--- a/lib/provider/api/search_users_notifier_provider.g.dart
+++ b/lib/provider/api/search_users_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class SearchUsersNotifierProvider
 }
 
 String _$searchUsersNotifierHash() =>
-    r'0189374919488391d778aabf120ae5fd83f598aa';
+    r'4fa843c6c3d7b27d6e114b9c0a320e0a251fa6dd';
 
 final class SearchUsersNotifierFamily extends $Family
     with

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
@@ -219,24 +219,25 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      if (value.items.firstOrNull?.id ?? sinceId case final sinceId?) {
+      if (value?.items.firstOrNull?.id ?? sinceId case final sinceId?) {
         final response = tabSettings.keepPosition
             ? await _fetchNotes(sinceId: sinceId)
             : await _fetchNotesEagerly(sinceId);
         shouldLoadMore = response.isNotEmpty && response.length < 5;
         return PaginationState(
-          items: [...response, ...value.items],
+          items: [...response, ...?value?.items],
           isLastLoaded: response.isEmpty,
         );
       } else {
-        return value.copyWith(isLastLoaded: true);
+        return value?.copyWith(isLastLoaded: true) ??
+            const PaginationState(isLastLoaded: true);
       }
     });
     if (shouldLoadMore) {

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
@@ -57,7 +57,7 @@ final class TimelineNotesAfterNoteNotifierProvider
 }
 
 String _$timelineNotesAfterNoteNotifierHash() =>
-    r'9ca73a8a2cc2c222f7a243603901626ed430f5be';
+    r'72603189a968769dda30b7c8898dd3088a5ebee8';
 
 final class TimelineNotesAfterNoteNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_clips_notifier_provider.dart
+++ b/lib/provider/api/user_clips_notifier_provider.dart
@@ -47,17 +47,17 @@ class UserClipsNotifier extends _$UserClipsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchClips(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchClips(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_clips_notifier_provider.g.dart
+++ b/lib/provider/api/user_clips_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class UserClipsNotifierProvider
   }
 }
 
-String _$userClipsNotifierHash() => r'acc98ccdcb5063831892d50dff6e6b92144d5eb4';
+String _$userClipsNotifierHash() => r'60d25eb4ab0f6d8c7a07929721e6b710db315326';
 
 final class UserClipsNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_featured_notes_notifier_provider.dart
+++ b/lib/provider/api/user_featured_notes_notifier_provider.dart
@@ -38,17 +38,17 @@ class UserFeaturedNotesNotifier extends _$UserFeaturedNotesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchNotes(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_featured_notes_notifier_provider.g.dart
+++ b/lib/provider/api/user_featured_notes_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class UserFeaturedNotesNotifierProvider
 }
 
 String _$userFeaturedNotesNotifierHash() =>
-    r'90a3b032be56662ceb85615ecfb9273944822d09';
+    r'da069603f0cc37f447b52c7aa2d0c801f8e1d708';
 
 final class UserFeaturedNotesNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_followers_notifier_provider.dart
+++ b/lib/provider/api/user_followers_notifier_provider.dart
@@ -37,19 +37,19 @@ class UserFollowersNotifier extends _$UserFollowersNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchFollowers(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_followers_notifier_provider.g.dart
+++ b/lib/provider/api/user_followers_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class UserFollowersNotifierProvider
 }
 
 String _$userFollowersNotifierHash() =>
-    r'77b51c21ae542161c58df737fbd378e071bd84c2';
+    r'e8fd3f07f5a94d4939279c9f9d14e43dd0697903';
 
 final class UserFollowersNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_following_notifier_provider.dart
+++ b/lib/provider/api/user_following_notifier_provider.dart
@@ -39,19 +39,19 @@ class UserFollowingNotifier extends _$UserFollowingNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchFollowing(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_following_notifier_provider.g.dart
+++ b/lib/provider/api/user_following_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class UserFollowingNotifierProvider
 }
 
 String _$userFollowingNotifierHash() =>
-    r'1f86e6794ca06aff0637cd3c44c27245c2e533c5';
+    r'3590627572eda2e473249b8e7460d23f89da9a71';
 
 final class UserFollowingNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_gallery_posts_notifier_provider.dart
+++ b/lib/provider/api/user_gallery_posts_notifier_provider.dart
@@ -51,17 +51,17 @@ class UserGalleryPostsNotifier extends _$UserGalleryPostsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPosts(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPosts(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_gallery_posts_notifier_provider.g.dart
+++ b/lib/provider/api/user_gallery_posts_notifier_provider.g.dart
@@ -56,7 +56,7 @@ final class UserGalleryPostsNotifierProvider
 }
 
 String _$userGalleryPostsNotifierHash() =>
-    r'bcf7bf502da1c69df8cff655bc58894fb3515f54';
+    r'b89bbab6531c0c44b98cdd40ed61bfe9e07e8012';
 
 final class UserGalleryPostsNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_pages_notifier_provider.dart
+++ b/lib/provider/api/user_pages_notifier_provider.dart
@@ -47,17 +47,17 @@ class UserPagesNotifier extends _$UserPagesNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPages(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPages(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_pages_notifier_provider.g.dart
+++ b/lib/provider/api/user_pages_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class UserPagesNotifierProvider
   }
 }
 
-String _$userPagesNotifierHash() => r'4ec091c2a47aa8555289391661606dff09d764aa';
+String _$userPagesNotifierHash() => r'07c5970b6e2b1618bbe8077fd40bcd86e8ba6ea2';
 
 final class UserPagesNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_plays_notifier_provider.dart
+++ b/lib/provider/api/user_plays_notifier_provider.dart
@@ -47,17 +47,17 @@ class UserPlaysNotifier extends _$UserPlaysNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchPlays(untilId: value.items.lastOrNull?.id);
+      final response = await _fetchPlays(untilId: value?.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_plays_notifier_provider.g.dart
+++ b/lib/provider/api/user_plays_notifier_provider.g.dart
@@ -50,7 +50,7 @@ final class UserPlaysNotifierProvider
   }
 }
 
-String _$userPlaysNotifierHash() => r'005484ab65efef54301f6a8b7c3dc96324cc6d96';
+String _$userPlaysNotifierHash() => r'ca3bf69a832e5d69143c6d00837ca6bbc0cd76cf';
 
 final class UserPlaysNotifierFamily extends $Family
     with

--- a/lib/provider/api/user_reactions_notifier_provider.dart
+++ b/lib/provider/api/user_reactions_notifier_provider.dart
@@ -55,19 +55,19 @@ class UserReactionsNotifier extends _$UserReactionsNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
       final response = await _fetchReactions(
-        untilId: value.items.lastOrNull?.id,
+        untilId: value?.items.lastOrNull?.id,
       );
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/user_reactions_notifier_provider.g.dart
+++ b/lib/provider/api/user_reactions_notifier_provider.g.dart
@@ -55,7 +55,7 @@ final class UserReactionsNotifierProvider
 }
 
 String _$userReactionsNotifierHash() =>
-    r'2849f3191c86222924d004ca3b25dc3c0c7776ca';
+    r'9049dcdebae7ac617c915c6c59308a3f11f1a646';
 
 final class UserReactionsNotifierFamily extends $Family
     with

--- a/lib/provider/api/users_notifier_provider.dart
+++ b/lib/provider/api/users_notifier_provider.dart
@@ -41,15 +41,15 @@ class UsersNotifier extends _$UsersNotifier {
     if (state.isLoading || (state.hasError && !skipError)) {
       return;
     }
-    final value = skipError ? state.value! : await future;
-    if (value.isLastLoaded) {
+    final value = skipError ? state.value : await future;
+    if (value?.isLastLoaded ?? false) {
       return;
     }
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchUsers(offset: value.items.length);
+      final response = await _fetchUsers(offset: value?.items.length);
       return PaginationState(
-        items: [...value.items, ...response],
+        items: [...?value?.items, ...response],
         isLastLoaded: response.isEmpty,
       );
     });

--- a/lib/provider/api/users_notifier_provider.g.dart
+++ b/lib/provider/api/users_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class UsersNotifierProvider
   }
 }
 
-String _$usersNotifierHash() => r'79b1679e7b54bcc0d143c5bdde0bc6053213dfc5';
+String _$usersNotifierHash() => r'e6f3ecc734c425c50677f86455524a9fcdfd0eb9';
 
 final class UsersNotifierFamily extends $Family
     with


### PR DESCRIPTION
Replaced `state.value!` with `state.value` in the `loadMore` methods.