### PR TITLE
fix: call onClickEv with empty string when ev is null

### DIFF
--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -1244,16 +1244,14 @@ class _Mfm extends StatelessWidget {
           ),
         );
       case 'clickable':
-        final clickEv = args['ev'];
+        final clickEv = args['ev'] ?? '';
         return WidgetSpan(
           alignment: children.any(_containsNewLine)
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
           child: InkWell(
-            onTap: clickEv != null && onClickEv != null
-                ? () => onClickEv?.call(clickEv)
-                : null,
+            onTap: onClickEv != null ? () => onClickEv?.call(clickEv) : null,
             child: AbsorbPointer(
               child: Text.rich(
                 TextSpan(children: _buildNodes(context, config, children)),


### PR DESCRIPTION
Fixed an issue where the `clickable` function for MFM without an `ev` argument is not called when clicked.

ref: https://github.com/misskey-dev/misskey/blob/059fbaa92b9765dce5028d0665911637ca2bc510/packages/frontend/src/components/global/MkMfm.ts#L325