### PR TITLE
ci: run flutter analyze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
         run: flutter pub get
 
       - name: Analyze
-        uses: invertase/github-action-dart-analyzer@e981b01a458d0bab71ee5da182e5b26687b7101b # v3.0.0
-        with:
-          fatal-infos: true
+        run: flutter analyze
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed archived [invertase/github-action-dart-analyzer](https://github.com/invertase/github-action-dart-analyzer) action and replaced it with a `flutter analyze` invocation.