### PR TITLE
fix: detect MeDetailed first when parsing UserDetailed

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1421,8 +1421,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "6bae76ef634627a2335834ded1b96cd481d20418"
-      resolved-ref: "6bae76ef634627a2335834ded1b96cd481d20418"
+      ref: ebd8ae33c1c9bbd4dc93c2b43b477f9425ec2ee5
+      resolved-ref: ebd8ae33c1c9bbd4dc93c2b43b477f9425ec2ee5
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: 6bae76ef634627a2335834ded1b96cd481d20418
+      ref: ebd8ae33c1c9bbd4dc93c2b43b477f9425ec2ee5
   mobile_scanner:
     git:
       url: https://github.com/poppingmoon/mobile_scanner


### PR DESCRIPTION
Fixed an issue where the response of `user/show` for the current user was regarded as a normal user after Sharkey changed to include `relation` in the response.

ref: https://activitypub.software/TransFem-org/Sharkey/-/commit/e92fe0504ae848eff66f7f46f6fc85f2e573017f?page=2#ddc24dd24e9edd6eb216dc4f829839a7adfdf67b_526_357

Fix #958 