### PR TITLE
fix: paginate with date range for user notes

### DIFF
--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.dart
@@ -35,13 +35,19 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
 
   Duration _duration = const Duration(minutes: 1);
 
-  Future<Iterable<Note>> _fetchNotesFromCustomTimeline(String? sinceId) async {
+  Future<Iterable<Note>> _fetchNotesFromCustomTimeline({
+    String? sinceId,
+    DateTime? sinceDate,
+    DateTime? untilDate,
+  }) async {
     final endpoint = tabSettings.endpoint;
-    if (endpoint == null) {
+    if (endpoint == null || endpoint.contains('//')) {
       return [];
     }
     final response = await _misskey.apiService.post<List<dynamic>>(endpoint, {
       'sinceId': ?sinceId,
+      'sinceDate': ?sinceDate?.millisecondsSinceEpoch,
+      'untilDate': ?untilDate?.millisecondsSinceEpoch,
       'withRenotes': tabSettings.withRenotes,
       'withReplies': tabSettings.withReplies,
       'withFiles': tabSettings.withFiles,
@@ -141,17 +147,26 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
         NotesSearchByTagRequest(
           tag: tabSettings.hashtag!,
           sinceId: sinceId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           reply: tabSettings.withReplies ? null : false,
           withFiles: tabSettings.withFiles,
         ),
       ),
       TabType.mention => _misskey.notes.mentions(
-        NotesMentionsRequest(sinceId: sinceId, limit: limit),
+        NotesMentionsRequest(
+          sinceId: sinceId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
+          limit: limit,
+        ),
       ),
       TabType.direct => _misskey.notes.mentions(
         NotesMentionsRequest(
           sinceId: sinceId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           visibility: NoteVisibility.specified,
         ),
@@ -172,7 +187,11 @@ class TimelineNotesAfterNoteNotifier extends _$TimelineNotesAfterNoteNotifier {
       TabType.notifications => throw UnsupportedError(
         '_fetchNote() for TabType.notifications is not supported',
       ),
-      TabType.custom => _fetchNotesFromCustomTimeline(sinceId),
+      TabType.custom => _fetchNotesFromCustomTimeline(
+        sinceId: sinceId,
+        sinceDate: sinceDate,
+        untilDate: untilDate,
+      ),
     };
     ref.read(notesNotifierProvider(tabSettings.account).notifier).addAll(notes);
     return (sinceId != null

--- a/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_after_note_notifier_provider.g.dart
@@ -57,7 +57,7 @@ final class TimelineNotesAfterNoteNotifierProvider
 }
 
 String _$timelineNotesAfterNoteNotifierHash() =>
-    r'72603189a968769dda30b7c8898dd3088a5ebee8';
+    r'd7825af8122ab585a3e459c1ad0fa5ad5adf1d3e';
 
 final class TimelineNotesAfterNoteNotifierFamily extends $Family
     with

--- a/lib/provider/api/timeline_notes_notifier_provider.dart
+++ b/lib/provider/api/timeline_notes_notifier_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -19,7 +20,17 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
     TabSettings tabSettings, {
     String? untilId,
   }) async* {
-    final response = await _fetchNotes(untilId: untilId, limit: 30);
+    final response = tabSettings.tabType == TabType.user
+        ? untilId != null
+              ? switch (Id.tryParse(untilId)?.date) {
+                  final untilDate? => await _fetchNotesEagerly(
+                    untilDate: untilDate,
+                    limit: 30,
+                  ),
+                  _ => await _fetchNotes(untilId: untilId),
+                }
+              : await _fetchNotesEagerly(untilDate: DateTime.now(), limit: 30)
+        : await _fetchNotes(untilId: untilId, limit: 30);
     yield PaginationState.fromIterable(response);
     if (response.isNotEmpty && response.length < 10) {
       await loadMore();
@@ -30,15 +41,19 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
 
   Future<Iterable<Note>> _fetchNotesFromCustomTimeline({
     String? untilId,
+    DateTime? sinceDate,
+    DateTime? untilDate,
     int? limit,
   }) async {
     final endpoint = tabSettings.endpoint;
-    if (endpoint == null) {
+    if (endpoint == null || endpoint.contains('//')) {
       return [];
     }
     final response = await _misskey.apiService.post<List<dynamic>>(endpoint, {
-      if (untilId != null) 'untilId': untilId,
-      if (limit != null) 'limit': limit,
+      'untilId': ?untilId,
+      'sinceDate': ?sinceDate?.millisecondsSinceEpoch,
+      'untilDate': ?untilDate?.millisecondsSinceEpoch,
+      'limit': ?limit,
       'withRenotes': tabSettings.withRenotes,
       'withReplies': tabSettings.withReplies,
       'withFiles': tabSettings.withFiles,
@@ -47,11 +62,18 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
     return response.map((e) => Note.fromJson(e as Map<String, dynamic>));
   }
 
-  Future<Iterable<Note>> _fetchNotes({String? untilId, int? limit}) async {
+  Future<Iterable<Note>> _fetchNotes({
+    String? untilId,
+    DateTime? sinceDate,
+    DateTime? untilDate,
+    int? limit,
+  }) async {
     final notes = await switch (tabSettings.tabType) {
       TabType.homeTimeline => _misskey.notes.homeTimeline(
         NotesTimelineRequest(
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           withRenotes: tabSettings.withRenotes,
           withFiles: tabSettings.withFiles,
@@ -61,6 +83,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.localTimeline => _misskey.notes.localTimeline(
         NotesLocalTimelineRequest(
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           withRenotes: tabSettings.withRenotes,
           withReplies: tabSettings.withReplies,
@@ -71,6 +95,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.hybridTimeline => _misskey.notes.hybridTimeline(
         NotesHybridTimelineRequest(
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           withRenotes: tabSettings.withRenotes,
           withReplies: tabSettings.withReplies,
@@ -81,6 +107,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       TabType.globalTimeline => _misskey.notes.globalTimeline(
         NotesGlobalTimelineRequest(
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           withRenotes: tabSettings.withRenotes,
           withFiles: tabSettings.withFiles,
@@ -90,6 +118,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
         RolesNotesRequest(
           roleId: tabSettings.roleId!,
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
         ),
       ),
@@ -97,6 +127,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
         UserListTimelineRequest(
           listId: tabSettings.listId!,
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           withRenotes: tabSettings.withRenotes,
           withFiles: tabSettings.withFiles,
@@ -107,6 +139,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
         AntennasNotesRequest(
           antennaId: tabSettings.antennaId!,
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           pagination: untilId != null
               ? Id.tryParse(untilId)?.date.millisecondsSinceEpoch.toString()
@@ -117,6 +151,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
         ChannelsTimelineRequest(
           channelId: tabSettings.channelId!,
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           allowPartial: true,
         ),
@@ -125,17 +161,26 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
         NotesSearchByTagRequest(
           tag: tabSettings.hashtag!,
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           reply: tabSettings.withReplies ? null : false,
           withFiles: tabSettings.withFiles,
         ),
       ),
       TabType.mention => _misskey.notes.mentions(
-        NotesMentionsRequest(untilId: untilId, limit: limit),
+        NotesMentionsRequest(
+          untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
+          limit: limit,
+        ),
       ),
       TabType.direct => _misskey.notes.mentions(
         NotesMentionsRequest(
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           visibility: NoteVisibility.specified,
         ),
@@ -144,6 +189,8 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
         UsersNotesRequest(
           userId: tabSettings.userId!,
           untilId: untilId,
+          sinceDate: sinceDate,
+          untilDate: untilDate,
           limit: limit,
           withRenotes: tabSettings.withRenotes,
           withReplies: tabSettings.withReplies,
@@ -157,15 +204,35 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
       ),
       TabType.custom => _fetchNotesFromCustomTimeline(
         untilId: untilId,
+        sinceDate: sinceDate,
+        untilDate: untilDate,
         limit: limit,
       ),
     };
     ref.read(notesNotifierProvider(tabSettings.account).notifier).addAll(notes);
     if (untilId != null) {
       return notes.where((note) => note.id.compareTo(untilId) < 0);
+    } else if (untilDate != null) {
+      return notes.where((note) => note.createdAt.isBefore(untilDate));
     } else {
       return notes;
     }
+  }
+
+  Future<Iterable<Note>> _fetchNotesEagerly({
+    required DateTime untilDate,
+    int? limit,
+  }) async {
+    final sinceDate = untilDate.subtract(const Duration(days: 100));
+    final response = await _fetchNotes(
+      sinceDate: sinceDate,
+      untilDate: untilDate,
+      limit: limit,
+    );
+    if (response.isNotEmpty) {
+      return response;
+    }
+    return _fetchNotes(untilDate: sinceDate, limit: limit);
   }
 
   Future<void> loadMore({bool skipError = false}) async {
@@ -181,7 +248,9 @@ class TimelineNotesNotifier extends _$TimelineNotesNotifier {
     bool shouldLoadMore = false;
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final response = await _fetchNotes(untilId: value.items.lastOrNull?.id);
+      final response = tabSettings.tabType == TabType.user
+          ? await _fetchNotesEagerly(untilDate: value.items.last.createdAt)
+          : await _fetchNotes(untilId: value.items.lastOrNull?.id);
       shouldLoadMore = response.isNotEmpty && response.length < 5;
       return PaginationState(
         items: [...value.items, ...response],

--- a/lib/provider/api/timeline_notes_notifier_provider.g.dart
+++ b/lib/provider/api/timeline_notes_notifier_provider.g.dart
@@ -52,7 +52,7 @@ final class TimelineNotesNotifierProvider
 }
 
 String _$timelineNotesNotifierHash() =>
-    r'07e0dac622ee39eac98506c3d915a5d62afc8167';
+    r'9d6ffcd11e0a6971c171ed74220588eebd5a6e30';
 
 final class TimelineNotesNotifierFamily extends $Family
     with

--- a/lib/view/page/settings/tab_settings_page.dart
+++ b/lib/view/page/settings/tab_settings_page.dart
@@ -711,7 +711,8 @@ class TabSettingsPage extends HookConsumerWidget {
                         );
                         if (result != null) {
                           if (!context.mounted) return;
-                          if (RegExp(r'^[\w\/\-]{0,100}$').hasMatch(result)) {
+                          if (RegExp(r'^[\w\/\-]{0,100}$').hasMatch(result) &&
+                              !result.contains('//')) {
                             tabSettings.value = tabSettings.value.copyWith(
                               endpoint: result.isNotEmpty ? result : null,
                             );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1429,8 +1429,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ebd8ae33c1c9bbd4dc93c2b43b477f9425ec2ee5
-      resolved-ref: ebd8ae33c1c9bbd4dc93c2b43b477f9425ec2ee5
+      ref: "14176c515a005a9fb01d3e6365a49b5a5d387a92"
+      resolved-ref: "14176c515a005a9fb01d3e6365a49b5a5d387a92"
       url: "https://github.com/poppingmoon/misskey_dart"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dependencies:
   misskey_dart:
     git:
       url: https://github.com/poppingmoon/misskey_dart
-      ref: ebd8ae33c1c9bbd4dc93c2b43b477f9425ec2ee5
+      ref: 14176c515a005a9fb01d3e6365a49b5a5d387a92
   mobile_scanner:
     git:
       url: https://github.com/poppingmoon/mobile_scanner


### PR DESCRIPTION
Changed to use `sinceDate` and `untilDate` to paginate `users/notes` to prevent notes from being missed.