### PR TITLE
fix: keep opacity of fg children

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -495,7 +495,7 @@ class _Mfm extends StatelessWidget {
           child: Code(
             code: code,
             inline: true,
-            fontSize: config.style.apply(fontSizeFactor: config.scale).fontSize,
+            style: config.style.apply(fontSizeFactor: config.scale),
           ),
         ),
       ),

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -317,7 +317,9 @@ class _Mfm extends StatelessWidget {
             : text,
         style: config.style.apply(
           fontSizeFactor: config.scale,
-          color: config.style.color?.withValues(alpha: config.opacity),
+          color: config.style.color?.withValues(
+            alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+          ),
         ),
       ),
       MfmBold(:final children?) => TextSpan(
@@ -580,7 +582,12 @@ class _Mfm extends StatelessWidget {
                       )
                     : null,
                 fallbackTextStyle: config.style
-                    .apply(fontSizeFactor: config.scale)
+                    .apply(
+                      fontSizeFactor: config.scale,
+                      color: config.style.color?.withValues(
+                        alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                      ),
+                    )
                     .copyWith(height: simple ? 1.0 : null),
                 fallbackToImage: false,
                 enableFadeIn: enableEmojiFadeIn,
@@ -597,7 +604,9 @@ class _Mfm extends StatelessWidget {
           emoji: emoji,
           style: config.style.apply(
             fontSizeFactor: config.scale,
-            color: config.style.color?.withValues(alpha: config.opacity),
+            color: config.style.color?.withValues(
+              alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+            ),
           ),
           onTap: !simple
               ? () => showModalBottomSheet<void>(
@@ -622,7 +631,9 @@ class _Mfm extends StatelessWidget {
           formula,
           mathStyle: MathStyle.text,
           textStyle: config.style.apply(
-            color: config.style.color?.withValues(alpha: config.opacity),
+            color: config.style.color?.withValues(
+              alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+            ),
           ),
           textScaleFactor: config.scale,
           onErrorFallback: (_) => Text(
@@ -642,7 +653,9 @@ class _Mfm extends StatelessWidget {
             child: Math.tex(
               formula,
               textStyle: config.style.apply(
-                color: config.style.color?.withValues(alpha: config.opacity),
+                color: config.style.color?.withValues(
+                  alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                ),
               ),
               textScaleFactor: config.scale,
               onErrorFallback: (_) => Text(
@@ -663,7 +676,9 @@ class _Mfm extends StatelessWidget {
         text: text,
         style: config.style.apply(
           fontSizeFactor: config.scale,
-          color: config.style.color?.withValues(alpha: config.opacity),
+          color: config.style.color?.withValues(
+            alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+          ),
         ),
       ),
       _ => null,
@@ -1068,10 +1083,7 @@ class _Mfm extends StatelessWidget {
         return TextSpan(
           children: _buildNodes(
             context,
-            config.copyWith(
-              style: config.style.apply(color: color),
-              opacity: config.opacity * color.a,
-            ),
+            config.copyWith(style: config.style.apply(color: color)),
             children,
           ),
         );
@@ -1114,7 +1126,9 @@ class _Mfm extends StatelessWidget {
         final rubyStyle = config.style
             .apply(
               fontSizeFactor: config.scale * 0.5,
-              color: config.style.color?.withValues(alpha: config.opacity),
+              color: config.style.color?.withValues(
+                alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+              ),
             )
             .copyWith(height: 1.0);
         if (children.length <= 1) {
@@ -1210,7 +1224,8 @@ class _Mfm extends StatelessWidget {
                       child: Icon(
                         Icons.access_time,
                         color: config.style.color?.withValues(
-                          alpha: config.opacity,
+                          alpha:
+                              (config.style.color?.a ?? 1.0) * config.opacity,
                         ),
                         size: config.style.lineHeight * config.scale * 0.9,
                       ),
@@ -1222,7 +1237,8 @@ class _Mfm extends StatelessWidget {
                         style: config.style.apply(
                           fontSizeFactor: config.scale * 0.9,
                           color: config.style.color?.withValues(
-                            alpha: config.opacity,
+                            alpha:
+                                (config.style.color?.a ?? 1.0) * config.opacity,
                           ),
                         ),
                       )

--- a/lib/view/widget/mfm/code.dart
+++ b/lib/view/widget/mfm/code.dart
@@ -24,24 +24,20 @@ class Code extends HookConsumerWidget {
     required this.code,
     this.language,
     this.inline = false,
-    this.fontSize,
+    this.style,
     this.copyOnTap = false,
   });
 
   final String code;
   final String? language;
   final bool inline;
-  final double? fontSize;
+  final TextStyle? style;
   final bool copyOnTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final input = code.replaceAll(RegExp(r'\r?\n$'), '');
-    final languageId =
-        allLanguages[language]?.id ??
-        allLanguages[allAliases[language]]?.id ??
-        'javascript';
-    final brightness = Theme.of(context).brightness;
+    final brightness = Theme.brightnessOf(context);
     final (fontFamily, themeId) = ref.watch(
       generalSettingsNotifierProvider.select(
         (settings) => (
@@ -95,6 +91,24 @@ class Code extends HookConsumerWidget {
       }
       return theme;
     }, [themeId]);
+    final style =
+        (fontFamily != null
+            ? GoogleFonts.asMap()[fontFamily]?.call(
+                textStyle:
+                    this.style?.copyWith(
+                      fontFamilyFallback: monospaceFallback,
+                    ) ??
+                    const TextStyle(fontFamilyFallback: monospaceFallback),
+              )
+            : null) ??
+        this.style?.copyWith(
+          fontFamily: fontFamily ?? 'monospace',
+          fontFamilyFallback: monospaceFallback,
+        ) ??
+        TextStyle(
+          fontFamily: fontFamily ?? 'monospace',
+          fontFamilyFallback: monospaceFallback,
+        );
 
     return Stack(
       children: [
@@ -116,18 +130,7 @@ class Code extends HookConsumerWidget {
                   padding: inline
                       ? const EdgeInsets.symmetric(horizontal: 2.0)
                       : const EdgeInsets.all(16.0),
-                  textStyle:
-                      GoogleFonts.asMap()[fontFamily]?.call(
-                        textStyle: TextStyle(
-                          fontSize: fontSize,
-                          fontFamilyFallback: monospaceFallback,
-                        ),
-                      ) ??
-                      TextStyle(
-                        fontSize: fontSize,
-                        fontFamily: fontFamily ?? 'monospace',
-                        fontFamilyFallback: monospaceFallback,
-                      ),
+                  textStyle: style,
                 ),
               ),
             ),

--- a/lib/view/widget/mfm/code.dart
+++ b/lib/view/widget/mfm/code.dart
@@ -37,6 +37,11 @@ class Code extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final input = code.replaceAll(RegExp(r'\r?\n$'), '');
+    final languageId = !inline
+        ? allLanguages[language]?.id ??
+              allLanguages[allAliases[language]]?.id ??
+              'javascript'
+        : 'plaintext';
     final brightness = Theme.brightnessOf(context);
     final (fontFamily, themeId) = ref.watch(
       generalSettingsNotifierProvider.select(


### PR DESCRIPTION
Fixed an issue where the `fg` function modifies the opacity of its children, including non-text elements, when the provided color has alpha.

Fix #935