### PR TITLE
perf: reduce BlurHash resolution for user avatar

### DIFF
--- a/lib/view/widget/cat_avatar.dart
+++ b/lib/view/widget/cat_avatar.dart
@@ -139,6 +139,7 @@ class CatAvatar extends HookWidget {
                 height: size,
                 width: size,
                 fit: BoxFit.cover,
+                blurHashDecodingSize: 16,
                 disableAnimations: disableAnimations,
               ),
             ),

--- a/lib/view/widget/image_widget.dart
+++ b/lib/view/widget/image_widget.dart
@@ -20,6 +20,7 @@ class ImageWidget extends ConsumerWidget {
     this.opacity = 1.0,
     this.fit,
     this.alignment = Alignment.center,
+    this.blurHashDecodingSize = 32,
     this.placeholderBuilder,
     this.errorBuilder,
     this.semanticLabel,
@@ -34,6 +35,7 @@ class ImageWidget extends ConsumerWidget {
   final double opacity;
   final BoxFit? fit;
   final Alignment alignment;
+  final int blurHashDecodingSize;
   final Widget Function(BuildContext context)? placeholderBuilder;
   final Widget Function(BuildContext, Object, Object?)? errorBuilder;
   final String? semanticLabel;
@@ -51,6 +53,8 @@ class ImageWidget extends ConsumerWidget {
         child: BlurHash(
           hash: blurHash,
           color: Colors.transparent,
+          decodingWidth: blurHashDecodingSize,
+          decodingHeight: blurHashDecodingSize,
           optimizationMode: BlurHashOptimizationMode.approximation,
         ),
       );

--- a/lib/view/widget/user_avatar.dart
+++ b/lib/view/widget/user_avatar.dart
@@ -115,6 +115,7 @@ class UserAvatar extends ConsumerWidget {
               height: size,
               width: size,
               fit: BoxFit.cover,
+              blurHashDecodingSize: 16,
               disableAnimations: useStaticImage,
             ),
           ),


### PR DESCRIPTION
Reduced `decodingWidth` and `decodingHeight` of `BlurHash` widget in `UserAvatar` from 32 to 16.