### PR TITLE
fix: replace InkWell with TextSpan for link MFM

### DIFF
--- a/lib/hook/force_accept_gesture_recognizer_hook.dart
+++ b/lib/hook/force_accept_gesture_recognizer_hook.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import '../util/force_accept_gesture_recognizer.dart';
+
+ForceAcceptGestureRecognizer useForceAcceptGestureRecognizer({
+  List<Object?>? keys,
+}) {
+  return use(_ForceAcceptGestureRecognizerHook(keys: keys));
+}
+
+class _ForceAcceptGestureRecognizerHook
+    extends Hook<ForceAcceptGestureRecognizer> {
+  const _ForceAcceptGestureRecognizerHook({super.keys});
+
+  @override
+  HookState<ForceAcceptGestureRecognizer, Hook<ForceAcceptGestureRecognizer>>
+  createState() => _ForceAcceptGestureRecognizerHookState();
+}
+
+class _ForceAcceptGestureRecognizerHookState
+    extends
+        HookState<
+          ForceAcceptGestureRecognizer,
+          _ForceAcceptGestureRecognizerHook
+        > {
+  final recognizer = ForceAcceptGestureRecognizer();
+
+  @override
+  ForceAcceptGestureRecognizer build(BuildContext context) => recognizer;
+
+  @override
+  void dispose() => recognizer.dispose();
+}

--- a/lib/hook/tap_gesture_recognizer_hook.dart
+++ b/lib/hook/tap_gesture_recognizer_hook.dart
@@ -16,11 +16,11 @@ class _TapGestureRecognizerHook extends Hook<TapGestureRecognizer> {
 
 class _TapGestureRecognizerHookState
     extends HookState<TapGestureRecognizer, _TapGestureRecognizerHook> {
-  final player = TapGestureRecognizer();
+  final recognizer = TapGestureRecognizer();
 
   @override
-  TapGestureRecognizer build(BuildContext context) => player;
+  TapGestureRecognizer build(BuildContext context) => recognizer;
 
   @override
-  void dispose() => player.dispose();
+  void dispose() => recognizer.dispose();
 }

--- a/lib/model/mfm_config.dart
+++ b/lib/model/mfm_config.dart
@@ -12,5 +12,6 @@ abstract class MfmConfig with _$MfmConfig {
     @Default(1.0) double opacity,
     TextAlign? align,
     @Default(0) int xNest,
+    int? linkId,
   }) = _MfmConfig;
 }

--- a/lib/model/mfm_config.freezed.dart
+++ b/lib/model/mfm_config.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MfmConfig {
 
- TextStyle get style; bool get disableNyaize; double get scale; double get opacity; TextAlign? get align; int get xNest;
+ TextStyle get style; bool get disableNyaize; double get scale; double get opacity; TextAlign? get align; int get xNest; int? get linkId;
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $MfmConfigCopyWith<MfmConfig> get copyWith => _$MfmConfigCopyWithImpl<MfmConfig>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align)&&(identical(other.xNest, xNest) || other.xNest == xNest));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align)&&(identical(other.xNest, xNest) || other.xNest == xNest)&&(identical(other.linkId, linkId) || other.linkId == linkId));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align,xNest);
+int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align,xNest,linkId);
 
 @override
 String toString() {
-  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align, xNest: $xNest)';
+  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align, xNest: $xNest, linkId: $linkId)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $MfmConfigCopyWith<$Res>  {
   factory $MfmConfigCopyWith(MfmConfig value, $Res Function(MfmConfig) _then) = _$MfmConfigCopyWithImpl;
 @useResult
 $Res call({
- TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align, int xNest
+ TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align, int xNest, int? linkId
 });
 
 
@@ -62,7 +62,7 @@ class _$MfmConfigCopyWithImpl<$Res>
 
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,Object? xNest = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,Object? xNest = null,Object? linkId = freezed,}) {
   return _then(_self.copyWith(
 style: null == style ? _self.style : style // ignore: cast_nullable_to_non_nullable
 as TextStyle,disableNyaize: null == disableNyaize ? _self.disableNyaize : disableNyaize // ignore: cast_nullable_to_non_nullable
@@ -70,7 +70,8 @@ as bool,scale: null == scale ? _self.scale : scale // ignore: cast_nullable_to_n
 as double,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
 as double,align: freezed == align ? _self.align : align // ignore: cast_nullable_to_non_nullable
 as TextAlign?,xNest: null == xNest ? _self.xNest : xNest // ignore: cast_nullable_to_non_nullable
-as int,
+as int,linkId: freezed == linkId ? _self.linkId : linkId // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -155,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( TextStyle style,  bool disableNyaize,  double scale,  double opacity,  TextAlign? align,  int xNest)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( TextStyle style,  bool disableNyaize,  double scale,  double opacity,  TextAlign? align,  int xNest,  int? linkId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MfmConfig() when $default != null:
-return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.align,_that.xNest);case _:
+return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.align,_that.xNest,_that.linkId);case _:
   return orElse();
 
 }
@@ -176,10 +177,10 @@ return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( TextStyle style,  bool disableNyaize,  double scale,  double opacity,  TextAlign? align,  int xNest)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( TextStyle style,  bool disableNyaize,  double scale,  double opacity,  TextAlign? align,  int xNest,  int? linkId)  $default,) {final _that = this;
 switch (_that) {
 case _MfmConfig():
-return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.align,_that.xNest);case _:
+return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.align,_that.xNest,_that.linkId);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -196,10 +197,10 @@ return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( TextStyle style,  bool disableNyaize,  double scale,  double opacity,  TextAlign? align,  int xNest)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( TextStyle style,  bool disableNyaize,  double scale,  double opacity,  TextAlign? align,  int xNest,  int? linkId)?  $default,) {final _that = this;
 switch (_that) {
 case _MfmConfig() when $default != null:
-return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.align,_that.xNest);case _:
+return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.align,_that.xNest,_that.linkId);case _:
   return null;
 
 }
@@ -211,7 +212,7 @@ return $default(_that.style,_that.disableNyaize,_that.scale,_that.opacity,_that.
 
 
 class _MfmConfig implements MfmConfig {
-  const _MfmConfig({required this.style, this.disableNyaize = false, this.scale = 1.0, this.opacity = 1.0, this.align, this.xNest = 0});
+  const _MfmConfig({required this.style, this.disableNyaize = false, this.scale = 1.0, this.opacity = 1.0, this.align, this.xNest = 0, this.linkId});
   
 
 @override final  TextStyle style;
@@ -220,6 +221,7 @@ class _MfmConfig implements MfmConfig {
 @override@JsonKey() final  double opacity;
 @override final  TextAlign? align;
 @override@JsonKey() final  int xNest;
+@override final  int? linkId;
 
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
@@ -231,16 +233,16 @@ _$MfmConfigCopyWith<_MfmConfig> get copyWith => __$MfmConfigCopyWithImpl<_MfmCon
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align)&&(identical(other.xNest, xNest) || other.xNest == xNest));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MfmConfig&&(identical(other.style, style) || other.style == style)&&(identical(other.disableNyaize, disableNyaize) || other.disableNyaize == disableNyaize)&&(identical(other.scale, scale) || other.scale == scale)&&(identical(other.opacity, opacity) || other.opacity == opacity)&&(identical(other.align, align) || other.align == align)&&(identical(other.xNest, xNest) || other.xNest == xNest)&&(identical(other.linkId, linkId) || other.linkId == linkId));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align,xNest);
+int get hashCode => Object.hash(runtimeType,style,disableNyaize,scale,opacity,align,xNest,linkId);
 
 @override
 String toString() {
-  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align, xNest: $xNest)';
+  return 'MfmConfig(style: $style, disableNyaize: $disableNyaize, scale: $scale, opacity: $opacity, align: $align, xNest: $xNest, linkId: $linkId)';
 }
 
 
@@ -251,7 +253,7 @@ abstract mixin class _$MfmConfigCopyWith<$Res> implements $MfmConfigCopyWith<$Re
   factory _$MfmConfigCopyWith(_MfmConfig value, $Res Function(_MfmConfig) _then) = __$MfmConfigCopyWithImpl;
 @override @useResult
 $Res call({
- TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align, int xNest
+ TextStyle style, bool disableNyaize, double scale, double opacity, TextAlign? align, int xNest, int? linkId
 });
 
 
@@ -268,7 +270,7 @@ class __$MfmConfigCopyWithImpl<$Res>
 
 /// Create a copy of MfmConfig
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,Object? xNest = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? style = null,Object? disableNyaize = null,Object? scale = null,Object? opacity = null,Object? align = freezed,Object? xNest = null,Object? linkId = freezed,}) {
   return _then(_MfmConfig(
 style: null == style ? _self.style : style // ignore: cast_nullable_to_non_nullable
 as TextStyle,disableNyaize: null == disableNyaize ? _self.disableNyaize : disableNyaize // ignore: cast_nullable_to_non_nullable
@@ -276,7 +278,8 @@ as bool,scale: null == scale ? _self.scale : scale // ignore: cast_nullable_to_n
 as double,opacity: null == opacity ? _self.opacity : opacity // ignore: cast_nullable_to_non_nullable
 as double,align: freezed == align ? _self.align : align // ignore: cast_nullable_to_non_nullable
 as TextAlign?,xNest: null == xNest ? _self.xNest : xNest // ignore: cast_nullable_to_non_nullable
-as int,
+as int,linkId: freezed == linkId ? _self.linkId : linkId // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/lib/util/force_accept_gesture_recognizer.dart
+++ b/lib/util/force_accept_gesture_recognizer.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/gestures.dart';
+
+class ForceAcceptGestureRecognizer extends LongPressGestureRecognizer {
+  GestureLongPressUpCallback? _onLongPressUp;
+
+  @override
+  set onLongPressUp(GestureLongPressUpCallback? onLongPressUp) =>
+      _onLongPressUp = onLongPressUp;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    super.addAllowedPointer(event);
+    resolve(GestureDisposition.accepted);
+  }
+
+  @override
+  void handlePrimaryPointer(PointerEvent event) {
+    if (event is PointerUpEvent) {
+      _onLongPressUp?.call();
+    }
+    super.handlePrimaryPointer(event);
+  }
+}

--- a/lib/util/get_link_background_color.dart
+++ b/lib/util/get_link_background_color.dart
@@ -1,0 +1,8 @@
+import 'dart:ui';
+
+Color getLinkBackgroundColor(Brightness brightness, double animationValue) {
+  return switch (brightness) {
+    Brightness.light => Color.fromRGBO(0xC3, 0xC3, 0xC3, 0.64 * animationValue),
+    Brightness.dark => Color.fromRGBO(0xCC, 0xCC, 0xCC, 0.44 * animationValue),
+  };
+}

--- a/lib/view/dialog/paste_emojis_dialog.dart
+++ b/lib/view/dialog/paste_emojis_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -5,14 +6,16 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:json5/json5.dart';
 
 import '../../constant/shortcuts.dart';
-import '../../extension/string_extension.dart';
-import '../../hook/tap_gesture_recognizer_hook.dart';
+import '../../hook/force_accept_gesture_recognizer_hook.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/api/endpoints_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
 import '../../provider/server_url_notifier_provider.dart';
+import '../../util/get_link_background_color.dart';
 import '../../util/launch_url.dart';
+import '../widget/url_sheet.dart';
+import '../widget/url_widget.dart';
 import 'message_dialog.dart';
 
 const _sampleEmojis = ['👍', '❤️', ':misskey:', ':ai_yay@.:'];
@@ -50,30 +53,14 @@ class PasteEmojisDialog extends HookConsumerWidget {
     final emojiPaletteUrl = serverUrl.replace(
       pathSegments: ['settings', 'emoji-palette'],
     );
-    final recognizer = useTapGestureRecognizer();
     final controller = useTextEditingController();
-    final colors = ref.watch(
-      misskeyColorsProvider(Theme.of(context).brightness),
-    );
 
     return AlertDialog(
       title: Text(t.aria.paste),
       content: Column(
         children: [
-          Text.rich(
-            t.aria.pastePinnedEmojisDescription(
-              url: TextSpan(
-                text: (useEmojiPalette ? emojiPaletteUrl : registryUrl)
-                    .toString()
-                    .breakAll,
-                style: TextStyle(color: colors.link),
-                recognizer: recognizer
-                  ..onTap = () => launchUrl(
-                    ref,
-                    useEmojiPalette ? emojiPaletteUrl : registryUrl,
-                  ),
-              ),
-            ),
+          _PastePinnedEmojisDescription(
+            url: useEmojiPalette ? emojiPaletteUrl : registryUrl,
           ),
           const SizedBox(height: 12.0),
           Shortcuts(
@@ -122,6 +109,123 @@ class PasteEmojisDialog extends HookConsumerWidget {
         ),
       ],
       scrollable: true,
+    );
+  }
+}
+
+class _PastePinnedEmojisDescription extends HookConsumerWidget {
+  const _PastePinnedEmojisDescription({required this.url});
+
+  final Uri url;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final url = useMemoized(() => parseDisplayUrl(this.url), [this.url]);
+    final controller = useAnimationController(
+      duration: kLongPressTimeout - kPressTimeout,
+    );
+    final animationValue = useAnimation(controller);
+    final recognizer = useForceAcceptGestureRecognizer();
+    useEffect(() {
+      recognizer
+        ..onLongPressDown = (_) {
+          controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+        }
+        ..onLongPressUp = () {
+          Feedback.forTap(context);
+          launchUrl(ref, this.url);
+          controller.animateTo(0.0, curve: Curves.easeOut);
+        }
+        ..onLongPressCancel = () {
+          controller.animateTo(0.0, curve: Curves.easeOut);
+        }
+        ..onLongPress = () {
+          Feedback.forLongPress(context);
+          showModalBottomSheet<void>(
+            context: context,
+            builder: (context) => UrlSheet(url: this.url.toString()),
+          );
+          controller.animateTo(0.0, curve: Curves.easeOut);
+        };
+      return;
+    });
+    final brightness = Theme.brightnessOf(context);
+    final colors = ref.watch(misskeyColorsProvider(brightness));
+    final style = DefaultTextStyle.of(context).style;
+
+    return Text.rich(
+      t.aria.pastePinnedEmojisDescription(
+        url: TextSpan(
+          children: [
+            buildUrlSpan(
+              url: url,
+              color: colors.link,
+              textSpanBuilder: ({text, style}) => TextSpan(
+                text: text,
+                style: style,
+                recognizer: recognizer,
+                onEnter: (_) {
+                  if (!controller.isAnimating && controller.value < 1.0) {
+                    controller.value = 0.25;
+                  }
+                },
+                onExit: (_) {
+                  if (!controller.isAnimating && controller.value < 1.0) {
+                    controller.value = 0.0;
+                  }
+                },
+              ),
+            ),
+            WidgetSpan(
+              child: InkWell(
+                onTapDown: (_) {
+                  controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+                },
+                onTapUp: (_) {
+                  Feedback.forTap(context);
+                  launchUrl(ref, this.url);
+                  controller.animateTo(0.0, curve: Curves.easeOut);
+                },
+                onTapCancel: () {
+                  controller.animateTo(0.0, curve: Curves.easeOut);
+                },
+                onLongPress: () {
+                  Feedback.forLongPress(context);
+                  showModalBottomSheet<void>(
+                    context: context,
+                    builder: (context) => UrlSheet(url: this.url.toString()),
+                  );
+                  controller.animateTo(0.0, curve: Curves.easeOut);
+                },
+                onHover: (value) {
+                  if (!controller.isAnimating && controller.value < 1.0) {
+                    if (value) {
+                      controller.value = 0.25;
+                    } else {
+                      controller.value = 0.0;
+                    }
+                  }
+                },
+                splashFactory: NoSplash.splashFactory,
+                overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+                mouseCursor: SystemMouseCursors.click,
+                child: AbsorbPointer(
+                  child: Icon(
+                    Icons.open_in_new,
+                    color: colors.link,
+                    size: style.fontSize,
+                  ),
+                ),
+              ),
+            ),
+          ],
+          style: TextStyle(
+            color: colors.link,
+            backgroundColor: getLinkBackgroundColor(brightness, animationValue),
+          ),
+          recognizer: recognizer,
+        ),
+      ),
     );
   }
 }

--- a/lib/view/dialog/sw_register_dialog.dart
+++ b/lib/view/dialog/sw_register_dialog.dart
@@ -14,9 +14,9 @@ import '../../constant/shortcuts.dart';
 import '../../i18n/strings.g.dart';
 import '../../model/account.dart';
 import '../../provider/general_settings_notifier_provider.dart';
-import '../../provider/misskey_colors_provider.dart';
 import '../../provider/server_url_notifier_provider.dart';
 import '../../provider/user_ids_notifier_provider.dart';
+import '../widget/link_widget.dart';
 import '../widget/mfm.dart';
 import '../widget/mfm/code.dart';
 import '../widget/url_sheet.dart';
@@ -42,9 +42,6 @@ class SwRegisterDialog extends HookConsumerWidget {
       ),
     );
     final responseText = useState('');
-    final colors = ref.watch(
-      misskeyColorsProvider(Theme.of(context).brightness),
-    );
 
     return AlertDialog(
       title: Text(t.misskey.subscribePushNotification),
@@ -52,27 +49,15 @@ class SwRegisterDialog extends HookConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text.rich(
-            t.aria.openScratchpadAndRunCode(
-              scratchpad: WidgetSpan(
-                alignment: PlaceholderAlignment.baseline,
-                baseline: TextBaseline.alphabetic,
-                child: InkWell(
-                  onTap: () => launchUrl(
-                    scratchPadUrl,
-                    mode: LaunchMode.externalApplication,
-                  ),
-                  onLongPress: () => showModalBottomSheet<void>(
-                    context: context,
-                    builder: (context) =>
-                        UrlSheet(url: scratchPadUrl.toString()),
-                  ),
-                  child: Text(
-                    t.misskey.scratchpad,
-                    style: TextStyle(color: colors.link),
-                  ),
-                ),
-              ),
+          LinkWidget(
+            text: t.misskey.scratchpad,
+            builder: (context, span) =>
+                Text.rich(t.aria.openScratchpadAndRunCode(scratchpad: span)),
+            onTap: () =>
+                launchUrl(scratchPadUrl, mode: LaunchMode.externalApplication),
+            onLongPress: () => showModalBottomSheet<void>(
+              context: context,
+              builder: (context) => UrlSheet(url: scratchPadUrl.toString()),
             ),
           ),
           const SizedBox(height: 8.0),

--- a/lib/view/page/about_aria_page.dart
+++ b/lib/view/page/about_aria_page.dart
@@ -1,5 +1,6 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
@@ -11,7 +12,9 @@ import '../../gen/assets.gen.dart';
 import '../../i18n/strings.g.dart';
 import '../../provider/misskey_colors_provider.dart';
 import '../../util/copy_text.dart';
+import '../../util/force_accept_gesture_recognizer.dart';
 import '../../util/future_with_dialog.dart';
+import '../../util/get_link_background_color.dart';
 import '../../util/launch_url.dart';
 import '../widget/url_sheet.dart';
 
@@ -31,6 +34,96 @@ class AboutAriaPage extends HookConsumerWidget {
       _ => (null, null),
     };
     final deviceInfo = useMemoized(() => DeviceInfoPlugin().deviceInfo);
+    final controller = useAnimationController(
+      duration: kLongPressTimeout - kPressTimeout,
+    );
+    final animationValue = useAnimation(controller);
+    final activeLinkId = useState<String?>(null);
+    final recognizers = useMemoized(() {
+      GestureRecognizer registerRecognizer({
+        required String linkId,
+        void Function()? onTap,
+        void Function()? onLongPress,
+      }) {
+        return ForceAcceptGestureRecognizer()
+          ..onLongPressDown = (_) {
+            activeLinkId.value = linkId;
+            controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+          }
+          ..onLongPressUp = () {
+            if (onTap case final onTap?) {
+              Feedback.forTap(context);
+              onTap();
+            }
+            controller.animateTo(0.0, curve: Curves.easeOut);
+          }
+          ..onLongPressCancel = () {
+            controller.animateTo(0.0, curve: Curves.easeOut);
+          }
+          ..onLongPress = () {
+            if (onLongPress case final onLongPress?) {
+              Feedback.forLongPress(context);
+              onLongPress();
+            }
+            controller.animateTo(0.0, curve: Curves.easeOut);
+          };
+      }
+
+      return {
+        'miria': registerRecognizer(
+          linkId: 'miria',
+          onTap: () => launchUrl(
+            ref,
+            Uri.https('github.com', 'shiosyakeyakini-info/miria'),
+          ),
+          onLongPress: () => showModalBottomSheet<void>(
+            context: context,
+            builder: (context) => const UrlSheet(
+              url: 'https://github.com/shiosyakeyakini-info/miria',
+            ),
+          ),
+        ),
+        'misskey': registerRecognizer(
+          linkId: 'misskey',
+          onTap: () =>
+              launchUrl(ref, Uri.https('github.com', 'misskey-dev/misskey')),
+          onLongPress: () => showModalBottomSheet<void>(
+            context: context,
+            builder: (context) =>
+                const UrlSheet(url: 'https://github.com/misskey-dev/misskey'),
+          ),
+        ),
+        'sevenc_nanashi': registerRecognizer(
+          linkId: 'sevenc_nanashi',
+          onTap: () => context.push('/voskey.icalo.net/users/9d8sfcv0qj'),
+          onLongPress: () => showModalBottomSheet<void>(
+            context: context,
+            builder: (context) =>
+                const UrlSheet(url: 'https://voskey.icalo.net/@sevenc_nanashi'),
+          ),
+        ),
+        'cc_by': registerRecognizer(
+          linkId: 'cc_by',
+          onTap: () => launchUrl(
+            ref,
+            Uri.https('creativecommons.org', 'licenses/by/4.0'),
+          ),
+          onLongPress: () => showModalBottomSheet<void>(
+            context: context,
+            builder: (context) => const UrlSheet(
+              url: 'https://creativecommons.org/licenses/by/4.0',
+            ),
+          ),
+        ),
+      };
+    });
+    useEffect(() {
+      return () {
+        for (final recognizer in recognizers.values) {
+          recognizer.dispose();
+        }
+      };
+    }, []);
     final colors = ref.watch(
       misskeyColorsProvider(Theme.of(context).brightness),
     );
@@ -81,96 +174,114 @@ class AboutAriaPage extends HookConsumerWidget {
                 TextSpan(
                   children: [
                     t.aria.acknowledgements(
-                      miria: WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: InkWell(
-                          onTap: () => launchUrl(
-                            ref,
-                            Uri.https(
-                              'github.com',
-                              'shiosyakeyakini-info/miria',
-                            ),
-                          ),
-                          onLongPress: () => showModalBottomSheet<void>(
-                            context: context,
-                            builder: (context) => const UrlSheet(
-                              url:
-                                  'https://github.com/shiosyakeyakini-info/miria',
-                            ),
-                          ),
-                          child: Text(
-                            'Miria',
-                            style: TextStyle(color: colors.link),
-                            textScaler: TextScaler.noScaling,
-                          ),
+                      miria: TextSpan(
+                        text: 'Miria',
+                        style: TextStyle(
+                          color: colors.link,
+                          backgroundColor: activeLinkId.value == 'miria'
+                              ? getLinkBackgroundColor(
+                                  Theme.brightnessOf(context),
+                                  animationValue,
+                                )
+                              : null,
                         ),
+                        recognizer: recognizers['miria'],
+                        onEnter: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            activeLinkId.value = 'miria';
+                            controller.value = 0.25;
+                          }
+                        },
+                        onExit: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            controller.value = 0.0;
+                          }
+                        },
+                        mouseCursor: SystemMouseCursors.click,
                       ),
-                      misskey: WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: InkWell(
-                          onTap: () => launchUrl(
-                            ref,
-                            Uri.https('github.com', 'misskey-dev/misskey'),
-                          ),
-                          onLongPress: () => showModalBottomSheet<void>(
-                            context: context,
-                            builder: (context) => const UrlSheet(
-                              url: 'https://github.com/misskey-dev/misskey',
-                            ),
-                          ),
-                          child: Text(
-                            'Misskey',
-                            style: TextStyle(color: colors.link),
-                            textScaler: TextScaler.noScaling,
-                          ),
+                      misskey: TextSpan(
+                        text: 'Misskey',
+                        style: TextStyle(
+                          color: colors.link,
+                          backgroundColor: activeLinkId.value == 'misskey'
+                              ? getLinkBackgroundColor(
+                                  Theme.brightnessOf(context),
+                                  animationValue,
+                                )
+                              : null,
                         ),
+                        recognizer: recognizers['misskey'],
+                        onEnter: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            activeLinkId.value = 'misskey';
+                            controller.value = 0.25;
+                          }
+                        },
+                        onExit: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            controller.value = 0.0;
+                          }
+                        },
                       ),
                     ),
                     const TextSpan(text: '\n\n'),
                     t.aria.iconAttribution(
-                      sevenc_nanashi: WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: InkWell(
-                          onTap: () => context.push(
-                            '/voskey.icalo.net/users/9d8sfcv0qj',
-                          ),
-                          onLongPress: () => showModalBottomSheet<void>(
-                            context: context,
-                            builder: (context) => const UrlSheet(
-                              url: 'https://voskey.icalo.net/@sevenc_nanashi',
-                            ),
-                          ),
-                          child: Text(
-                            '@sevenc_nanashi@voskey.icalo.net',
-                            style: TextStyle(color: colors.mention),
-                            textScaler: TextScaler.noScaling,
-                          ),
+                      sevenc_nanashi: TextSpan(
+                        text: '@sevenc_nanashi@voskey.icalo.net',
+                        style: TextStyle(
+                          color: colors.mention,
+                          backgroundColor:
+                              activeLinkId.value == 'sevenc_nanashi'
+                              ? getLinkBackgroundColor(
+                                  Theme.brightnessOf(context),
+                                  animationValue,
+                                )
+                              : null,
                         ),
+                        recognizer: recognizers['sevenc_nanashi'],
+                        onEnter: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            activeLinkId.value = 'sevenc_nanashi';
+                            controller.value = 0.25;
+                          }
+                        },
+                        onExit: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            controller.value = 0.0;
+                          }
+                        },
                       ),
-                      cc_by: WidgetSpan(
-                        alignment: PlaceholderAlignment.baseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: InkWell(
-                          onTap: () => launchUrl(
-                            ref,
-                            Uri.https('creativecommons.org', 'licenses/by/4.0'),
-                          ),
-                          onLongPress: () => showModalBottomSheet<void>(
-                            context: context,
-                            builder: (context) => const UrlSheet(
-                              url:
-                                  'https://creativecommons.org/licenses/by/4.0',
-                            ),
-                          ),
-                          child: Text(
-                            'CC-BY 4.0',
-                            style: TextStyle(color: colors.link),
-                            textScaler: TextScaler.noScaling,
-                          ),
+                      cc_by: TextSpan(
+                        text: 'CC-BY 4.0',
+                        style: TextStyle(
+                          color: colors.link,
+                          backgroundColor: activeLinkId.value == 'cc_by'
+                              ? getLinkBackgroundColor(
+                                  Theme.brightnessOf(context),
+                                  animationValue,
+                                )
+                              : null,
                         ),
+                        recognizer: recognizers['cc_by'],
+                        onEnter: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            activeLinkId.value = 'cc_by';
+                            controller.value = 0.25;
+                          }
+                        },
+                        onExit: (_) {
+                          if (!controller.isAnimating &&
+                              controller.value < 1.0) {
+                            controller.value = 0.0;
+                          }
+                        },
                       ),
                     ),
                   ],
@@ -188,6 +299,12 @@ class AboutAriaPage extends HookConsumerWidget {
                 title: Text(t.misskey.aboutMisskey_.source),
                 onTap: () =>
                     launchUrl(ref, Uri.https('github.com', 'poppingmoon/aria')),
+                onLongPress: () => showModalBottomSheet<void>(
+                  context: context,
+                  builder: (context) => const UrlSheet(
+                    url: 'https://github.com/poppingmoon/aria',
+                  ),
+                ),
               ),
             ),
           ),
@@ -199,6 +316,11 @@ class AboutAriaPage extends HookConsumerWidget {
                 leading: const Icon(Icons.alternate_email),
                 title: Text(t.misskey.contact),
                 onTap: () => context.push('/misskey.io/users/9qaqpdbgn1nk03sc'),
+                onLongPress: () => showModalBottomSheet<void>(
+                  context: context,
+                  builder: (context) =>
+                      const UrlSheet(url: 'https://misskey.io/@aria_app'),
+                ),
               ),
             ),
           ),

--- a/lib/view/page/settings/languages_page.dart
+++ b/lib/view/page/settings/languages_page.dart
@@ -10,7 +10,9 @@ import '../../../provider/general_settings_notifier_provider.dart';
 import '../../../provider/misskey_colors_provider.dart';
 import '../../../util/launch_url.dart';
 import '../../widget/general_settings_scaffold.dart';
+import '../../widget/link_widget.dart';
 import '../../widget/mfm.dart';
+import '../../widget/url_sheet.dart';
 
 class LanguagesPage extends ConsumerWidget {
   const LanguagesPage({super.key});
@@ -66,47 +68,23 @@ class LanguagesPage extends ConsumerWidget {
                     margin: EdgeInsets.zero,
                     child: Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: Text.rich(
-                        t.aria.i18nInfo(
-                          link: WidgetSpan(
-                            alignment: PlaceholderAlignment.baseline,
-                            baseline: TextBaseline.alphabetic,
-                            child: InkWell(
-                              onTap: () => launchUrl(
-                                ref,
-                                Uri.https(
-                                  'crowdin.com',
-                                  'project/aria-for-misskey',
-                                ),
-                              ),
-                              child: Text.rich(
-                                TextSpan(
-                                  children: [
-                                    TextSpan(
-                                      text: 'Crowdin',
-                                      style: TextStyle(color: colors.link),
-                                    ),
-                                    WidgetSpan(
-                                      child: Builder(
-                                        builder: (context) => Icon(
-                                          Icons.open_in_new,
-                                          color: colors.link,
-                                          size: DefaultTextStyle.of(
-                                            context,
-                                          ).style.fontSize,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                textAlign: TextAlign.center,
-                                textScaler: TextScaler.noScaling,
-                              ),
-                            ),
+                      child: LinkWidget(
+                        text: 'Crowdin',
+                        builder: (context, span) => Text.rich(
+                          t.aria.i18nInfo(link: span),
+                          style: TextStyle(
+                            color: theme.colorScheme.onSecondaryContainer,
                           ),
                         ),
-                        style: TextStyle(
-                          color: theme.colorScheme.onSecondaryContainer,
+                        onTap: () => launchUrl(
+                          ref,
+                          Uri.https('crowdin.com', 'project/aria-for-misskey'),
+                        ),
+                        onLongPress: () => showModalBottomSheet<void>(
+                          context: context,
+                          builder: (context) => const UrlSheet(
+                            url: 'https://crowdin.com/project/aria-for-misskey',
+                          ),
                         ),
                       ),
                     ),

--- a/lib/view/page/settings/profile_page.dart
+++ b/lib/view/page/settings/profile_page.dart
@@ -22,7 +22,6 @@ import '../../../provider/cache_manager_provider.dart';
 import '../../../provider/general_settings_notifier_provider.dart';
 import '../../../provider/misskey_colors_provider.dart';
 import '../../../util/future_with_dialog.dart';
-import '../../../util/navigate.dart';
 import '../../dialog/confirmation_dialog.dart';
 import '../../dialog/field_dialog.dart';
 import '../../dialog/radio_dialog.dart';
@@ -32,7 +31,6 @@ import '../../widget/file_picker_sheet.dart';
 import '../../widget/key_value_widget.dart';
 import '../../widget/mfm.dart';
 import '../../widget/reorderable_drag_start_listener_wrapper.dart';
-import '../../widget/url_widget.dart';
 import '../../widget/user_avatar.dart';
 import '../../widget/user_banner.dart';
 
@@ -169,8 +167,9 @@ class ProfilePage extends HookConsumerWidget {
       );
       return;
     }, []);
-    final theme = Theme.of(context);
-    final colors = ref.watch(misskeyColorsProvider(theme.brightness));
+    final colors = ref.watch(
+      misskeyColorsProvider(Theme.brightnessOf(context)),
+    );
 
     return AccountSettingsScaffold(
       account: account,
@@ -389,7 +388,7 @@ class ProfilePage extends HookConsumerWidget {
                   margin: const EdgeInsets.symmetric(horizontal: 8.0),
                   width: maxContentWidth,
                   child: Card(
-                    color: theme.colorScheme.surface,
+                    color: colors.panel,
                     margin: EdgeInsets.zero,
                     child: Padding(
                       padding: const EdgeInsets.all(8.0),
@@ -495,7 +494,7 @@ class ProfilePage extends HookConsumerWidget {
                       );
                     }
                   },
-                  tileColor: theme.colorScheme.surface,
+                  tileColor: colors.panel,
                 ),
               ),
             ),
@@ -545,7 +544,7 @@ class ProfilePage extends HookConsumerWidget {
                       );
                     }
                   },
-                  tileColor: theme.colorScheme.surface,
+                  tileColor: colors.panel,
                 ),
               ),
             ),
@@ -556,8 +555,8 @@ class ProfilePage extends HookConsumerWidget {
                 width: maxContentWidth,
                 child: ExpansionTile(
                   title: Text(t.misskey.profile_.metadataEdit),
-                  backgroundColor: theme.colorScheme.surface,
-                  collapsedBackgroundColor: theme.colorScheme.surface,
+                  backgroundColor: colors.panel,
+                  collapsedBackgroundColor: colors.panel,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(6.0),
                   ),
@@ -636,21 +635,35 @@ class ProfilePage extends HookConsumerWidget {
                                   flex: 7,
                                   child: KeyValueWidget(
                                     label: t.misskey.profile_.metadataContent,
-                                    child: i.verifiedLinks.contains(value)
-                                        ? UrlWidget(
-                                            url: value,
-                                            verified: true,
-                                            onTap: () =>
-                                                navigate(ref, account, value),
-                                            style: TextStyle(
-                                              color: colors.link,
-                                            ),
-                                          )
-                                        : Mfm(
-                                            account: account,
-                                            text: value,
-                                            author: i,
-                                          ),
+                                    child: Mfm(
+                                      account: account,
+                                      text: value,
+                                      trailingSpans:
+                                          i.verifiedLinks.contains(value)
+                                          ? [
+                                              const WidgetSpan(
+                                                child: SizedBox(width: 2.0),
+                                              ),
+                                              WidgetSpan(
+                                                child: Tooltip(
+                                                  message:
+                                                      t.misskey.verifiedLink,
+                                                  child: Builder(
+                                                    builder: (context) => Icon(
+                                                      Icons
+                                                          .check_circle_outline,
+                                                      color: colors.success,
+                                                      size: DefaultTextStyle.of(
+                                                        context,
+                                                      ).style.fontSize,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                            ]
+                                          : null,
+                                      author: i,
+                                    ),
                                   ),
                                 ),
                               ],
@@ -755,8 +768,8 @@ class ProfilePage extends HookConsumerWidget {
                 width: maxContentWidth,
                 child: ExpansionTile(
                   title: Text(t.misskey.advancedSettings),
-                  backgroundColor: theme.colorScheme.surface,
-                  collapsedBackgroundColor: theme.colorScheme.surface,
+                  backgroundColor: colors.panel,
+                  collapsedBackgroundColor: colors.panel,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(6.0),
                   ),

--- a/lib/view/page/user/user_home.dart
+++ b/lib/view/page/user/user_home.dart
@@ -34,7 +34,6 @@ import '../../widget/shake_widget.dart';
 import '../../widget/skeb_status_widget.dart';
 import '../../widget/time_widget.dart';
 import '../../widget/url_sheet.dart';
-import '../../widget/url_widget.dart';
 import '../../widget/user_avatar.dart';
 import '../../widget/user_banner.dart';
 import '../../widget/username_widget.dart';
@@ -669,30 +668,30 @@ class _UserHome extends HookConsumerWidget {
                                 ),
                                 Padding(
                                   padding: const EdgeInsets.all(4.0),
-                                  child:
-                                      user.verifiedLinks.contains(field.value)
-                                      ? Align(
-                                          alignment:
-                                              AlignmentDirectional.centerStart,
-                                          child: UrlWidget(
-                                            url: field.value,
-                                            verified: true,
-                                            onTap: () => navigate(
-                                              ref,
-                                              account,
-                                              field.value,
+                                  child: Mfm(
+                                    account: account,
+                                    text: field.value,
+                                    trailingSpans:
+                                        user.verifiedLinks.contains(field.value)
+                                        ? [
+                                            const WidgetSpan(
+                                              child: SizedBox(width: 2.0),
                                             ),
-                                            style: TextStyle(
-                                              color: colors.link,
+                                            WidgetSpan(
+                                              child: Tooltip(
+                                                message: t.misskey.verifiedLink,
+                                                child: Icon(
+                                                  Icons.check_circle_outline,
+                                                  color: colors.success,
+                                                  size: style.fontSize,
+                                                ),
+                                              ),
                                             ),
-                                          ),
-                                        )
-                                      : Mfm(
-                                          account: account,
-                                          text: field.value,
-                                          emojis: user.emojis,
-                                          author: user,
-                                        ),
+                                          ]
+                                        : null,
+                                    emojis: user.emojis,
+                                    author: user,
+                                  ),
                                 ),
                               ],
                             ),

--- a/lib/view/widget/link_widget.dart
+++ b/lib/view/widget/link_widget.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../hook/force_accept_gesture_recognizer_hook.dart';
+import '../../provider/misskey_colors_provider.dart';
+import '../../util/get_link_background_color.dart';
+
+class LinkWidget extends HookConsumerWidget {
+  const LinkWidget({
+    super.key,
+    required this.text,
+    required this.builder,
+    this.onTap,
+    this.onLongPress,
+  });
+
+  final String text;
+  final Widget Function(BuildContext context, TextSpan span) builder;
+  final void Function()? onTap;
+  final void Function()? onLongPress;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useAnimationController(
+      duration: kLongPressTimeout - kPressTimeout,
+    );
+    final animationValue = useAnimation(controller);
+    final recognizer = useForceAcceptGestureRecognizer();
+    useEffect(() {
+      recognizer
+        ..onLongPressDown = (_) {
+          controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+        }
+        ..onLongPressUp = () {
+          if (onTap case final onTap?) {
+            Feedback.forTap(context);
+            onTap();
+          }
+          controller.animateTo(0.0, curve: Curves.easeOut);
+        }
+        ..onLongPressCancel = () {
+          controller.animateTo(0.0, curve: Curves.easeOut);
+        }
+        ..onLongPress = () {
+          if (onLongPress case final onLongPress?) {
+            Feedback.forLongPress(context);
+            onLongPress();
+          }
+          controller.animateTo(0.0, curve: Curves.easeOut);
+        };
+      return;
+    }, []);
+    final brightness = Theme.brightnessOf(context);
+    final colors = ref.watch(misskeyColorsProvider(brightness));
+    final style = DefaultTextStyle.of(context).style;
+
+    return builder(
+      context,
+      TextSpan(
+        children: [
+          TextSpan(
+            text: text,
+            recognizer: recognizer,
+            onEnter: (_) {
+              if (!controller.isAnimating && controller.value < 1.0) {
+                controller.value = 0.25;
+              }
+            },
+            onExit: (_) {
+              if (!controller.isAnimating && controller.value < 1.0) {
+                controller.value = 0.0;
+              }
+            },
+          ),
+          WidgetSpan(
+            child: InkWell(
+              onTapDown: (_) {
+                controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+              },
+              onTapUp: (_) {
+                if (onTap case final onTap?) {
+                  Feedback.forTap(context);
+                  onTap();
+                }
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              },
+              onTapCancel: () {
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              },
+              onLongPress: () {
+                if (onLongPress case final onLongPress?) {
+                  Feedback.forLongPress(context);
+                  onLongPress();
+                }
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              },
+              onHover: (value) {
+                if (!controller.isAnimating && controller.value < 1.0) {
+                  if (value) {
+                    controller.value = 0.25;
+                  } else {
+                    controller.value = 0.0;
+                  }
+                }
+              },
+              splashFactory: NoSplash.splashFactory,
+              overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+              mouseCursor: SystemMouseCursors.click,
+              child: AbsorbPointer(
+                child: Icon(
+                  Icons.open_in_new,
+                  color: colors.link,
+                  size: style.fontSize,
+                ),
+              ),
+            ),
+          ),
+        ],
+        style: TextStyle(
+          color: colors.link,
+          backgroundColor: getLinkBackgroundColor(brightness, animationValue),
+        ),
+        recognizer: recognizer,
+      ),
+    );
+  }
+}

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -1,8 +1,9 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' hide Border;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' as material show Border;
+import 'package:flutter/material.dart' hide Border;
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:go_router/go_router.dart';
@@ -12,6 +13,7 @@ import 'package:mfm_parser/mfm_parser.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 
 import '../../constant/fonts.dart';
+import '../../extension/list_mfm_node_extension.dart';
 import '../../extension/text_style_extension.dart';
 import '../../gen/fonts.gen.dart';
 import '../../model/account.dart';
@@ -20,6 +22,8 @@ import '../../model/mfm_config.dart';
 import '../../model/misskey_colors.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/misskey_colors_provider.dart';
+import '../../util/force_accept_gesture_recognizer.dart';
+import '../../util/get_link_background_color.dart';
 import '../../util/navigate.dart';
 import '../../util/nyaize.dart';
 import '../../util/safe_parse_color.dart';
@@ -169,6 +173,97 @@ class Mfm extends HookConsumerWidget {
       );
     }
 
+    final linkNodes = useMemoized(
+      () => nodes?.extract(
+        (node) => switch (node) {
+          MfmUrl() || MfmLink() || MfmHashtag() => true,
+          _ => false,
+        },
+      ),
+      [nodes],
+    );
+    final urls = useMemoized(() {
+      final urls = <String, DisplayUrl?>{};
+      if (linkNodes == null) {
+        return urls;
+      }
+      for (final node in linkNodes) {
+        if (node is MfmUrl) {
+          urls.putIfAbsent(
+            node.url,
+            () => switch (Uri.tryParse(node.url)) {
+              final url? => parseDisplayUrl(url),
+              _ => null,
+            },
+          );
+        }
+      }
+      return urls;
+    }, [linkNodes]);
+    final controller = useAnimationController(
+      duration: kLongPressTimeout - kPressTimeout,
+    );
+    useAnimation(controller);
+    final callbacks = useRef(
+      <int, ({void Function()? onTap, void Function()? onLongPress})>{},
+    );
+    final activeLinkId = useState<int?>(null);
+    final recognizers = useState(<int, GestureRecognizer>{});
+    useEffect(() {
+      if (linkNodes != null) {
+        callbacks.value = {
+          for (final node in linkNodes)
+            identityHashCode(node): switch (node) {
+              MfmUrl(:final url) || MfmLink(:final url) => (
+                onTap: () => navigate(ref, account, url),
+                onLongPress: () => showModalBottomSheet<void>(
+                  context: context,
+                  builder: (context) => UrlSheet(url: url),
+                ),
+              ),
+              MfmHashtag(:final hashtag) => (
+                onTap: () => context.push(
+                  '/$account/tags/$hashtag${isUserDescription ? '#users' : ''}',
+                ),
+                onLongPress: null,
+              ),
+              _ => (onTap: null, onLongPress: null),
+            },
+        };
+        recognizers.value = {
+          for (final linkId in linkNodes.map(identityHashCode))
+            linkId: ForceAcceptGestureRecognizer()
+              ..onLongPressDown = (_) {
+                activeLinkId.value = linkId;
+                controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+              }
+              ..onLongPressUp = () {
+                if (callbacks.value[linkId]?.onTap case final onTap?) {
+                  Feedback.forTap(context);
+                  onTap();
+                }
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              }
+              ..onLongPressCancel = () {
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              }
+              ..onLongPress = () {
+                if (callbacks.value[linkId]?.onLongPress
+                    case final onLongPress?) {
+                  Feedback.forLongPress(context);
+                  onLongPress();
+                }
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              },
+        };
+      }
+
+      return () {
+        for (final recognizer in recognizers.value.values) {
+          recognizer.dispose();
+        }
+      };
+    }, [account, linkNodes]);
     final colors = ref.watch(misskeyColorsProvider(theme.brightness));
 
     return _Mfm(
@@ -204,6 +299,11 @@ class Mfm extends HookConsumerWidget {
       mathFontFamily: mathFontFamily,
       emojiStyle: emojiStyle,
       colors: colors,
+      urls: urls,
+      controller: controller,
+      recognizers: recognizers.value,
+      callbacks: callbacks,
+      activeLinkId: activeLinkId,
     );
   }
 }
@@ -454,6 +554,11 @@ class _Mfm extends StatelessWidget {
     required this.mathFontFamily,
     required this.emojiStyle,
     required this.colors,
+    required this.urls,
+    required this.controller,
+    required this.recognizers,
+    required this.callbacks,
+    required this.activeLinkId,
   });
 
   final Account account;
@@ -483,6 +588,14 @@ class _Mfm extends StatelessWidget {
   final String? mathFontFamily;
   final EmojiStyle emojiStyle;
   final MisskeyColors colors;
+  final Map<String, DisplayUrl?> urls;
+  final AnimationController controller;
+  final Map<int, GestureRecognizer> recognizers;
+  final ObjectRef<
+    Map<int, ({void Function()? onTap, void Function()? onLongPress})>
+  >
+  callbacks;
+  final ValueNotifier<int?> activeLinkId;
 
   List<InlineSpan> _buildNodes(
     BuildContext context,
@@ -491,14 +604,15 @@ class _Mfm extends StatelessWidget {
   ) {
     return [
       for (final node in nodes)
-        if (_buildNode(context, config, node) case final node?) node,
+        if (_buildNode(context, config, node) case final span?) span,
     ];
   }
 
   InlineSpan? _buildNode(BuildContext context, MfmConfig config, MfmNode node) {
     switch (node) {
       case MfmText(:final text):
-        return TextSpan(
+        return _buildLinkSpan(
+          linkId: config.linkId,
           text: !config.disableNyaize && shouldNyaize ? nyaize(text) : text,
           style: config.style.apply(
             fontSizeFactor: config.scale,
@@ -581,59 +695,73 @@ class _Mfm extends StatelessWidget {
           ),
         );
       case MfmUrl(:final url):
-        return WidgetSpan(
-          alignment: PlaceholderAlignment.baseline,
-          baseline: TextBaseline.alphabetic,
-          child: Consumer(
-            builder: (context, ref, _) => UrlWidget(
-              url: url,
-              onTap: () => navigate(ref, account, url),
-              style: config.style.apply(color: colors.link),
-              scale: config.scale,
-              opacity: config.opacity,
-              align: config.align,
-              overflow: overflow,
-              maxLines: maxLines,
-              textScaler: TextScaler.noScaling,
-            ),
-          ),
-        );
-      case MfmLink(:final url, :final children?):
-        return WidgetSpan(
-          alignment: PlaceholderAlignment.baseline,
-          baseline: TextBaseline.alphabetic,
-          child: Consumer(
-            builder: (context, ref, _) => InkWell(
-              onTap: () => navigate(ref, account, url),
-              onLongPress: () => showModalBottomSheet<void>(
-                context: context,
-                builder: (context) => UrlSheet(url: url),
-              ),
-              child: AbsorbPointer(
-                child: Text.rich(
-                  TextSpan(
-                    children: [
-                      ..._buildNodes(
-                        context,
-                        config.copyWith(
-                          style: config.style.apply(color: colors.link),
-                        ),
-                        children,
-                      ),
-                      WidgetSpan(
-                        child: Icon(
-                          Icons.open_in_new,
-                          color: colors.link.withValues(alpha: config.opacity),
-                          size: config.style.fontSize! * config.scale,
-                        ),
-                      ),
-                    ],
-                  ),
-                  textAlign: config.align,
-                  textScaler: TextScaler.noScaling,
+        final linkId = identityHashCode(node);
+        return TextSpan(
+          children: [
+            if (urls[url] case final url?)
+              buildUrlSpan(
+                url: url,
+                textSpanBuilder: ({text, style}) =>
+                    _buildLinkSpan(linkId: linkId, text: text, style: style),
+                color: colors.link,
+                opacity: config.opacity,
+              )
+            else
+              _buildLinkSpan(linkId: linkId, text: url),
+            WidgetSpan(
+              child: _buildLinkWidget(
+                context,
+                linkId: linkId,
+                child: Icon(
+                  Icons.open_in_new,
+                  color: colors.link.withValues(alpha: config.opacity),
+                  size: config.style.fontSize! * config.scale,
                 ),
               ),
             ),
+          ],
+          style: config.style.apply(
+            fontSizeFactor: config.scale,
+            color: colors.link.withValues(alpha: config.opacity),
+            backgroundColor: activeLinkId.value == linkId
+                ? getLinkBackgroundColor(
+                    Theme.brightnessOf(context),
+                    controller.value,
+                  )
+                : null,
+          ),
+        );
+      case MfmLink(:final children?):
+        final linkId = identityHashCode(node);
+        return TextSpan(
+          children: [
+            ..._buildNodes(
+              context,
+              config.copyWith(
+                style: config.style.apply(color: colors.link),
+                linkId: linkId,
+              ),
+              children,
+            ),
+            WidgetSpan(
+              child: _buildLinkWidget(
+                context,
+                linkId: linkId,
+                child: Icon(
+                  Icons.open_in_new,
+                  color: colors.link.withValues(alpha: config.opacity),
+                  size: config.style.fontSize! * config.scale,
+                ),
+              ),
+            ),
+          ],
+          style: TextStyle(
+            backgroundColor: activeLinkId.value == linkId
+                ? getLinkBackgroundColor(
+                    Theme.brightnessOf(context),
+                    controller.value,
+                  )
+                : null,
           ),
         );
       case MfmMention(:final username, :final host):
@@ -658,23 +786,19 @@ class _Mfm extends StatelessWidget {
           ),
         );
       case MfmHashtag(:final hashtag):
-        return WidgetSpan(
-          alignment: PlaceholderAlignment.baseline,
-          baseline: TextBaseline.alphabetic,
-          child: InkWell(
-            onTap: () => context.push(
-              '/$account/tags/$hashtag${isUserDescription ? '#users' : ''}',
-            ),
-            child: Text(
-              '#$hashtag',
-              style: config.style.apply(
-                fontSizeFactor: config.scale,
-                color: colors.hashtag.withValues(alpha: config.opacity),
-              ),
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
-            ),
+        final linkId = identityHashCode(node);
+        return _buildLinkSpan(
+          linkId: linkId,
+          text: '#$hashtag',
+          style: config.style.apply(
+            fontSizeFactor: config.scale,
+            color: colors.hashtag.withValues(alpha: config.opacity),
+            backgroundColor: activeLinkId.value == linkId
+                ? getLinkBackgroundColor(
+                    Theme.brightnessOf(context),
+                    controller.value,
+                  )
+                : null,
           ),
         );
       case MfmCodeBlock(:final code, :final lang):
@@ -689,12 +813,16 @@ class _Mfm extends StatelessWidget {
         );
       case MfmInlineCode(:final code):
         return WidgetSpan(
-          child: Opacity(
-            opacity: config.opacity,
-            child: Code(
-              code: code,
-              inline: true,
-              style: config.style.apply(fontSizeFactor: config.scale),
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Opacity(
+              opacity: config.opacity,
+              child: Code(
+                code: code,
+                inline: true,
+                style: config.style.apply(fontSizeFactor: config.scale),
+              ),
             ),
           ),
         );
@@ -737,53 +865,57 @@ class _Mfm extends StatelessWidget {
       case MfmEmojiCode(:final name):
         return WidgetSpan(
           alignment: PlaceholderAlignment.middle,
-          child: maxLines == 1
-              ? LayoutBuilder(
-                  builder: (context, constraints) => ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxWidth: constraints.maxWidth - config.style.fontSize!,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: maxLines == 1
+                ? LayoutBuilder(
+                    builder: (context, constraints) => ConstrainedBox(
+                      constraints: BoxConstraints(
+                        maxWidth: constraints.maxWidth - config.style.fontSize!,
+                      ),
+                      child: CustomEmoji(
+                        account: account,
+                        emoji: ':$name:',
+                        url: emojis?[name],
+                        host: author?.host,
+                        opacity: config.opacity,
+                        alignment: Alignment.centerLeft,
+                        fallbackTextStyle: config.style.copyWith(height: 1.0),
+                        fallbackToImage: false,
+                        enableFadeIn: enableEmojiFadeIn,
+                      ),
                     ),
-                    child: CustomEmoji(
-                      account: account,
-                      emoji: ':$name:',
-                      url: emojis?[name],
-                      host: author?.host,
-                      opacity: config.opacity,
-                      alignment: Alignment.centerLeft,
-                      fallbackTextStyle: config.style.copyWith(height: 1.0),
-                      fallbackToImage: false,
-                      enableFadeIn: enableEmojiFadeIn,
+                  )
+                : CustomEmoji(
+                    account: account,
+                    emoji: ':$name:',
+                    url: emojis?[name],
+                    host: author?.host,
+                    useOriginalSize: config.scale >= 2.5,
+                    height: config.style.fontSize! * config.scale * 2.0,
+                    opacity: config.opacity,
+                    fit: BoxFit.cover,
+                    alignment: Alignment.centerLeft,
+                    onTap: () => showModalBottomSheet<void>(
+                      context: context,
+                      builder: (context) => EmojiSheet(
+                        account: account,
+                        emoji: ':$name@${author?.host ?? '.'}:',
+                        targetNoteId: noteId,
+                        targetMessageId: messageId,
+                      ),
                     ),
+                    fallbackTextStyle: config.style.apply(
+                      fontSizeFactor: config.scale,
+                      color: config.style.color?.withValues(
+                        alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                      ),
+                    ),
+                    fallbackToImage: false,
+                    enableFadeIn: enableEmojiFadeIn,
                   ),
-                )
-              : CustomEmoji(
-                  account: account,
-                  emoji: ':$name:',
-                  url: emojis?[name],
-                  host: author?.host,
-                  useOriginalSize: config.scale >= 2.5,
-                  height: config.style.fontSize! * config.scale * 2.0,
-                  opacity: config.opacity,
-                  fit: BoxFit.cover,
-                  alignment: Alignment.centerLeft,
-                  onTap: () => showModalBottomSheet<void>(
-                    context: context,
-                    builder: (context) => EmojiSheet(
-                      account: account,
-                      emoji: ':$name@${author?.host ?? '.'}:',
-                      targetNoteId: noteId,
-                      targetMessageId: messageId,
-                    ),
-                  ),
-                  fallbackTextStyle: config.style.apply(
-                    fontSizeFactor: config.scale,
-                    color: config.style.color?.withValues(
-                      alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-                    ),
-                  ),
-                  fallbackToImage: false,
-                  enableFadeIn: enableEmojiFadeIn,
-                ),
+          ),
         );
       case MfmUnicodeEmoji(:final emoji):
         return WidgetSpan(
@@ -792,49 +924,57 @@ class _Mfm extends StatelessWidget {
             EmojiStyle.twemoji => PlaceholderAlignment.middle,
           },
           baseline: TextBaseline.alphabetic,
-          child: UnicodeEmoji(
-            account: account,
-            emoji: emoji,
-            style: config.style.apply(
-              fontSizeFactor: config.scale,
-              color: config.style.color?.withValues(
-                alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: UnicodeEmoji(
+              account: account,
+              emoji: emoji,
+              style: config.style.apply(
+                fontSizeFactor: config.scale,
+                color: config.style.color?.withValues(
+                  alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                ),
               ),
-            ),
-            onTap: () => showModalBottomSheet<void>(
-              context: context,
-              builder: (context) => EmojiSheet(
-                account: account,
-                emoji: emoji,
-                targetNoteId: noteId,
-                targetMessageId: messageId,
+              onTap: () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => EmojiSheet(
+                  account: account,
+                  emoji: emoji,
+                  targetNoteId: noteId,
+                  targetMessageId: messageId,
+                ),
               ),
+              inline: true,
+              fit: BoxFit.cover,
+              alignment: Alignment.centerLeft,
             ),
-            inline: true,
-            fit: BoxFit.cover,
-            alignment: Alignment.centerLeft,
           ),
         );
       case MfmMathInline(:final formula):
         return WidgetSpan(
           alignment: PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Math.tex(
-            formula,
-            mathStyle: MathStyle.text,
-            textStyle: config.style.apply(
-              color: config.style.color?.withValues(
-                alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-              ),
-            ),
-            textScaleFactor: config.scale,
-            onErrorFallback: (_) => Text(
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Math.tex(
               formula,
-              style: config.style.apply(
-                fontSizeFactor: config.scale,
-                color: Color.fromRGBO(178, 34, 34, config.opacity),
+              mathStyle: MathStyle.text,
+              textStyle: config.style.apply(
+                color: config.style.color?.withValues(
+                  alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                ),
               ),
-              textScaler: TextScaler.noScaling,
+              textScaleFactor: config.scale,
+              onErrorFallback: (_) => Text(
+                formula,
+                style: config.style.apply(
+                  fontSizeFactor: config.scale,
+                  color: Color.fromRGBO(178, 34, 34, config.opacity),
+                ),
+                textScaler: TextScaler.noScaling,
+              ),
             ),
           ),
         );
@@ -867,7 +1007,8 @@ class _Mfm extends StatelessWidget {
           child: Search(query: query, textScaler: TextScaler.noScaling),
         );
       case MfmPlain(:final text):
-        return TextSpan(
+        return _buildLinkSpan(
+          linkId: config.linkId,
           text: text,
           style: config.style.apply(
             fontSizeFactor: config.scale,
@@ -890,29 +1031,38 @@ class _Mfm extends StatelessWidget {
   }) {
     switch (name) {
       case 'tada':
-        final span = TextSpan(
-          children: _buildNodes(
-            context,
-            config.copyWith(scale: config.scale * 1.5),
-            children,
-          ),
-        );
         if (!enableAnimation) {
-          return span;
+          return TextSpan(
+            children: _buildNodes(
+              context,
+              config.copyWith(scale: config.scale * 1.5),
+              children,
+            ),
+          );
         }
         return WidgetSpan(
           alignment: children.any(_containsNewLine)
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Tada(
-            args: args,
-            child: Text.rich(
-              span,
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Tada(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(scale: config.scale * 1.5, linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -923,14 +1073,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Jelly(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Jelly(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -941,14 +1101,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Twitch(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Twitch(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -959,14 +1129,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Shake(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Shake(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -977,14 +1157,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Spin(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Spin(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -995,14 +1185,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Jump(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Jump(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1013,14 +1213,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Bounce(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Bounce(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1030,15 +1240,25 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Transform.scale(
-            scaleX: !args.containsKey('h') && args.containsKey('v') ? 1 : -1,
-            scaleY: !args.containsKey('v') ? 1 : -1,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Transform.scale(
+              scaleX: !args.containsKey('h') && args.containsKey('v') ? 1 : -1,
+              scaleY: !args.containsKey('v') ? 1 : -1,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1148,52 +1368,78 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Blur(
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Blur(
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
       case 'rainbow':
-        final span = TextSpan(children: _buildNodes(context, config, children));
+        final span = TextSpan(
+          children: _buildNodes(
+            context,
+            config.copyWith(linkId: null),
+            children,
+          ),
+        );
         return WidgetSpan(
           alignment: children.any(_containsNewLine)
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: enableAnimation
-              ? Rainbow(
-                  args: args,
-                  child: Text.rich(
-                    span,
-                    textAlign: config.align,
-                    overflow: overflow,
-                    textScaler: TextScaler.noScaling,
-                    maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: enableAnimation
+                ? Rainbow(
+                    args: args,
+                    child: Text.rich(
+                      span,
+                      textAlign: config.align,
+                      overflow: overflow,
+                      textScaler: TextScaler.noScaling,
+                      maxLines: maxLines,
+                    ),
+                  )
+                : ShaderMask(
+                    shaderCallback: (rect) =>
+                        const LinearGradient(
+                          colors: [
+                            Color(0xffff0000),
+                            Color(0xffffa500),
+                            Color(0xffffff00),
+                            Color(0xff00ff00),
+                            Color(0xff00ffff),
+                            Color(0xff0000ff),
+                            Color(0xffff00ff),
+                          ],
+                        ).createShader(
+                          Rect.fromLTWH(0.0, 0.0, rect.width, rect.height),
+                        ),
+                    blendMode: BlendMode.srcIn,
+                    child: Text.rich(
+                      span,
+                      textAlign: config.align,
+                      overflow: overflow,
+                      textScaler: TextScaler.noScaling,
+                      maxLines: maxLines,
+                    ),
                   ),
-                )
-              : ShaderMask(
-                  shaderCallback: (rect) =>
-                      const LinearGradient(
-                        colors: [
-                          Color(0xffff0000),
-                          Color(0xffffa500),
-                          Color(0xffffff00),
-                          Color(0xff00ff00),
-                          Color(0xff00ffff),
-                          Color(0xff0000ff),
-                          Color(0xffff00ff),
-                        ],
-                      ).createShader(
-                        Rect.fromLTWH(0.0, 0.0, rect.width, rect.height),
-                      ),
-                  blendMode: BlendMode.srcIn,
-                  child: Text.rich(span, textScaler: TextScaler.noScaling),
-                ),
+          ),
         );
       case 'sparkle':
         if (!enableAnimation) break;
@@ -1202,14 +1448,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Sparkle(
-            opacity: config.opacity,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Sparkle(
+              opacity: config.opacity,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1219,14 +1475,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Transform.rotate(
-            angle: (safeParseDouble(args['deg']) ?? 90.0) * pi / 180,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Transform.rotate(
+              angle: (safeParseDouble(args['deg']) ?? 90.0) * pi / 180,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1237,21 +1503,31 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Transform.translate(
-            offset: Offset(
-              (safeParseDouble(args['x']) ?? 0.0) *
-                  config.scale *
-                  config.style.fontSize!,
-              (safeParseDouble(args['y']) ?? 0.0) *
-                  config.scale *
-                  config.style.fontSize!,
-            ),
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Transform.translate(
+              offset: Offset(
+                (safeParseDouble(args['x']) ?? 0.0) *
+                    config.scale *
+                    config.style.fontSize!,
+                (safeParseDouble(args['y']) ?? 0.0) *
+                    config.scale *
+                    config.style.fontSize!,
+              ),
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1262,15 +1538,25 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Transform.scale(
-            scaleX: min(safeParseDouble(args['x']) ?? 1.0, 5.0),
-            scaleY: min(safeParseDouble(args['y']) ?? 1.0, 5.0),
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Transform.scale(
+              scaleX: min(safeParseDouble(args['x']) ?? 1.0, 5.0),
+              scaleY: min(safeParseDouble(args['y']) ?? 1.0, 5.0),
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1290,14 +1576,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: ColoredBox(
-            color: color.withValues(alpha: config.opacity * color.a),
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: ColoredBox(
+              color: color.withValues(alpha: config.opacity * color.a),
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1307,14 +1603,24 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Border(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Border(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
@@ -1338,21 +1644,28 @@ class _Mfm extends StatelessWidget {
           final ruby = l.elementAtOrNull(1)?.replaceAll('\n', ' ') ?? '';
           final span = _buildNode(
             context,
-            config.copyWith(style: config.style.copyWith(height: 1.0)),
+            config.copyWith(
+              style: config.style.copyWith(height: 1.0),
+              linkId: null,
+            ),
             MfmText(text: l.first.replaceAll('\n', ' ')),
           );
           return WidgetSpan(
             alignment: PlaceholderAlignment.aboveBaseline,
             baseline: TextBaseline.ideographic,
-            child: Ruby(
-              style: rubyStyle,
-              ruby: ruby,
-              child: Text.rich(
-                span ?? const TextSpan(),
-                textAlign: config.align,
-                overflow: overflow,
-                textScaler: TextScaler.noScaling,
-                maxLines: maxLines,
+            child: _buildLinkWidget(
+              context,
+              linkId: config.linkId,
+              child: Ruby(
+                style: rubyStyle,
+                ruby: ruby,
+                child: Text.rich(
+                  span ?? const TextSpan(),
+                  textAlign: config.align,
+                  overflow: overflow,
+                  textScaler: TextScaler.noScaling,
+                  maxLines: maxLines,
+                ),
               ),
             ),
           );
@@ -1368,25 +1681,32 @@ class _Mfm extends StatelessWidget {
           return WidgetSpan(
             alignment: PlaceholderAlignment.aboveBaseline,
             baseline: TextBaseline.ideographic,
-            child: Ruby(
-              style: rubyStyle,
-              ruby: ruby,
-              child: Text.rich(
-                TextSpan(
-                  children: _buildNodes(
-                    context,
-                    config.copyWith(style: config.style.copyWith(height: 1.0)),
-                    children
-                        .sublist(0, children.length - 1)
-                        .whereType<MfmInline>()
-                        .map(_removeNewLines)
-                        .toList(),
+            child: _buildLinkWidget(
+              context,
+              linkId: config.linkId,
+              child: Ruby(
+                style: rubyStyle,
+                ruby: ruby,
+                child: Text.rich(
+                  TextSpan(
+                    children: _buildNodes(
+                      context,
+                      config.copyWith(
+                        style: config.style.copyWith(height: 1.0),
+                        linkId: null,
+                      ),
+                      children
+                          .sublist(0, children.length - 1)
+                          .whereType<MfmInline>()
+                          .map(_removeNewLines)
+                          .toList(),
+                    ),
                   ),
+                  textAlign: config.align,
+                  overflow: overflow,
+                  textScaler: TextScaler.noScaling,
+                  maxLines: maxLines,
                 ),
-                textAlign: config.align,
-                overflow: overflow,
-                textScaler: TextScaler.noScaling,
-                maxLines: maxLines,
               ),
             ),
           );
@@ -1400,42 +1720,47 @@ class _Mfm extends StatelessWidget {
         return WidgetSpan(
           alignment: PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              border: material.Border.all(color: colors.divider),
-              borderRadius: BorderRadius.circular(
-                config.style.lineHeight * config.scale,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                border: material.Border.all(color: colors.divider),
+                borderRadius: BorderRadius.circular(
+                  config.style.lineHeight * config.scale,
+                ),
               ),
-            ),
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: 4.0 * config.scale,
-                horizontal: 8.0 * config.scale,
-              ),
-              child: TimeWidget(
-                leadingSpans: [
-                  WidgetSpan(
-                    alignment: PlaceholderAlignment.middle,
-                    child: Icon(
-                      Icons.access_time,
-                      color: config.style.color?.withValues(
-                        alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  vertical: 4.0 * config.scale,
+                  horizontal: 8.0 * config.scale,
+                ),
+                child: TimeWidget(
+                  leadingSpans: [
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.middle,
+                      child: Icon(
+                        Icons.access_time,
+                        color: config.style.color?.withValues(
+                          alpha:
+                              (config.style.color?.a ?? 1.0) * config.opacity,
+                        ),
+                        size: config.style.lineHeight * config.scale * 0.9,
                       ),
-                      size: config.style.lineHeight * config.scale * 0.9,
+                    ),
+                    WidgetSpan(child: SizedBox(width: 2.0 * config.scale)),
+                  ],
+                  time: time,
+                  detailed: true,
+                  disableTooltip: true,
+                  style: config.style.apply(
+                    fontSizeFactor: config.scale * 0.9,
+                    color: config.style.color?.withValues(
+                      alpha: (config.style.color?.a ?? 1.0) * config.opacity,
                     ),
                   ),
-                  WidgetSpan(child: SizedBox(width: 2.0 * config.scale)),
-                ],
-                time: time,
-                detailed: true,
-                disableTooltip: true,
-                style: config.style.apply(
-                  fontSizeFactor: config.scale * 0.9,
-                  color: config.style.color?.withValues(
-                    alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-                  ),
+                  textScaler: TextScaler.noScaling,
                 ),
-                textScaler: TextScaler.noScaling,
               ),
             ),
           ),
@@ -1449,9 +1774,40 @@ class _Mfm extends StatelessWidget {
           baseline: TextBaseline.alphabetic,
           child: InkWell(
             onTap: onClickEv != null ? () => onClickEv?.call(clickEv) : null,
+            onLongPress: switch (config.linkId) {
+              final linkId? => () {
+                if (callbacks.value[linkId]?.onLongPress
+                    case final onLongPress?) {
+                  Feedback.forLongPress(context);
+                  onLongPress();
+                }
+                controller.animateTo(0.0, curve: Curves.easeOut);
+              },
+              _ => null,
+            },
+            onHover: switch (config.linkId) {
+              final linkId? => (value) {
+                if (!controller.isAnimating && controller.value < 1.0) {
+                  if (value) {
+                    activeLinkId.value = linkId;
+                    controller.value = 0.25;
+                  } else {
+                    controller.value = 0.0;
+                  }
+                }
+              },
+              _ => null,
+            },
+            mouseCursor: SystemMouseCursors.click,
             child: AbsorbPointer(
               child: Text.rich(
-                TextSpan(children: _buildNodes(context, config, children)),
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
                 textAlign: config.align,
                 overflow: overflow,
                 textScaler: TextScaler.noScaling,
@@ -1466,27 +1822,128 @@ class _Mfm extends StatelessWidget {
               ? PlaceholderAlignment.bottom
               : PlaceholderAlignment.baseline,
           baseline: TextBaseline.alphabetic,
-          child: Crop(
-            args: args,
-            child: Text.rich(
-              TextSpan(children: _buildNodes(context, config, children)),
-              textAlign: config.align,
-              overflow: overflow,
-              textScaler: TextScaler.noScaling,
-              maxLines: maxLines,
+          child: _buildLinkWidget(
+            context,
+            linkId: config.linkId,
+            child: Crop(
+              args: args,
+              child: Text.rich(
+                TextSpan(
+                  children: _buildNodes(
+                    context,
+                    config.copyWith(linkId: null),
+                    children,
+                  ),
+                ),
+                textAlign: config.align,
+                overflow: overflow,
+                textScaler: TextScaler.noScaling,
+                maxLines: maxLines,
+              ),
             ),
           ),
         );
       default:
         return TextSpan(
           children: [
-            TextSpan(text: '\$[$name '),
+            _buildLinkSpan(
+              linkId: config.linkId,
+              text: '\$[$name ',
+              style: config.style.apply(
+                fontSizeFactor: config.scale,
+                color: config.style.color?.withValues(
+                  alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                ),
+              ),
+            ),
             ..._buildNodes(context, config, children),
-            const TextSpan(text: ']'),
+            _buildLinkSpan(
+              linkId: config.linkId,
+              text: ']',
+              style: config.style.apply(
+                fontSizeFactor: config.scale,
+                color: config.style.color?.withValues(
+                  alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                ),
+              ),
+            ),
           ],
         );
     }
     return TextSpan(children: _buildNodes(context, config, children));
+  }
+
+  Widget _buildLinkWidget(
+    BuildContext context, {
+    required int? linkId,
+    required Widget child,
+  }) {
+    if (linkId == null) {
+      return child;
+    }
+    return InkWell(
+      onTapDown: (_) {
+        activeLinkId.value = linkId;
+        controller.animateTo(1.0, curve: Curves.fastOutSlowIn);
+      },
+      onTapUp: (_) {
+        if (callbacks.value[linkId]?.onTap case final onTap?) {
+          Feedback.forTap(context);
+          onTap();
+        }
+        controller.animateTo(0.0, curve: Curves.easeOut);
+      },
+      onTapCancel: () {
+        controller.animateTo(0.0, curve: Curves.easeOut);
+      },
+      onLongPress: () {
+        if (callbacks.value[linkId]?.onLongPress case final onLongPress?) {
+          Feedback.forLongPress(context);
+          onLongPress();
+        }
+        controller.animateTo(0.0, curve: Curves.easeOut);
+      },
+      onHover: (value) {
+        if (!controller.isAnimating && controller.value < 1.0) {
+          if (value) {
+            activeLinkId.value = linkId;
+            controller.value = 0.25;
+          } else {
+            controller.value = 0.0;
+          }
+        }
+      },
+      splashFactory: NoSplash.splashFactory,
+      overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+      mouseCursor: SystemMouseCursors.click,
+      child: AbsorbPointer(child: child),
+    );
+  }
+
+  TextSpan _buildLinkSpan({
+    required int? linkId,
+    String? text,
+    TextStyle? style,
+  }) {
+    if (linkId == null) {
+      return TextSpan(text: text, style: style);
+    }
+    return TextSpan(
+      text: text,
+      style: style,
+      recognizer: recognizers[linkId],
+      onEnter: (_) {
+        if (!controller.isAnimating && controller.value < 1.0) {
+          activeLinkId.value = linkId;
+          controller.value = 0.25;
+        }
+      },
+      onExit: (_) {
+        if (!controller.isAnimating && controller.value < 1.0) {
+          controller.value = 0.0;
+        }
+      },
+    );
   }
 
   @override

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -496,368 +496,389 @@ class _Mfm extends StatelessWidget {
   }
 
   InlineSpan? _buildNode(BuildContext context, MfmConfig config, MfmNode node) {
-    return switch (node) {
-      MfmText(:final text) => TextSpan(
-        text: !config.disableNyaize && shouldNyaize ? nyaize(text) : text,
-        style: config.style.apply(
-          fontSizeFactor: config.scale,
-          color: config.style.color?.withValues(
-            alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-          ),
-        ),
-      ),
-      MfmBold(:final children?) => TextSpan(
-        children: _buildNodes(
-          context,
-          config.copyWith(
-            style: config.style.merge(
-              const TextStyle(fontWeight: FontWeight.bold),
-            ),
-          ),
-          children,
-        ),
-      ),
-      MfmStrike(:final children?) => TextSpan(
-        children: _buildNodes(
-          context,
-          config.copyWith(
-            style: config.style.apply(
-              decoration: TextDecoration.lineThrough,
-              decorationColor: config.style.color,
-            ),
-          ),
-          children,
-        ),
-      ),
-      MfmItalic(:final children?) => TextSpan(
-        children: _buildNodes(
-          context,
-          config.copyWith(
-            style: config.style.apply(fontStyle: FontStyle.italic),
-          ),
-          children,
-        ),
-      ),
-      MfmFn(:final name, :final args, :final children?) => _buildMfmFn(
-        context,
-        config,
-        name: name,
-        args: args,
-        children: children,
-      ),
-      MfmSmall(:final children?) => TextSpan(
-        children: _buildNodes(
-          context,
-          config.copyWith(
-            scale: config.scale * 0.8,
-            opacity: config.opacity * 0.7,
-          ),
-          children,
-        ),
-      ),
-      MfmCenter(:final children?) => WidgetSpan(
-        child: SizedBox(
-          width: double.infinity,
-          child: Text.rich(
-            TextSpan(
-              children: _buildNodes(
-                context,
-                config.copyWith(align: TextAlign.center),
-                children,
-              ),
-            ),
-            textAlign: TextAlign.center,
-            overflow: overflow,
-            maxLines: maxLines,
-            textScaler: TextScaler.noScaling,
-          ),
-        ),
-      ),
-      MfmUrl(:final url) => WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
-        baseline: TextBaseline.alphabetic,
-        child: Consumer(
-          builder: (context, ref, _) => UrlWidget(
-            url: url,
-            onTap: () => navigate(ref, account, url),
-            style: config.style.apply(color: colors.link),
-            scale: config.scale,
-            opacity: config.opacity,
-            align: config.align,
-            overflow: overflow,
-            maxLines: maxLines,
-            textScaler: TextScaler.noScaling,
-          ),
-        ),
-      ),
-      MfmLink(:final url, :final children?) => WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
-        baseline: TextBaseline.alphabetic,
-        child: Consumer(
-          builder: (context, ref, _) => InkWell(
-            onTap: () => navigate(ref, account, url),
-            onLongPress: () => showModalBottomSheet<void>(
-              context: context,
-              builder: (context) => UrlSheet(url: url),
-            ),
-            child: AbsorbPointer(
-              child: Text.rich(
-                TextSpan(
-                  children: [
-                    ..._buildNodes(
-                      context,
-                      config.copyWith(
-                        style: config.style.apply(color: colors.link),
-                      ),
-                      children,
-                    ),
-                    WidgetSpan(
-                      child: Icon(
-                        Icons.open_in_new,
-                        color: colors.link.withValues(alpha: config.opacity),
-                        size: config.style.fontSize! * config.scale,
-                      ),
-                    ),
-                  ],
-                ),
-                textAlign: config.align,
-                textScaler: TextScaler.noScaling,
-              ),
-            ),
-          ),
-        ),
-      ),
-      MfmMention(:final username, :final host) => WidgetSpan(
-        alignment: PlaceholderAlignment.middle,
-        child: Builder(
-          builder: (context) {
-            final absoluteHost = host ?? author?.host ?? account.host;
-            return MentionWidget(
-              account: account,
-              username: username,
-              host: absoluteHost,
-              scale: config.scale,
-              opacity: config.opacity,
-              onTap: () =>
-                  account.host.toLowerCase() == absoluteHost.toLowerCase()
-                  ? context.push('/$account/@$username')
-                  : context.push('/$account/@$username@$absoluteHost'),
-              textScaler: TextScaler.noScaling,
-            );
-          },
-        ),
-      ),
-      MfmHashtag(:final hashtag) => WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
-        baseline: TextBaseline.alphabetic,
-        child: InkWell(
-          onTap: () => context.push(
-            '/$account/tags/$hashtag${isUserDescription ? '#users' : ''}',
-          ),
-          child: Text(
-            '#$hashtag',
-            style: config.style.apply(
-              fontSizeFactor: config.scale,
-              color: colors.hashtag.withValues(alpha: config.opacity),
-            ),
-            overflow: overflow,
-            textScaler: TextScaler.noScaling,
-            maxLines: maxLines,
-          ),
-        ),
-      ),
-      MfmCodeBlock(:final code, :final lang) => WidgetSpan(
-        child: Opacity(
-          opacity: config.opacity,
-          child: SizedBox(
-            width: double.infinity,
-            child: Code(code: code, language: lang),
-          ),
-        ),
-      ),
-      MfmInlineCode(:final code) => WidgetSpan(
-        child: Opacity(
-          opacity: config.opacity,
-          child: Code(
-            code: code,
-            inline: true,
-            style: config.style.apply(fontSizeFactor: config.scale),
-          ),
-        ),
-      ),
-      MfmQuote(:final children?) => WidgetSpan(
-        child: Container(
-          margin: const EdgeInsets.all(8.0),
-          padding: const EdgeInsetsDirectional.only(
-            start: 12.0,
-            top: 6.0,
-            bottom: 6.0,
-          ),
-          width: double.infinity,
-          decoration: BoxDecoration(
-            border: BorderDirectional(
-              start: BorderSide(
-                color: colors.fg.withValues(alpha: config.opacity * 0.7),
-                width: 3.0,
-              ),
-            ),
-          ),
-          child: Text.rich(
-            TextSpan(
-              children: _buildNodes(
-                context,
-                config.copyWith(
-                  opacity: config.opacity * 0.7,
-                  disableNyaize: true,
-                ),
-                children,
-              ),
-            ),
-            textAlign: config.align,
-            overflow: overflow,
-            textScaler: TextScaler.noScaling,
-            maxLines: maxLines,
-          ),
-        ),
-      ),
-      MfmEmojiCode(:final name) => WidgetSpan(
-        alignment: PlaceholderAlignment.middle,
-        child: maxLines == 1
-            ? LayoutBuilder(
-                builder: (context, constraints) => ConstrainedBox(
-                  constraints: BoxConstraints(
-                    maxWidth: constraints.maxWidth - config.style.fontSize!,
-                  ),
-                  child: CustomEmoji(
-                    account: account,
-                    emoji: ':$name:',
-                    url: emojis?[name],
-                    host: author?.host,
-                    opacity: config.opacity,
-                    alignment: Alignment.centerLeft,
-                    fallbackTextStyle: config.style.copyWith(height: 1.0),
-                    fallbackToImage: false,
-                    enableFadeIn: enableEmojiFadeIn,
-                  ),
-                ),
-              )
-            : CustomEmoji(
-                account: account,
-                emoji: ':$name:',
-                url: emojis?[name],
-                host: author?.host,
-                useOriginalSize: config.scale >= 2.5,
-                height: config.style.fontSize! * config.scale * 2.0,
-                opacity: config.opacity,
-                fit: BoxFit.cover,
-                alignment: Alignment.centerLeft,
-                onTap: () => showModalBottomSheet<void>(
-                  context: context,
-                  builder: (context) => EmojiSheet(
-                    account: account,
-                    emoji: ':$name@${author?.host ?? '.'}:',
-                    targetNoteId: noteId,
-                    targetMessageId: messageId,
-                  ),
-                ),
-                fallbackTextStyle: config.style.apply(
-                  fontSizeFactor: config.scale,
-                  color: config.style.color?.withValues(
-                    alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-                  ),
-                ),
-                fallbackToImage: false,
-                enableFadeIn: enableEmojiFadeIn,
-              ),
-      ),
-      MfmUnicodeEmoji(:final emoji) => WidgetSpan(
-        alignment: switch (emojiStyle) {
-          EmojiStyle.native => PlaceholderAlignment.baseline,
-          EmojiStyle.twemoji => PlaceholderAlignment.middle,
-        },
-        baseline: TextBaseline.alphabetic,
-        child: UnicodeEmoji(
-          account: account,
-          emoji: emoji,
+    switch (node) {
+      case MfmText(:final text):
+        return TextSpan(
+          text: !config.disableNyaize && shouldNyaize ? nyaize(text) : text,
           style: config.style.apply(
             fontSizeFactor: config.scale,
             color: config.style.color?.withValues(
               alpha: (config.style.color?.a ?? 1.0) * config.opacity,
             ),
           ),
-          onTap: () => showModalBottomSheet<void>(
-            context: context,
-            builder: (context) => EmojiSheet(
-              account: account,
-              emoji: emoji,
-              targetNoteId: noteId,
-              targetMessageId: messageId,
+        );
+      case MfmBold(:final children?):
+        return TextSpan(
+          children: _buildNodes(
+            context,
+            config.copyWith(
+              style: config.style.merge(
+                const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+            children,
+          ),
+        );
+      case MfmStrike(:final children?):
+        return TextSpan(
+          children: _buildNodes(
+            context,
+            config.copyWith(
+              style: config.style.apply(
+                decoration: TextDecoration.lineThrough,
+                decorationColor: config.style.color,
+              ),
+            ),
+            children,
+          ),
+        );
+      case MfmItalic(:final children?):
+        return TextSpan(
+          children: _buildNodes(
+            context,
+            config.copyWith(
+              style: config.style.apply(fontStyle: FontStyle.italic),
+            ),
+            children,
+          ),
+        );
+      case MfmFn(:final name, :final args, :final children?):
+        return _buildMfmFn(
+          context,
+          config,
+          name: name,
+          args: args,
+          children: children,
+        );
+      case MfmSmall(:final children?):
+        return TextSpan(
+          children: _buildNodes(
+            context,
+            config.copyWith(
+              scale: config.scale * 0.8,
+              opacity: config.opacity * 0.7,
+            ),
+            children,
+          ),
+        );
+      case MfmCenter(:final children?):
+        return WidgetSpan(
+          child: SizedBox(
+            width: double.infinity,
+            child: Text.rich(
+              TextSpan(
+                children: _buildNodes(
+                  context,
+                  config.copyWith(align: TextAlign.center),
+                  children,
+                ),
+              ),
+              textAlign: TextAlign.center,
+              overflow: overflow,
+              maxLines: maxLines,
+              textScaler: TextScaler.noScaling,
             ),
           ),
-          inline: true,
-          fit: BoxFit.cover,
-          alignment: Alignment.centerLeft,
-        ),
-      ),
-      MfmMathInline(:final formula) => WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
-        baseline: TextBaseline.alphabetic,
-        child: Math.tex(
-          formula,
-          mathStyle: MathStyle.text,
-          textStyle: config.style.apply(
+        );
+      case MfmUrl(:final url):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Consumer(
+            builder: (context, ref, _) => UrlWidget(
+              url: url,
+              onTap: () => navigate(ref, account, url),
+              style: config.style.apply(color: colors.link),
+              scale: config.scale,
+              opacity: config.opacity,
+              align: config.align,
+              overflow: overflow,
+              maxLines: maxLines,
+              textScaler: TextScaler.noScaling,
+            ),
+          ),
+        );
+      case MfmLink(:final url, :final children?):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Consumer(
+            builder: (context, ref, _) => InkWell(
+              onTap: () => navigate(ref, account, url),
+              onLongPress: () => showModalBottomSheet<void>(
+                context: context,
+                builder: (context) => UrlSheet(url: url),
+              ),
+              child: AbsorbPointer(
+                child: Text.rich(
+                  TextSpan(
+                    children: [
+                      ..._buildNodes(
+                        context,
+                        config.copyWith(
+                          style: config.style.apply(color: colors.link),
+                        ),
+                        children,
+                      ),
+                      WidgetSpan(
+                        child: Icon(
+                          Icons.open_in_new,
+                          color: colors.link.withValues(alpha: config.opacity),
+                          size: config.style.fontSize! * config.scale,
+                        ),
+                      ),
+                    ],
+                  ),
+                  textAlign: config.align,
+                  textScaler: TextScaler.noScaling,
+                ),
+              ),
+            ),
+          ),
+        );
+      case MfmMention(:final username, :final host):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.middle,
+          child: Builder(
+            builder: (context) {
+              final absoluteHost = host ?? author?.host ?? account.host;
+              return MentionWidget(
+                account: account,
+                username: username,
+                host: absoluteHost,
+                scale: config.scale,
+                opacity: config.opacity,
+                onTap: () =>
+                    account.host.toLowerCase() == absoluteHost.toLowerCase()
+                    ? context.push('/$account/@$username')
+                    : context.push('/$account/@$username@$absoluteHost'),
+                textScaler: TextScaler.noScaling,
+              );
+            },
+          ),
+        );
+      case MfmHashtag(:final hashtag):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: InkWell(
+            onTap: () => context.push(
+              '/$account/tags/$hashtag${isUserDescription ? '#users' : ''}',
+            ),
+            child: Text(
+              '#$hashtag',
+              style: config.style.apply(
+                fontSizeFactor: config.scale,
+                color: colors.hashtag.withValues(alpha: config.opacity),
+              ),
+              overflow: overflow,
+              textScaler: TextScaler.noScaling,
+              maxLines: maxLines,
+            ),
+          ),
+        );
+      case MfmCodeBlock(:final code, :final lang):
+        return WidgetSpan(
+          child: Opacity(
+            opacity: config.opacity,
+            child: SizedBox(
+              width: double.infinity,
+              child: Code(code: code, language: lang),
+            ),
+          ),
+        );
+      case MfmInlineCode(:final code):
+        return WidgetSpan(
+          child: Opacity(
+            opacity: config.opacity,
+            child: Code(
+              code: code,
+              inline: true,
+              style: config.style.apply(fontSizeFactor: config.scale),
+            ),
+          ),
+        );
+      case MfmQuote(:final children?):
+        return WidgetSpan(
+          child: Container(
+            margin: const EdgeInsets.all(8.0),
+            padding: const EdgeInsetsDirectional.only(
+              start: 12.0,
+              top: 6.0,
+              bottom: 6.0,
+            ),
+            width: double.infinity,
+            decoration: BoxDecoration(
+              border: BorderDirectional(
+                start: BorderSide(
+                  color: colors.fg.withValues(alpha: config.opacity * 0.7),
+                  width: 3.0,
+                ),
+              ),
+            ),
+            child: Text.rich(
+              TextSpan(
+                children: _buildNodes(
+                  context,
+                  config.copyWith(
+                    opacity: config.opacity * 0.7,
+                    disableNyaize: true,
+                  ),
+                  children,
+                ),
+              ),
+              textAlign: config.align,
+              overflow: overflow,
+              textScaler: TextScaler.noScaling,
+              maxLines: maxLines,
+            ),
+          ),
+        );
+      case MfmEmojiCode(:final name):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.middle,
+          child: maxLines == 1
+              ? LayoutBuilder(
+                  builder: (context, constraints) => ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: constraints.maxWidth - config.style.fontSize!,
+                    ),
+                    child: CustomEmoji(
+                      account: account,
+                      emoji: ':$name:',
+                      url: emojis?[name],
+                      host: author?.host,
+                      opacity: config.opacity,
+                      alignment: Alignment.centerLeft,
+                      fallbackTextStyle: config.style.copyWith(height: 1.0),
+                      fallbackToImage: false,
+                      enableFadeIn: enableEmojiFadeIn,
+                    ),
+                  ),
+                )
+              : CustomEmoji(
+                  account: account,
+                  emoji: ':$name:',
+                  url: emojis?[name],
+                  host: author?.host,
+                  useOriginalSize: config.scale >= 2.5,
+                  height: config.style.fontSize! * config.scale * 2.0,
+                  opacity: config.opacity,
+                  fit: BoxFit.cover,
+                  alignment: Alignment.centerLeft,
+                  onTap: () => showModalBottomSheet<void>(
+                    context: context,
+                    builder: (context) => EmojiSheet(
+                      account: account,
+                      emoji: ':$name@${author?.host ?? '.'}:',
+                      targetNoteId: noteId,
+                      targetMessageId: messageId,
+                    ),
+                  ),
+                  fallbackTextStyle: config.style.apply(
+                    fontSizeFactor: config.scale,
+                    color: config.style.color?.withValues(
+                      alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                    ),
+                  ),
+                  fallbackToImage: false,
+                  enableFadeIn: enableEmojiFadeIn,
+                ),
+        );
+      case MfmUnicodeEmoji(:final emoji):
+        return WidgetSpan(
+          alignment: switch (emojiStyle) {
+            EmojiStyle.native => PlaceholderAlignment.baseline,
+            EmojiStyle.twemoji => PlaceholderAlignment.middle,
+          },
+          baseline: TextBaseline.alphabetic,
+          child: UnicodeEmoji(
+            account: account,
+            emoji: emoji,
+            style: config.style.apply(
+              fontSizeFactor: config.scale,
+              color: config.style.color?.withValues(
+                alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+              ),
+            ),
+            onTap: () => showModalBottomSheet<void>(
+              context: context,
+              builder: (context) => EmojiSheet(
+                account: account,
+                emoji: emoji,
+                targetNoteId: noteId,
+                targetMessageId: messageId,
+              ),
+            ),
+            inline: true,
+            fit: BoxFit.cover,
+            alignment: Alignment.centerLeft,
+          ),
+        );
+      case MfmMathInline(:final formula):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: Math.tex(
+            formula,
+            mathStyle: MathStyle.text,
+            textStyle: config.style.apply(
+              color: config.style.color?.withValues(
+                alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+              ),
+            ),
+            textScaleFactor: config.scale,
+            onErrorFallback: (_) => Text(
+              formula,
+              style: config.style.apply(
+                fontSizeFactor: config.scale,
+                color: Color.fromRGBO(178, 34, 34, config.opacity),
+              ),
+              textScaler: TextScaler.noScaling,
+            ),
+          ),
+        );
+      case MfmMathBlock(:final formula):
+        return WidgetSpan(
+          child: SizedBox(
+            width: double.infinity,
+            child: Center(
+              child: Math.tex(
+                formula,
+                textStyle: config.style.apply(
+                  color: config.style.color?.withValues(
+                    alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                  ),
+                ),
+                textScaleFactor: config.scale,
+                onErrorFallback: (_) => Text(
+                  formula,
+                  style: config.style.apply(
+                    color: Color.fromRGBO(178, 34, 34, config.opacity),
+                  ),
+                  textScaler: TextScaler.noScaling,
+                ),
+              ),
+            ),
+          ),
+        );
+      case MfmSearch(:final query):
+        return WidgetSpan(
+          child: Search(query: query, textScaler: TextScaler.noScaling),
+        );
+      case MfmPlain(:final text):
+        return TextSpan(
+          text: text,
+          style: config.style.apply(
+            fontSizeFactor: config.scale,
             color: config.style.color?.withValues(
               alpha: (config.style.color?.a ?? 1.0) * config.opacity,
             ),
           ),
-          textScaleFactor: config.scale,
-          onErrorFallback: (_) => Text(
-            formula,
-            style: config.style.apply(
-              fontSizeFactor: config.scale,
-              color: Color.fromRGBO(178, 34, 34, config.opacity),
-            ),
-            textScaler: TextScaler.noScaling,
-          ),
-        ),
-      ),
-      MfmMathBlock(:final formula) => WidgetSpan(
-        child: SizedBox(
-          width: double.infinity,
-          child: Center(
-            child: Math.tex(
-              formula,
-              textStyle: config.style.apply(
-                color: config.style.color?.withValues(
-                  alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-                ),
-              ),
-              textScaleFactor: config.scale,
-              onErrorFallback: (_) => Text(
-                formula,
-                style: config.style.apply(
-                  color: Color.fromRGBO(178, 34, 34, config.opacity),
-                ),
-                textScaler: TextScaler.noScaling,
-              ),
-            ),
-          ),
-        ),
-      ),
-      MfmSearch(:final query) => WidgetSpan(
-        child: Search(query: query, textScaler: TextScaler.noScaling),
-      ),
-      MfmPlain(:final text) => TextSpan(
-        text: text,
-        style: config.style.apply(
-          fontSizeFactor: config.scale,
-          color: config.style.color?.withValues(
-            alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-          ),
-        ),
-      ),
-      _ => null,
-    };
+        );
+      default:
+        return null;
+    }
   }
 
   InlineSpan _buildMfmFn(

--- a/lib/view/widget/mfm.dart
+++ b/lib/view/widget/mfm.dart
@@ -106,6 +106,9 @@ class Mfm extends HookConsumerWidget {
       }
       return null;
     }, [this.nodes, text]);
+    final needsIsolate =
+        defaultTargetPlatform != TargetPlatform.linux &&
+        (builder != null || (trailingSpans?.isNotEmpty ?? false));
     final (
       enableAdvanced,
       enableAnimation,
@@ -143,6 +146,29 @@ class Mfm extends HookConsumerWidget {
               : null,
         )
         .merge(this.style);
+
+    if (simple) {
+      return _SimpleMfm(
+        account: account,
+        leadingSpans: leadingSpans,
+        nodes: nodes,
+        trailingSpans: trailingSpans,
+        builder: builder,
+        config: MfmConfig(
+          style: style,
+          align: textAlign,
+          opacity: this.style?.color?.a ?? defaultTextStyle.color?.a ?? 1.0,
+        ),
+        emojis: emojis,
+        author: author,
+        overflow: overflow,
+        maxLines: maxLines,
+        needsIsolate: needsIsolate,
+        enableEmojiFadeIn: enableEmojiFadeIn,
+        emojiStyle: emojiStyle,
+      );
+    }
+
     final colors = ref.watch(misskeyColorsProvider(theme.brightness));
 
     return _Mfm(
@@ -156,7 +182,6 @@ class Mfm extends HookConsumerWidget {
         align: textAlign,
         opacity: this.style?.color?.a ?? defaultTextStyle.color?.a ?? 1.0,
       ),
-      simple: simple,
       emojis: emojis,
       author: author,
       noteId: noteId,
@@ -167,6 +192,7 @@ class Mfm extends HookConsumerWidget {
       onClickEv: onClickEv,
       overflow: overflow,
       maxLines: maxLines,
+      needsIsolate: needsIsolate,
       enableEmojiFadeIn: enableEmojiFadeIn,
       enableAdvanced: enableAdvanced,
       enableAnimation: enableAnimation,
@@ -179,6 +205,169 @@ class Mfm extends HookConsumerWidget {
       emojiStyle: emojiStyle,
       colors: colors,
     );
+  }
+}
+
+class _SimpleMfm extends StatelessWidget {
+  const _SimpleMfm({
+    required this.account,
+    required this.leadingSpans,
+    required this.nodes,
+    required this.trailingSpans,
+    required this.builder,
+    required this.config,
+    required this.emojis,
+    required this.author,
+    required this.overflow,
+    required this.maxLines,
+    required this.needsIsolate,
+    required this.enableEmojiFadeIn,
+    required this.emojiStyle,
+  });
+
+  final Account account;
+  final List<InlineSpan>? leadingSpans;
+  final List<MfmNode>? nodes;
+  final List<InlineSpan>? trailingSpans;
+  final Widget Function(BuildContext context, InlineSpan span)? builder;
+  final MfmConfig config;
+  final Map<String, String>? emojis;
+  final User? author;
+  final TextOverflow? overflow;
+  final int? maxLines;
+  final bool needsIsolate;
+  final bool? enableEmojiFadeIn;
+  final EmojiStyle emojiStyle;
+
+  List<InlineSpan> _buildNodes(
+    BuildContext context,
+    MfmConfig config,
+    List<MfmNode> nodes,
+  ) {
+    return [
+      for (final node in nodes)
+        if (_buildNode(context, config, node) case final span?) span,
+    ];
+  }
+
+  InlineSpan? _buildNode(BuildContext context, MfmConfig config, MfmNode node) {
+    switch (node) {
+      case MfmText(:final text):
+        return TextSpan(
+          text: text.replaceAll('\n', ' '),
+          style: config.style.apply(
+            fontSizeFactor: config.scale,
+            color: config.style.color?.withValues(
+              alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+            ),
+          ),
+        );
+      case MfmEmojiCode(:final name):
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.middle,
+          child: maxLines == 1
+              ? LayoutBuilder(
+                  builder: (context, constraints) => ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: constraints.maxWidth - config.style.fontSize!,
+                    ),
+                    child: CustomEmoji(
+                      account: account,
+                      emoji: ':$name:',
+                      url: emojis?[name],
+                      host: author?.host,
+                      opacity: config.opacity,
+                      alignment: Alignment.centerLeft,
+                      fallbackTextStyle: config.style.copyWith(height: 1.0),
+                      fallbackToImage: false,
+                      enableFadeIn: enableEmojiFadeIn,
+                    ),
+                  ),
+                )
+              : CustomEmoji(
+                  account: account,
+                  emoji: ':$name:',
+                  url: emojis?[name],
+                  host: author?.host,
+                  useOriginalSize: config.scale >= 2.5,
+                  height: config.style.fontSize! * config.scale,
+                  opacity: config.opacity,
+                  fit: BoxFit.cover,
+                  alignment: Alignment.centerLeft,
+                  fallbackTextStyle: config.style
+                      .apply(
+                        fontSizeFactor: config.scale,
+                        color: config.style.color?.withValues(
+                          alpha:
+                              (config.style.color?.a ?? 1.0) * config.opacity,
+                        ),
+                      )
+                      .copyWith(height: 1.0),
+                  fallbackToImage: false,
+                  enableFadeIn: enableEmojiFadeIn,
+                ),
+        );
+      case MfmUnicodeEmoji(:final emoji):
+        return WidgetSpan(
+          alignment: switch (emojiStyle) {
+            EmojiStyle.native => PlaceholderAlignment.baseline,
+            EmojiStyle.twemoji => PlaceholderAlignment.middle,
+          },
+          baseline: TextBaseline.alphabetic,
+          child: UnicodeEmoji(
+            account: account,
+            emoji: emoji,
+            style: config.style.apply(
+              fontSizeFactor: config.scale,
+              color: config.style.color?.withValues(
+                alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+              ),
+            ),
+            inline: true,
+            fit: BoxFit.cover,
+            alignment: Alignment.centerLeft,
+          ),
+        );
+      case MfmPlain(:final text):
+        return TextSpan(
+          text: text,
+          style: config.style.apply(
+            fontSizeFactor: config.scale,
+            color: config.style.color?.withValues(
+              alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+            ),
+          ),
+        );
+      default:
+        return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final needsIsolate =
+        defaultTargetPlatform != TargetPlatform.linux &&
+        (builder != null || (trailingSpans?.isNotEmpty ?? false));
+    final span = TextSpan(
+      children: [
+        ...?leadingSpans,
+        if (needsIsolate) const TextSpan(text: Unicode.FSI),
+        if (nodes case final nodes?) ..._buildNodes(context, config, nodes),
+        if (needsIsolate) const TextSpan(text: Unicode.PDI),
+        ...?trailingSpans,
+      ],
+    );
+
+    if (builder case final builder?) {
+      return builder(context, span);
+    } else {
+      return Text.rich(
+        span,
+        textAlign: config.align,
+        overflow: overflow,
+        maxLines: maxLines,
+      );
+    }
   }
 }
 
@@ -239,22 +428,22 @@ MfmInline _removeNewLines(MfmInline node) {
 class _Mfm extends StatelessWidget {
   const _Mfm({
     required this.account,
-    this.leadingSpans,
+    required this.leadingSpans,
     required this.nodes,
-    this.trailingSpans,
-    this.builder,
+    required this.trailingSpans,
+    required this.builder,
     required this.config,
-    required this.simple,
-    this.emojis,
-    this.author,
-    this.noteId,
-    this.messageId,
+    required this.emojis,
+    required this.author,
+    required this.noteId,
+    required this.messageId,
     required this.shouldNyaize,
     required this.isUserDescription,
-    this.onClickEv,
-    this.overflow,
-    this.maxLines,
-    this.enableEmojiFadeIn,
+    required this.onClickEv,
+    required this.overflow,
+    required this.maxLines,
+    required this.needsIsolate,
+    required this.enableEmojiFadeIn,
     required this.enableAdvanced,
     required this.enableAnimation,
     required this.serifFontFamily,
@@ -273,7 +462,6 @@ class _Mfm extends StatelessWidget {
   final List<InlineSpan>? trailingSpans;
   final Widget Function(BuildContext context, InlineSpan span)? builder;
   final MfmConfig config;
-  final bool simple;
   final Map<String, String>? emojis;
   final User? author;
   final String? noteId;
@@ -283,6 +471,7 @@ class _Mfm extends StatelessWidget {
   final void Function(String clickEv)? onClickEv;
   final TextOverflow? overflow;
   final int? maxLines;
+  final bool needsIsolate;
   final bool? enableEmojiFadeIn;
   final bool enableAdvanced;
   final bool enableAnimation;
@@ -309,11 +498,7 @@ class _Mfm extends StatelessWidget {
   InlineSpan? _buildNode(BuildContext context, MfmConfig config, MfmNode node) {
     return switch (node) {
       MfmText(:final text) => TextSpan(
-        text: simple
-            ? text.replaceAll('\n', ' ')
-            : !config.disableNyaize && shouldNyaize
-            ? nyaize(text)
-            : text,
+        text: !config.disableNyaize && shouldNyaize ? nyaize(text) : text,
         style: config.style.apply(
           fontSizeFactor: config.scale,
           color: config.style.color?.withValues(
@@ -537,7 +722,7 @@ class _Mfm extends StatelessWidget {
       ),
       MfmEmojiCode(:final name) => WidgetSpan(
         alignment: PlaceholderAlignment.middle,
-        child: simple && maxLines == 1
+        child: maxLines == 1
             ? LayoutBuilder(
                 builder: (context, constraints) => ConstrainedBox(
                   constraints: BoxConstraints(
@@ -562,32 +747,25 @@ class _Mfm extends StatelessWidget {
                 url: emojis?[name],
                 host: author?.host,
                 useOriginalSize: config.scale >= 2.5,
-                height:
-                    config.style.fontSize! *
-                    config.scale *
-                    (simple ? 1.0 : 2.0),
+                height: config.style.fontSize! * config.scale * 2.0,
                 opacity: config.opacity,
                 fit: BoxFit.cover,
                 alignment: Alignment.centerLeft,
-                onTap: !simple
-                    ? () => showModalBottomSheet<void>(
-                        context: context,
-                        builder: (context) => EmojiSheet(
-                          account: account,
-                          emoji: ':$name@${author?.host ?? '.'}:',
-                          targetNoteId: noteId,
-                          targetMessageId: messageId,
-                        ),
-                      )
-                    : null,
-                fallbackTextStyle: config.style
-                    .apply(
-                      fontSizeFactor: config.scale,
-                      color: config.style.color?.withValues(
-                        alpha: (config.style.color?.a ?? 1.0) * config.opacity,
-                      ),
-                    )
-                    .copyWith(height: simple ? 1.0 : null),
+                onTap: () => showModalBottomSheet<void>(
+                  context: context,
+                  builder: (context) => EmojiSheet(
+                    account: account,
+                    emoji: ':$name@${author?.host ?? '.'}:',
+                    targetNoteId: noteId,
+                    targetMessageId: messageId,
+                  ),
+                ),
+                fallbackTextStyle: config.style.apply(
+                  fontSizeFactor: config.scale,
+                  color: config.style.color?.withValues(
+                    alpha: (config.style.color?.a ?? 1.0) * config.opacity,
+                  ),
+                ),
                 fallbackToImage: false,
                 enableFadeIn: enableEmojiFadeIn,
               ),
@@ -607,17 +785,15 @@ class _Mfm extends StatelessWidget {
               alpha: (config.style.color?.a ?? 1.0) * config.opacity,
             ),
           ),
-          onTap: !simple
-              ? () => showModalBottomSheet<void>(
-                  context: context,
-                  builder: (context) => EmojiSheet(
-                    account: account,
-                    emoji: emoji,
-                    targetNoteId: noteId,
-                    targetMessageId: messageId,
-                  ),
-                )
-              : null,
+          onTap: () => showModalBottomSheet<void>(
+            context: context,
+            builder: (context) => EmojiSheet(
+              account: account,
+              emoji: emoji,
+              targetNoteId: noteId,
+              targetMessageId: messageId,
+            ),
+          ),
           inline: true,
           fit: BoxFit.cover,
           alignment: Alignment.centerLeft,
@@ -1294,9 +1470,6 @@ class _Mfm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final needsIsolate =
-        (builder != null || (trailingSpans?.isNotEmpty ?? false)) &&
-        defaultTargetPlatform != TargetPlatform.linux;
     final span = TextSpan(
       children: [
         ...?leadingSpans,

--- a/lib/view/widget/url_widget.dart
+++ b/lib/view/widget/url_widget.dart
@@ -8,6 +8,84 @@ import '../../provider/misskey_colors_provider.dart';
 import '../../util/punycode.dart';
 import 'url_sheet.dart';
 
+String _decodeComponent(String encodedComponent) {
+  try {
+    return Uri.decodeComponent(encodedComponent);
+  } catch (_) {
+    return encodedComponent;
+  }
+}
+
+String _decodeQueryComponent(String encodedComponent) {
+  try {
+    return Uri.decodeQueryComponent(encodedComponent);
+  } catch (_) {
+    // TODO: Decode other encodings.
+    return encodedComponent;
+  }
+}
+
+typedef DisplayUrl = ({
+  String? scheme,
+  String host,
+  String? port,
+  String path,
+  String? query,
+  String? fragment,
+});
+
+DisplayUrl parseDisplayUrl(Uri url) {
+  return (
+    scheme: url.hasScheme ? '${url.scheme.breakAll}://' : null,
+    host: toUnicode(url.host).breakAll,
+    port: url.hasPort ? ':${url.port.toString().breakAll}' : null,
+    path: _decodeComponent(url.path).breakAll,
+    query: url.hasQuery
+        ? '?${_decodeQueryComponent(url.query).breakAll}'
+        : null,
+    fragment: url.hasFragment
+        ? '#${_decodeQueryComponent(url.fragment).breakAll}'
+        : null,
+  );
+}
+
+TextSpan buildUrlSpan({
+  required DisplayUrl url,
+  TextSpan Function({String? text, TextStyle? style}) textSpanBuilder =
+      TextSpan.new,
+  Color? color,
+  double opacity = 1.0,
+}) {
+  return TextSpan(
+    children: [
+      if (url.scheme != null)
+        textSpanBuilder(
+          text: url.scheme,
+          style: TextStyle(color: color?.withValues(alpha: opacity * 0.5)),
+        ),
+      textSpanBuilder(
+        text: url.host,
+        style: const TextStyle(fontWeight: FontWeight.bold),
+      ),
+      if (url.port != null) textSpanBuilder(text: url.port),
+      textSpanBuilder(
+        text: url.path,
+        style: TextStyle(color: color?.withValues(alpha: opacity * 0.8)),
+      ),
+      if (url.query != null)
+        textSpanBuilder(
+          text: url.query,
+          style: TextStyle(color: color?.withValues(alpha: opacity * 0.5)),
+        ),
+      if (url.fragment != null)
+        textSpanBuilder(
+          text: url.fragment,
+          style: const TextStyle(fontStyle: FontStyle.italic),
+        ),
+    ],
+  );
+}
+
 class UrlWidget extends HookWidget {
   const UrlWidget({
     required this.url,
@@ -33,57 +111,16 @@ class UrlWidget extends HookWidget {
   final TextScaler? textScaler;
   final int? maxLines;
 
-  String _decodeComponent(String encodedComponent) {
-    try {
-      return Uri.decodeComponent(encodedComponent);
-    } catch (_) {
-      return encodedComponent;
-    }
-  }
-
-  String _decodeQueryComponent(String encodedComponent) {
-    try {
-      return Uri.decodeQueryComponent(encodedComponent);
-    } catch (_) {
-      // TODO: Decode other encodings.
-      return encodedComponent;
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final url = useMemoized(() => Uri.tryParse(this.url), [this.url]);
+    final url = useMemoized(
+      () => switch (Uri.tryParse(this.url)) {
+        final url? => parseDisplayUrl(url),
+        _ => null,
+      },
+      [this.url],
+    );
     final style = DefaultTextStyle.of(context).style.merge(this.style);
-    if (url == null) {
-      return InkWell(
-        onTap: onTap,
-        onLongPress: () => showModalBottomSheet<void>(
-          context: context,
-          builder: (context) => UrlSheet(url: this.url),
-        ),
-        child: Text(
-          this.url,
-          style: style.apply(
-            fontSizeFactor: scale,
-            color: style.color?.withValues(alpha: opacity),
-          ),
-          textAlign: align,
-          overflow: overflow,
-          textScaler: textScaler,
-          maxLines: maxLines,
-          semanticsLabel: this.url,
-        ),
-      );
-    }
-
-    final scheme = url.scheme;
-    final host = useMemoized(() => toUnicode(url.host), [url.host]);
-    final port = url.port;
-    final path = useMemoized(() => _decodeComponent(url.path), [url.path]);
-    final query = useMemoized(() => _decodeQueryComponent(url.query), [
-      url.query,
-    ]);
-    final fragment = useMemoized(() => _decodeComponent(url.fragment));
 
     return InkWell(
       onTap: onTap,
@@ -94,36 +131,10 @@ class UrlWidget extends HookWidget {
       child: Text.rich(
         TextSpan(
           children: [
-            if (scheme.isNotEmpty)
-              TextSpan(
-                text: '$scheme://'.breakAll,
-                style: TextStyle(
-                  color: style.color?.withValues(alpha: opacity * 0.5),
-                ),
-              ),
-            TextSpan(
-              text: host.breakAll,
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
-            if (url.hasPort) TextSpan(text: ':$port'.breakAll),
-            TextSpan(
-              text: path.breakAll,
-              style: TextStyle(
-                color: style.color?.withValues(alpha: opacity * 0.8),
-              ),
-            ),
-            if (query.isNotEmpty)
-              TextSpan(
-                text: '?$query'.breakAll,
-                style: TextStyle(
-                  color: style.color?.withValues(alpha: opacity * 0.5),
-                ),
-              ),
-            if (fragment.isNotEmpty)
-              TextSpan(
-                text: '#$fragment'.breakAll,
-                style: const TextStyle(fontStyle: FontStyle.italic),
-              ),
+            if (url != null)
+              buildUrlSpan(url: url, color: style.color)
+            else
+              TextSpan(text: this.url),
             WidgetSpan(
               child: Icon(
                 Icons.open_in_new,
@@ -145,7 +156,7 @@ class UrlWidget extends HookWidget {
         overflow: overflow,
         textScaler: textScaler,
         maxLines: maxLines,
-        semanticsLabel: url.toString(),
+        semanticsLabel: this.url,
       ),
     );
   }
@@ -162,7 +173,7 @@ class _VerifiedIcon extends ConsumerWidget {
         Icons.check_circle_outline,
         color: ref.watch(
           misskeyColorsProvider(
-            Theme.of(context).brightness,
+            Theme.brightnessOf(context),
           ).select((colors) => colors.success),
         ),
         size: DefaultTextStyle.of(context).style.fontSize,

--- a/lib/view/widget/url_widget.dart
+++ b/lib/view/widget/url_widget.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../extension/string_extension.dart';
-import '../../i18n/strings.g.dart';
-import '../../provider/misskey_colors_provider.dart';
 import '../../util/punycode.dart';
 import 'url_sheet.dart';
 
@@ -89,7 +86,6 @@ TextSpan buildUrlSpan({
 class UrlWidget extends HookWidget {
   const UrlWidget({
     required this.url,
-    this.verified = false,
     this.onTap,
     this.style,
     this.scale = 1.0,
@@ -101,7 +97,6 @@ class UrlWidget extends HookWidget {
   });
 
   final String url;
-  final bool verified;
   final void Function()? onTap;
   final TextStyle? style;
   final double scale;
@@ -142,10 +137,6 @@ class UrlWidget extends HookWidget {
                 size: style.fontSize! * scale,
               ),
             ),
-            if (verified) ...[
-              const WidgetSpan(child: SizedBox(width: 2.0)),
-              const WidgetSpan(child: _VerifiedIcon()),
-            ],
           ],
         ),
         style: style.apply(
@@ -157,26 +148,6 @@ class UrlWidget extends HookWidget {
         textScaler: textScaler,
         maxLines: maxLines,
         semanticsLabel: this.url,
-      ),
-    );
-  }
-}
-
-class _VerifiedIcon extends ConsumerWidget {
-  const _VerifiedIcon();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Tooltip(
-      message: t.misskey.verifiedLink,
-      child: Icon(
-        Icons.check_circle_outline,
-        color: ref.watch(
-          misskeyColorsProvider(
-            Theme.brightnessOf(context),
-          ).select((colors) => colors.success),
-        ),
-        size: DefaultTextStyle.of(context).style.fontSize,
       ),
     );
   }


### PR DESCRIPTION
Changed to use `TextSpan` and `GestureRecognizer` to handle gestures for urls, links, and hashtags in MFM.

Previously, links were wrapped with `WidgetSpan` and `InkWell` to capture tap and long-press events. Since widgets in Flutter are rectangles, they move to the next line when there is not enough remaining space in the current line, causing #966.

With this PR, links are wrapped with `TextSpan` instead, and the gesture events are captured by `GestureRecognizer`s. To mimic the splash effect of `InkWell`, the background color of `TextSpan` changes while it is being tapped. `GestureRecognizer` is customized to stop gesture event propagation immediately and to handle both tap and long-press events.

Close #966