### PR TITLE
fix: add border radius to url preview

### DIFF
--- a/lib/view/widget/url_preview.dart
+++ b/lib/view/widget/url_preview.dart
@@ -149,10 +149,11 @@ class UrlPreview extends HookConsumerWidget {
                     context: context,
                     builder: (context) => UrlSheet(url: link),
                   ),
+                  borderRadius: BorderRadius.circular(4.0),
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       border: Border.all(
-                        color: Theme.of(context).colorScheme.outlineVariant,
+                        color: colors.divider,
                         strokeAlign: BorderSide.strokeAlignOutside,
                       ),
                       borderRadius: BorderRadius.circular(4.0),


### PR DESCRIPTION
Fixed an issue where `InkWell` in `UrlPreview` renders a splash effect over the border.