### PR TITLE
fix: count AiScript UI component update

### DIFF
--- a/lib/rust/api/aiscript/ui.dart
+++ b/lib/rust/api/aiscript/ui.dart
@@ -20,7 +20,8 @@ abstract class AsUiButtonCallback implements RustOpaqueInterface {
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner< AsUiLib>>
 abstract class AsUiLib implements RustOpaqueInterface {
   factory AsUiLib({
-    required FutureOr<void> Function(String, AsUiComponent) onUpdate,
+    required FutureOr<void> Function(String, AsUiComponent, PlatformInt64)
+    onUpdate,
   }) => RustLib.instance.api.crateApiAiscriptUiAsUiLibNew(onUpdate: onUpdate);
 }
 

--- a/lib/rust/frb_generated.dart
+++ b/lib/rust/frb_generated.dart
@@ -121,7 +121,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   AsUiLib crateApiAiscriptUiAsUiLibNew({
-    required FutureOr<void> Function(String, AsUiComponent) onUpdate,
+    required FutureOr<void> Function(String, AsUiComponent, PlatformInt64)
+    onUpdate,
   });
 
   Future<void> crateApiAiscriptUiAsUiMfmCallbackCall({
@@ -555,13 +556,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   AsUiLib crateApiAiscriptUiAsUiLibNew({
-    required FutureOr<void> Function(String, AsUiComponent) onUpdate,
+    required FutureOr<void> Function(String, AsUiComponent, PlatformInt64)
+    onUpdate,
   }) {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+          sse_encode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
             onUpdate,
             serializer,
           );
@@ -1027,18 +1029,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     };
   }
 
-  Future<void> Function(int, dynamic, dynamic)
-  encode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
-    FutureOr<void> Function(String, AsUiComponent) raw,
+  Future<void> Function(int, dynamic, dynamic, dynamic)
+  encode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(String, AsUiComponent, PlatformInt64) raw,
   ) {
-    return (callId, rawArg0, rawArg1) async {
+    return (callId, rawArg0, rawArg1, rawArg2) async {
       final arg0 = dco_decode_String(rawArg0);
       final arg1 = dco_decode_as_ui_component(rawArg1);
+      final arg2 = dco_decode_i_64(rawArg2);
 
       Box<void>? rawOutput;
       Box<AnyhowException>? rawError;
       try {
-        rawOutput = Box(await raw(arg0, arg1));
+        rawOutput = Box(await raw(arg0, arg1, arg2));
       } catch (e, s) {
         rawError = Box(AnyhowException("$e\n\n$s"));
       }
@@ -1362,8 +1365,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  FutureOr<void> Function(String, AsUiComponent)
-  dco_decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+  FutureOr<void> Function(String, AsUiComponent, PlatformInt64)
+  dco_decode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -1980,6 +1983,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
+  }
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeI64(raw);
   }
 
   @protected
@@ -3130,6 +3139,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getPlatformInt64();
+  }
+
+  @protected
   PlatformInt64 sse_decode_isize(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getPlatformInt64();
@@ -3806,13 +3821,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
-  sse_encode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
-    FutureOr<void> Function(String, AsUiComponent) self,
+  sse_encode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(String, AsUiComponent, PlatformInt64) self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_DartOpaque(
-      encode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+      encode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
         self,
       ),
       serializer,
@@ -4474,6 +4489,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_f_64(double self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putFloat64(self);
+  }
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putPlatformInt64(self);
   }
 
   @protected

--- a/lib/rust/frb_generated.io.dart
+++ b/lib/rust/frb_generated.io.dart
@@ -205,8 +205,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  FutureOr<void> Function(String, AsUiComponent)
-  dco_decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+  FutureOr<void> Function(String, AsUiComponent, PlatformInt64)
+  dco_decode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
     dynamic raw,
   );
 
@@ -439,6 +439,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double dco_decode_f_64(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw);
 
   @protected
   PlatformInt64 dco_decode_isize(dynamic raw);
@@ -911,6 +914,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double sse_decode_f_64(SseDeserializer deserializer);
 
   @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
   PlatformInt64 sse_decode_isize(SseDeserializer deserializer);
 
   @protected
@@ -1213,8 +1219,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
-    FutureOr<void> Function(String, AsUiComponent) self,
+  sse_encode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(String, AsUiComponent, PlatformInt64) self,
     SseSerializer serializer,
   );
 
@@ -1518,6 +1524,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
 
   @protected
   void sse_encode_isize(PlatformInt64 self, SseSerializer serializer);

--- a/lib/rust/frb_generated.web.dart
+++ b/lib/rust/frb_generated.web.dart
@@ -207,8 +207,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  FutureOr<void> Function(String, AsUiComponent)
-  dco_decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+  FutureOr<void> Function(String, AsUiComponent, PlatformInt64)
+  dco_decode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
     dynamic raw,
   );
 
@@ -441,6 +441,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   double dco_decode_f_64(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw);
 
   @protected
   PlatformInt64 dco_decode_isize(dynamic raw);
@@ -913,6 +916,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   double sse_decode_f_64(SseDeserializer deserializer);
 
   @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
   PlatformInt64 sse_decode_isize(SseDeserializer deserializer);
 
   @protected
@@ -1215,8 +1221,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
-    FutureOr<void> Function(String, AsUiComponent) self,
+  sse_encode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
+    FutureOr<void> Function(String, AsUiComponent, PlatformInt64) self,
     SseSerializer serializer,
   );
 
@@ -1520,6 +1526,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
 
   @protected
   void sse_encode_isize(PlatformInt64 self, SseSerializer serializer);

--- a/lib/util/create_aiscript.dart
+++ b/lib/util/create_aiscript.dart
@@ -47,6 +47,7 @@ Future<AiScript> createAiScript(
   if (components != null) {
     components.value = {};
   }
+  final updateCounts = <String, int>{};
 
   return AiScript.newInstance(
     read: (prompt) async {
@@ -138,8 +139,14 @@ Future<AiScript> createAiScript(
     ),
     ui: components != null
         ? AsUiLib(
-            onUpdate: (id, component) =>
-                components.value = {...components.value, id: component},
+            onUpdate: (id, component, updateCount) {
+              if (updateCounts[id] case final previousCount?
+                  when updateCount < previousCount) {
+                return;
+              }
+              updateCounts[id] = updateCount;
+              components.value = {...components.value, id: component};
+            },
           )
         : null,
     play: playId != null

--- a/rust/src/api/aiscript/ui.rs
+++ b/rust/src/api/aiscript/ui.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    sync::atomic::{AtomicI64, Ordering},
     sync::{Arc, Mutex},
 };
 
@@ -2116,22 +2117,20 @@ impl AsUiComponent {
 
 #[derive(Clone)]
 pub struct AsUiLib {
-    // on_update: Arc<dyn Fn(String, AsUiComponent) -> DartFnFuture<()> + Sync + Send + 'static>,
     v0: AsUiLibV0,
     v1: AsUiLibV1,
-    // components: Arc<Mutex<HashMap<String, AsUiComponent>>>,
-    // instances: Arc<Mutex<HashMap<String, v0::values::Value>>>,
 }
 
 impl AsUiLib {
     #[frb(sync)]
     pub fn new(
-        on_update: impl Fn(String, AsUiComponent) -> DartFnFuture<()> + Sync + Send + 'static,
+        on_update: impl Fn(String, AsUiComponent, i64) -> DartFnFuture<()> + Sync + Send + 'static,
     ) -> Self {
         let on_update = Arc::new(on_update);
+        let update_count = Arc::new(AtomicI64::new(0));
         AsUiLib {
-            v0: AsUiLibV0::new(on_update.clone()),
-            v1: AsUiLibV1::new(on_update),
+            v0: AsUiLibV0::new(on_update.clone(), update_count.clone()),
+            v1: AsUiLibV1::new(on_update, update_count),
         }
     }
 
@@ -2146,19 +2145,24 @@ impl AsUiLib {
 
 #[derive(Clone)]
 struct AsUiLibV0 {
-    on_update: Arc<dyn Fn(String, AsUiComponent) -> DartFnFuture<()> + Sync + Send + 'static>,
+    on_update: Arc<dyn Fn(String, AsUiComponent, i64) -> DartFnFuture<()> + Sync + Send + 'static>,
     components: Arc<Mutex<HashMap<String, AsUiComponent>>>,
     instances: Arc<Mutex<HashMap<String, v0::values::Value>>>,
+    update_count: Arc<AtomicI64>,
 }
 
 impl AsUiLibV0 {
     fn new(
-        on_update: Arc<dyn Fn(String, AsUiComponent) -> DartFnFuture<()> + Sync + Send + 'static>,
+        on_update: Arc<
+            dyn Fn(String, AsUiComponent, i64) -> DartFnFuture<()> + Sync + Send + 'static,
+        >,
+        update_count: Arc<AtomicI64>,
     ) -> Self {
         AsUiLibV0 {
             on_update,
             components: Arc::new(Mutex::new(HashMap::new())),
             instances: Arc::new(Mutex::new(HashMap::new())),
+            update_count,
         }
     }
 
@@ -2189,6 +2193,7 @@ impl AsUiLibV0 {
                     let id = id.clone();
                     let components = self.components.clone();
                     let on_update = self.on_update.clone();
+                    let update_count = self.update_count.clone();
                     move |args, _| {
                         let def = args
                             .first()
@@ -2208,7 +2213,8 @@ impl AsUiLibV0 {
                                     updates
                                 }
                             };
-                            tokio::spawn(on_update(id.clone(), component));
+                            let update_count = update_count.fetch_add(1, Ordering::Relaxed);
+                            tokio::spawn(on_update(id.clone(), component, update_count));
                             Ok(v0::values::Value::null())
                         });
                         async { result }.boxed()
@@ -2220,7 +2226,8 @@ impl AsUiLibV0 {
             .lock()
             .map_err(v0::errors::AiScriptError::internal)?
             .insert(id.clone(), instance.clone());
-        tokio::spawn((self.on_update)(id, component));
+        let update_count = self.update_count.fetch_add(1, Ordering::Relaxed);
+        tokio::spawn((self.on_update)(id, component, update_count));
         Ok(instance)
     }
 
@@ -2274,6 +2281,7 @@ impl AsUiLibV0 {
             v0::values::Value::fn_native({
                 let components = self.components.clone();
                 let on_update = self.on_update.clone();
+                let update_count = self.update_count.clone();
                 move |args, _| {
                     let mut args = args.into_iter();
                     let result =
@@ -2296,7 +2304,12 @@ impl AsUiLibV0 {
                                     .lock()
                                     .map_err(v0::errors::AiScriptError::internal)?
                                     .insert(ROOT_ID.to_string(), component.clone());
-                                tokio::spawn(on_update(ROOT_ID.to_string(), component));
+                                let update_count = update_count.fetch_add(1, Ordering::Relaxed);
+                                tokio::spawn(on_update(
+                                    ROOT_ID.to_string(),
+                                    component,
+                                    update_count,
+                                ));
                                 Ok(v0::values::Value::null())
                             });
                     async { result }.boxed()
@@ -2550,19 +2563,24 @@ impl AsUiLibV0 {
 
 #[derive(Clone)]
 struct AsUiLibV1 {
-    on_update: Arc<dyn Fn(String, AsUiComponent) -> DartFnFuture<()> + Sync + Send + 'static>,
+    on_update: Arc<dyn Fn(String, AsUiComponent, i64) -> DartFnFuture<()> + Sync + Send + 'static>,
     components: Arc<Mutex<HashMap<String, AsUiComponent>>>,
     instances: Arc<Mutex<HashMap<String, v1::values::Value>>>,
+    update_count: Arc<AtomicI64>,
 }
 
 impl AsUiLibV1 {
     fn new(
-        on_update: Arc<dyn Fn(String, AsUiComponent) -> DartFnFuture<()> + Sync + Send + 'static>,
+        on_update: Arc<
+            dyn Fn(String, AsUiComponent, i64) -> DartFnFuture<()> + Sync + Send + 'static,
+        >,
+        update_count: Arc<AtomicI64>,
     ) -> Self {
         AsUiLibV1 {
             on_update,
             components: Arc::new(Mutex::new(HashMap::new())),
             instances: Arc::new(Mutex::new(HashMap::new())),
+            update_count,
         }
     }
 
@@ -2593,6 +2611,7 @@ impl AsUiLibV1 {
                     let id = id.clone();
                     let components = self.components.clone();
                     let on_update = self.on_update.clone();
+                    let update_count = self.update_count.clone();
                     move |args, _| {
                         let def = args
                             .first()
@@ -2612,7 +2631,8 @@ impl AsUiLibV1 {
                                     updates
                                 }
                             };
-                            tokio::spawn(on_update(id.clone(), component));
+                            let update_count = update_count.fetch_add(1, Ordering::Relaxed);
+                            tokio::spawn(on_update(id.clone(), component, update_count));
                             Ok(v1::values::Value::null())
                         });
                         async { result }.boxed()
@@ -2624,7 +2644,8 @@ impl AsUiLibV1 {
             .lock()
             .map_err(v1::errors::AiScriptError::internal)?
             .insert(id.clone(), instance.clone());
-        tokio::spawn((self.on_update)(id, component));
+        let update_count = self.update_count.fetch_add(1, Ordering::Relaxed);
+        tokio::spawn((self.on_update)(id, component, update_count));
         Ok(instance)
     }
 
@@ -2678,6 +2699,7 @@ impl AsUiLibV1 {
             v1::values::Value::fn_native({
                 let components = self.components.clone();
                 let on_update = self.on_update.clone();
+                let update_count = self.update_count.clone();
                 move |args, _| {
                     let mut args = args.into_iter();
                     let result =
@@ -2700,7 +2722,12 @@ impl AsUiLibV1 {
                                     .lock()
                                     .map_err(v1::errors::AiScriptError::internal)?
                                     .insert(ROOT_ID.to_string(), component.clone());
-                                tokio::spawn(on_update(ROOT_ID.to_string(), component));
+                                let update_count = update_count.fetch_add(1, Ordering::Relaxed);
+                                tokio::spawn(on_update(
+                                    ROOT_ID.to_string(),
+                                    component,
+                                    update_count,
+                                ));
                                 Ok(v1::values::Value::null())
                             });
                     async { result }.boxed()

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -256,7 +256,7 @@ fn wire__crate__api__aiscript__api__AsApiLib_new_impl(
     rust_vec_len_: i32,
     data_len_: i32,
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "AsApiLib_new", port: None, mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync }, move || { 
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "AsApiLib_new", port: None, mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync }, move || {
             let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
             let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_user_id = <Option<String>>::sse_decode(&mut deserializer);
@@ -358,7 +358,7 @@ fn wire__crate__api__aiscript__ui__AsUiLib_new_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_on_update =
-                decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+                decode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
                     <flutter_rust_bridge::DartOpaque>::sse_decode(&mut deserializer),
                 );
             deserializer.end();
@@ -963,9 +963,9 @@ fn decode_DartFn_Inputs_String_String_opt_String_Output_record_string_opt_string
         ))
     }
 }
-fn decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
+fn decode_DartFn_Inputs_String_as_ui_component_i_64_Output_unit_AnyhowException(
     dart_opaque: flutter_rust_bridge::DartOpaque,
-) -> impl Fn(String, crate::api::aiscript::ui::AsUiComponent) -> flutter_rust_bridge::DartFnFuture<()>
+) -> impl Fn(String, crate::api::aiscript::ui::AsUiComponent, i64) -> flutter_rust_bridge::DartFnFuture<()>
 {
     use flutter_rust_bridge::IntoDart;
 
@@ -973,10 +973,12 @@ fn decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
         dart_opaque: flutter_rust_bridge::DartOpaque,
         arg0: String,
         arg1: crate::api::aiscript::ui::AsUiComponent,
+        arg2: i64,
     ) -> () {
         let args = vec![
             arg0.into_into_dart().into_dart(),
             arg1.into_into_dart().into_dart(),
+            arg2.into_into_dart().into_dart(),
         ];
         let message = FLUTTER_RUST_BRIDGE_HANDLER
             .dart_fn_invoke(dart_opaque, args)
@@ -996,11 +998,12 @@ fn decode_DartFn_Inputs_String_as_ui_component_Output_unit_AnyhowException(
         ans
     }
 
-    move |arg0: String, arg1: crate::api::aiscript::ui::AsUiComponent| {
+    move |arg0: String, arg1: crate::api::aiscript::ui::AsUiComponent, arg2: i64| {
         flutter_rust_bridge::for_generated::convert_into_dart_fn_future(body(
             dart_opaque.clone(),
             arg0,
             arg1,
+            arg2,
         ))
     }
 }
@@ -1594,6 +1597,13 @@ impl SseDecode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_f64::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for i64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_i64::<NativeEndian>().unwrap()
     }
 }
 
@@ -3021,6 +3031,13 @@ impl SseEncode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_f64::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for i64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_i64::<NativeEndian>(self).unwrap();
     }
 }
 


### PR DESCRIPTION
Added a counter to `AsUiLib` that counts `on_update` calls.

When `on_update` is called, the update count is sent to Flutter. On the Flutter side, the count is stored and compared to the previous one. If the count is lower, it means the `on_update` call was invoked out of order. In that case, the update is ignored to keep the components in the latest state.