### PR TITLE
fix: hide expand note button if lookup is not possible

### DIFF
--- a/lib/view/widget/url_preview.dart
+++ b/lib/view/widget/url_preview.dart
@@ -2,14 +2,17 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../extension/text_style_extension.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../model/lookup.dart';
 import '../../provider/api/lookup_provider.dart';
+import '../../provider/api/meta_notifier_provider.dart';
 import '../../provider/data_saver_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
+import '../../provider/server_url_notifier_provider.dart';
 import '../../provider/summaly_provider.dart';
 import '../../util/navigate.dart';
 import 'bluesky_embed.dart';
@@ -99,6 +102,20 @@ class UrlPreview extends HookConsumerWidget {
       () => apUrl != null ? _normalizeActivityPub(apUrl, url) : null,
       [apUrl, url],
     );
+    final canLookup =
+        activityPub != null &&
+        (apUrl?.authority.toLowerCase() ==
+                ref
+                    .watch(serverUrlNotifierProvider(account.host))
+                    .authority
+                    .toLowerCase() ||
+            (!account.isGuest &&
+                ref.watch(
+                      metaNotifierProvider(
+                        account.host,
+                      ).select((meta) => meta.value?.federation),
+                    ) !=
+                    MetaFederation.none));
     final tweetId = useMemoized(
       () => switch (url) {
         final url? => _extractTweetId(url),
@@ -217,7 +234,7 @@ class UrlPreview extends HookConsumerWidget {
                 TargetPlatform.windows
             when summalyResult != null &&
                 (playerUrl != null ||
-                    activityPub != null ||
+                    canLookup ||
                     tweetId != null ||
                     atId != null)) ...[
           if (isPlayerOpen.value)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1421,8 +1421,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "886e407cb07bd60274631125ee0d2e559a89e32a"
-      resolved-ref: "886e407cb07bd60274631125ee0d2e559a89e32a"
+      ref: "6bae76ef634627a2335834ded1b96cd481d20418"
+      resolved-ref: "6bae76ef634627a2335834ded1b96cd481d20418"
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: 886e407cb07bd60274631125ee0d2e559a89e32a
+      ref: 6bae76ef634627a2335834ded1b96cd481d20418
   mobile_scanner:
     git:
       url: https://github.com/poppingmoon/mobile_scanner


### PR DESCRIPTION
Changed to show the expand note button on the url previews only if the user can lookup the url.