### PR TITLE
fix: wait for persist to complete before returning value

### DIFF
--- a/lib/provider/api/endpoints_notifier_provider.dart
+++ b/lib/provider/api/endpoints_notifier_provider.dart
@@ -14,14 +14,16 @@ class EndpointsNotifier extends _$EndpointsNotifier {
   @override
   FutureOr<List<String>> build(String host) async {
     final link = ref.keepAlive();
-    persist(ref.watch(riverpodStorageProvider.future));
+    final persistResult = persist(ref.watch(riverpodStorageProvider.future));
     try {
       final endpoints = await ref
           .watch(misskeyProvider(Account(host: host)))
           .endpoints();
+      await persistResult.future;
       return endpoints;
     } catch (_) {
       link.close();
+      await persistResult.future;
       if (state.value case final endpoints?) {
         return endpoints;
       }

--- a/lib/provider/api/endpoints_notifier_provider.g.dart
+++ b/lib/provider/api/endpoints_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class EndpointsNotifierProvider
   }
 }
 
-String _$endpointsNotifierHash() => r'57baa3332c348703e927be6674200cc094fe3209';
+String _$endpointsNotifierHash() => r'19e80ea94d32ea3aad67e2ef40353f1cbf4a8c0f';
 
 @JsonPersist()
 final class EndpointsNotifierFamily extends $Family

--- a/lib/provider/api/i_notifier_provider.dart
+++ b/lib/provider/api/i_notifier_provider.dart
@@ -30,12 +30,14 @@ class INotifier extends _$INotifier {
         ref.read(notesNotifierProvider(account).notifier).addAll(pinnedNotes);
       }
     });
-    persist(ref.watch(riverpodStorageProvider.future));
+    final persistResult = persist(ref.watch(riverpodStorageProvider.future));
     try {
       final i = await _misskey.i.i();
+      await persistResult.future;
       return i;
     } catch (_) {
       link.close();
+      await persistResult.future;
       if (state.value case final i?) {
         return i;
       }

--- a/lib/provider/api/i_notifier_provider.g.dart
+++ b/lib/provider/api/i_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class INotifierProvider
   }
 }
 
-String _$iNotifierHash() => r'305ab6de54e1bf6c16762395ac7ad8e3e7dcbeb3';
+String _$iNotifierHash() => r'44144694f0868413ee8add08f442c213ae2346e1';
 
 @JsonPersist()
 final class INotifierFamily extends $Family

--- a/lib/provider/api/meta_notifier_provider.dart
+++ b/lib/provider/api/meta_notifier_provider.dart
@@ -15,12 +15,14 @@ class MetaNotifier extends _$MetaNotifier {
   @override
   FutureOr<MetaResponse> build(String host) async {
     final link = ref.keepAlive();
-    persist(ref.watch(riverpodStorageProvider.future));
+    final persistResult = persist(ref.watch(riverpodStorageProvider.future));
     try {
       final meta = await ref.read(misskeyProvider(Account(host: host))).meta();
+      await persistResult.future;
       return meta;
     } catch (_) {
       link.close();
+      await persistResult.future;
       if (state.value case final meta?) {
         return meta;
       }

--- a/lib/provider/api/meta_notifier_provider.g.dart
+++ b/lib/provider/api/meta_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class MetaNotifierProvider
   }
 }
 
-String _$metaNotifierHash() => r'1b7df220286a85f8d2f422db70c44cef4ec34ddd';
+String _$metaNotifierHash() => r'4646792a521f70e2a32db170b3d59ec843e0699b';
 
 @JsonPersist()
 final class MetaNotifierFamily extends $Family

--- a/lib/provider/emojis_notifier_provider.dart
+++ b/lib/provider/emojis_notifier_provider.dart
@@ -18,15 +18,17 @@ class EmojisNotifier extends _$EmojisNotifier {
   @override
   FutureOr<Map<String, Emoji>> build(String host) async {
     ref.onDispose(() => _timer?.cancel());
-    persist(ref.watch(riverpodStorageProvider.future));
+    final persistResult = persist(ref.watch(riverpodStorageProvider.future));
     try {
       final response = await _fetchEmojis();
       _recentlyFetched = true;
       _timer = Timer(const Duration(minutes: 10), () {
         _recentlyFetched = false;
       });
+      await persistResult.future;
       return {for (final emoji in response) emoji.name: emoji};
     } catch (_) {
+      await persistResult.future;
       if (state.value case final emojis?) {
         return emojis;
       }

--- a/lib/provider/emojis_notifier_provider.g.dart
+++ b/lib/provider/emojis_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class EmojisNotifierProvider
   }
 }
 
-String _$emojisNotifierHash() => r'435830bddf419cf81d54c762750299c769810203';
+String _$emojisNotifierHash() => r'16c25b3948db840d628ccd5f9d9f3c774330b60c';
 
 @JsonPersist()
 final class EmojisNotifierFamily extends $Family


### PR DESCRIPTION
Fixed an issue where `provider.future` never completes if a cached value from `persist` is loaded after the API call is done.