### PR TITLE
fix: snap timeline header

### DIFF
--- a/lib/view/widget/timeline_header.dart
+++ b/lib/view/widget/timeline_header.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart' hide TextDirection;
 
@@ -12,16 +10,16 @@ import '../../model/tab_type.dart';
 import '../../provider/api/i_notifier_provider.dart';
 import '../../provider/api/online_users_count_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
-import '../../provider/timeline_scroll_controller_provider.dart';
 import 'ad_widget.dart';
 import 'streaming_error_icon.dart';
 import 'tab_icon_widget.dart';
 import 'timeline_menu.dart';
 
-class TimelineHeader extends HookConsumerWidget {
-  const TimelineHeader({super.key, required this.tabSettings});
+class TimelineHeader extends ConsumerWidget {
+  const TimelineHeader({super.key, required this.tabSettings, this.controller});
 
   final TabSettings tabSettings;
+  final ExpansibleController? controller;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -32,166 +30,118 @@ class TimelineHeader extends HookConsumerWidget {
     final onlineUsersCount = ref
         .watch(onlineUsersCountProvider(tabSettings.account))
         .value;
-    final scrollController = ref.watch(
-      timelineScrollControllerProvider(tabSettings),
-    );
-    final (alwaysShowHeader, oneLine, enableHapticFeedback) = ref.watch(
+    final (oneLine, enableHapticFeedback) = ref.watch(
       generalSettingsNotifierProvider.select(
-        (settings) => (
-          settings.alwaysShowTabHeader,
-          settings.showTabHeaderInOneLine,
-          settings.enableHapticFeedback,
-        ),
+        (settings) =>
+            (settings.showTabHeaderInOneLine, settings.enableHapticFeedback),
       ),
     );
-    final isMenuExpanded = useState(false);
-    final sizeFactor = useState(1.0);
-    useEffect(() {
-      double? offset;
-
-      void callback() {
-        final nextOffset = scrollController.position.extentBefore;
-        final scrollDirection = scrollController.position.userScrollDirection;
-        if (scrollDirection == ScrollDirection.idle) {
-          if (nextOffset == 0.0) {
-            sizeFactor.value = 1.0;
-          }
-          return;
-        }
-        if (offset case final offset?) {
-          final diff = nextOffset - offset;
-          switch ((scrollDirection, diff)) {
-            case (ScrollDirection.forward, < 0) ||
-                    (ScrollDirection.reverse, > 0)
-                when !isMenuExpanded.value:
-              sizeFactor.value = clampDouble(
-                sizeFactor.value - diff * 0.01,
-                0.0,
-                1.0,
-              );
-          }
-        }
-        offset = nextOffset;
-      }
-
-      sizeFactor.value = 1.0;
-      if (!alwaysShowHeader) {
-        scrollController.addListener(callback);
-      }
-      return () => scrollController.removeListener(callback);
-    }, [alwaysShowHeader]);
     final theme = Theme.of(context);
 
-    return SizeTransition(
-      sizeFactor: Animation.fromValueListenable(sizeFactor),
-      child: ExpansionTile(
-        leading: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            StreamingErrorIcon(tabSettings: tabSettings),
-            Stack(
-              children: [
-                TabIconWidget(tabSettings: tabSettings),
-                if (hasUnreadNotification ||
-                    hasUnreadAnnouncement ||
-                    hasUnreadChatMessages)
-                  DecoratedBox(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: theme.colorScheme.primary,
-                    ),
-                    child: const SizedBox(height: 12.0, width: 12.0),
-                  ),
-              ],
-            ),
-          ],
-        ),
-        title: Text.rich(
-          TextSpan(
-            children: [
-              TextSpan(
-                text:
-                    tabSettings.name ??
-                    switch (tabSettings.tabType) {
-                      TabType.homeTimeline => t.misskey.timelines_.home,
-                      TabType.localTimeline => t.misskey.timelines_.local,
-                      TabType.hybridTimeline => t.misskey.timelines_.social,
-                      TabType.globalTimeline => t.misskey.timelines_.global,
-                      TabType.roleTimeline => t.misskey.role,
-                      TabType.userList => t.misskey.userList,
-                      TabType.antenna => t.misskey.antennas,
-                      TabType.channel => t.misskey.channel,
-                      TabType.hashtag => t.misskey.hashtags,
-                      TabType.mention => t.misskey.mentions,
-                      TabType.direct => t.misskey.directNotes,
-                      TabType.user => t.misskey.user,
-                      TabType.notifications => t.misskey.notifications,
-                      TabType.custom => t.aria.custom,
-                    },
-              ),
-              if (oneLine) ...[
-                const WidgetSpan(child: SizedBox(width: 8.0)),
-                if (defaultTargetPlatform != TargetPlatform.linux)
-                  const TextSpan(text: Unicode.LRI),
-                TextSpan(
-                  text: tabSettings.account.toString(),
-                  style: DefaultTextStyle.of(context).style.apply(
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.85),
-                  ),
-                ),
-                if (defaultTargetPlatform != TargetPlatform.linux)
-                  const TextSpan(text: Unicode.PDI),
-              ],
-            ],
-          ),
-          overflow: TextOverflow.ellipsis,
-          maxLines: oneLine ? 1 : null,
-        ),
-        subtitle: !oneLine
-            ? Align(
-                alignment: AlignmentDirectional.centerStart,
-                child: Text(
-                  tabSettings.account.toString(),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                  textDirection: TextDirection.ltr,
-                ),
-              )
-            : null,
-        onExpansionChanged: (value) {
-          if (enableHapticFeedback) {
-            HapticFeedback.lightImpact();
-          }
-          isMenuExpanded.value = value;
-          if (value) {
-            sizeFactor.value = 1.0;
-          }
-        },
-        backgroundColor: theme.colorScheme.surface,
-        collapsedBackgroundColor: theme.colorScheme.surface,
-        shape: const Border(),
-        collapsedShape: const Border(),
-        visualDensity: VisualDensity.compact,
+    return ExpansionTile(
+      controller: controller,
+      leading: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          if (onlineUsersCount != null)
-            Text.rich(
-              t.aria.onlineUsersCount(
-                n: TextSpan(
-                  text: NumberFormat().format(onlineUsersCount),
-                  style: const TextStyle(
-                    color: Color(0xff41b781),
-                    fontWeight: FontWeight.bold,
+          StreamingErrorIcon(tabSettings: tabSettings),
+          Stack(
+            children: [
+              TabIconWidget(tabSettings: tabSettings),
+              if (hasUnreadNotification ||
+                  hasUnreadAnnouncement ||
+                  hasUnreadChatMessages)
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: theme.colorScheme.primary,
                   ),
+                  child: const SizedBox(height: 12.0, width: 12.0),
                 ),
-              ),
-            ),
-          TimelineMenu(tabSettings: tabSettings),
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 300.0),
-            child: AdWidget(account: tabSettings.account),
+            ],
           ),
         ],
       ),
+      title: Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(
+              text:
+                  tabSettings.name ??
+                  switch (tabSettings.tabType) {
+                    TabType.homeTimeline => t.misskey.timelines_.home,
+                    TabType.localTimeline => t.misskey.timelines_.local,
+                    TabType.hybridTimeline => t.misskey.timelines_.social,
+                    TabType.globalTimeline => t.misskey.timelines_.global,
+                    TabType.roleTimeline => t.misskey.role,
+                    TabType.userList => t.misskey.userList,
+                    TabType.antenna => t.misskey.antennas,
+                    TabType.channel => t.misskey.channel,
+                    TabType.hashtag => t.misskey.hashtags,
+                    TabType.mention => t.misskey.mentions,
+                    TabType.direct => t.misskey.directNotes,
+                    TabType.user => t.misskey.user,
+                    TabType.notifications => t.misskey.notifications,
+                    TabType.custom => t.aria.custom,
+                  },
+            ),
+            if (oneLine) ...[
+              const WidgetSpan(child: SizedBox(width: 8.0)),
+              if (defaultTargetPlatform != TargetPlatform.linux)
+                const TextSpan(text: Unicode.LRI),
+              TextSpan(
+                text: tabSettings.account.toString(),
+                style: DefaultTextStyle.of(context).style.apply(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.85),
+                ),
+              ),
+              if (defaultTargetPlatform != TargetPlatform.linux)
+                const TextSpan(text: Unicode.PDI),
+            ],
+          ],
+        ),
+        overflow: TextOverflow.ellipsis,
+        maxLines: oneLine ? 1 : null,
+      ),
+      subtitle: !oneLine
+          ? Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: Text(
+                tabSettings.account.toString(),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+                textDirection: TextDirection.ltr,
+              ),
+            )
+          : null,
+      onExpansionChanged: (value) {
+        if (enableHapticFeedback) {
+          HapticFeedback.lightImpact();
+        }
+      },
+      backgroundColor: theme.colorScheme.surface,
+      collapsedBackgroundColor: theme.colorScheme.surface,
+      shape: const Border(),
+      collapsedShape: const Border(),
+      visualDensity: VisualDensity.compact,
+      children: [
+        if (onlineUsersCount != null)
+          Text.rich(
+            t.aria.onlineUsersCount(
+              n: TextSpan(
+                text: NumberFormat().format(onlineUsersCount),
+                style: const TextStyle(
+                  color: Color(0xff41b781),
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        TimelineMenu(tabSettings: tabSettings),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 300.0),
+          child: AdWidget(account: tabSettings.account),
+        ),
+      ],
     );
   }
 }

--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -1,4 +1,7 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart' hide Notification;
+import 'package:flutter/rendering.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -43,9 +46,10 @@ class TimelineWidget extends HookConsumerWidget {
     );
     final account = tabSettings.account;
     final i = ref.watch(iNotifierProvider(account)).value;
-    final showTimelineLastViewedAt = ref.watch(
+    final (showTimelineLastViewedAt, alwaysShowHeader) = ref.watch(
       generalSettingsNotifierProvider.select(
-        (settings) => settings.showTimelineLastViewedAt,
+        (settings) =>
+            (settings.showTimelineLastViewedAt, settings.alwaysShowTabHeader),
       ),
     );
     final lastViewedNoteId = tabSettings.tabType != TabType.notifications
@@ -77,6 +81,15 @@ class TimelineWidget extends HookConsumerWidget {
     final scrollController = ref.watch(
       timelineScrollControllerProvider(tabSettings),
     );
+    final sizeFactorController = useAnimationController(
+      duration: const Duration(milliseconds: 200),
+      initialValue: 1.0,
+    );
+    final headerKey = useMemoized(() => GlobalKey());
+    final expansibleController = useExpansibleController();
+    final isMenuExpanded = useRef(false);
+    final headerHeight = useRef<double?>(null);
+    final scrollDirection = useRef<ScrollDirection?>(null);
     useEffect(() {
       if (!tabSettings.keepPosition) {
         ref
@@ -85,6 +98,9 @@ class TimelineWidget extends HookConsumerWidget {
             )
             .saveFromDate(DateTime.now());
       }
+      expansibleController.addListener(() {
+        isMenuExpanded.value = expansibleController.isExpanded;
+      });
       return;
     }, []);
     if (!account.isGuest) {
@@ -160,17 +176,25 @@ class TimelineWidget extends HookConsumerWidget {
       (announcement) => announcement.display == AnnouncementDisplayType.banner,
     );
     final showLastViewedAt = useState(showTimelineLastViewedAt);
+    final theme = Theme.of(context);
 
     return Stack(
       alignment: Alignment.center,
       children: [
         Column(
           children: [
-            TimelineHeader(tabSettings: tabSettings),
+            SizeTransition(
+              sizeFactor: sizeFactorController,
+              child: TimelineHeader(
+                key: headerKey,
+                tabSettings: tabSettings,
+                controller: expansibleController,
+              ),
+            ),
             ...?bannerAnnouncements?.map(
               (announcement) => Container(
                 width: double.infinity,
-                color: Theme.of(context).colorScheme.primary,
+                color: theme.colorScheme.primary,
                 padding: const EdgeInsets.all(4.0),
                 child: InkWell(
                   onTap: () => context.push('/$account/announcements'),
@@ -178,9 +202,7 @@ class TimelineWidget extends HookConsumerWidget {
                     child: Text.rich(
                       TextSpan(
                         children: [
-                          if (announcement case AnnouncementsResponse(
-                            :final icon?,
-                          ))
+                          if (announcement.icon case final icon?)
                             WidgetSpan(
                               alignment: PlaceholderAlignment.middle,
                               child: Padding(
@@ -216,9 +238,7 @@ class TimelineWidget extends HookConsumerWidget {
                           ),
                         ],
                       ),
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.onPrimary,
-                      ),
+                      style: TextStyle(color: theme.colorScheme.onPrimary),
                       overflow: TextOverflow.ellipsis,
                       maxLines: 1,
                     ),
@@ -230,7 +250,7 @@ class TimelineWidget extends HookConsumerWidget {
               if (previousNoteId != null &&
                   lastViewedNoteId.compareTo(previousNoteId) < 0)
                 Container(
-                  color: Theme.of(context).colorScheme.secondaryContainer,
+                  color: theme.colorScheme.secondaryContainer,
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: InkWell(
                     onTap: () async {
@@ -310,7 +330,7 @@ class TimelineWidget extends HookConsumerWidget {
               else if (nextNoteId != null &&
                   lastViewedNoteId.compareTo(nextNoteId) < 0)
                 Container(
-                  color: Theme.of(context).colorScheme.secondaryContainer,
+                  color: theme.colorScheme.secondaryContainer,
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: InkWell(
                     onTap: () async {
@@ -347,10 +367,61 @@ class TimelineWidget extends HookConsumerWidget {
                 ),
             const Divider(height: 1.0),
             Expanded(
-              child: TimelineListView(
-                tabSettings: tabSettings,
-                focusPostForm: focusPostForm,
-                lastViewedAtKey: lastViewedAtKey,
+              child: NotificationListener<ScrollNotification>(
+                onNotification: (notification) {
+                  if (alwaysShowHeader || isMenuExpanded.value) {
+                    return false;
+                  }
+                  switch (notification) {
+                    case UserScrollNotification(:final direction):
+                      if (direction == ScrollDirection.idle) {
+                        final sizeFactor = sizeFactorController.value;
+                        switch (scrollDirection.value) {
+                          case ScrollDirection.forward when sizeFactor < 1.0:
+                            sizeFactorController.animateTo(
+                              1.0,
+                              curve: Curves.easeOut,
+                            );
+                          case ScrollDirection.reverse when sizeFactor > 0.0:
+                            sizeFactorController.animateTo(
+                              0.0,
+                              curve: Curves.easeOut,
+                            );
+                          default:
+                        }
+                      } else {
+                        sizeFactorController.stop();
+                      }
+                      scrollDirection.value = direction;
+                    case ScrollUpdateNotification(:final scrollDelta?) ||
+                        OverscrollNotification(overscroll: final scrollDelta):
+                      final sizeFactor = sizeFactorController.value;
+                      if ((scrollDirection.value, scrollDelta, sizeFactor)
+                          case (ScrollDirection.forward, < 0.0, < 1.0) ||
+                              (ScrollDirection.reverse, > 0.0, > 0.0)) {
+                        headerHeight.value ??=
+                            headerKey.currentContext?.size?.height;
+                        final height = headerHeight.value ?? 48.0;
+                        final currentHeight = height * sizeFactor;
+                        final nextHeight = currentHeight - scrollDelta;
+                        final clampedHeight = clampDouble(
+                          nextHeight,
+                          0.0,
+                          height,
+                        );
+                        sizeFactorController.value = clampedHeight / height;
+                        scrollController.position.correctBy(
+                          clampedHeight - currentHeight,
+                        );
+                      }
+                  }
+                  return false;
+                },
+                child: TimelineListView(
+                  tabSettings: tabSettings,
+                  focusPostForm: focusPostForm,
+                  lastViewedAtKey: lastViewedAtKey,
+                ),
               ),
             ),
           ],


### PR DESCRIPTION
Moved size management of the `TimelineHeader` to `TimelineWidget`, and changed to use `NotificationListener` to watch scroll and modify its height.

The scroll of the timeline is cancelled by `ScrollController.position.correctBy` while the header size changes. This aligns the actual gesture distance with the displacement of the timeline.