### PR TITLE
fix: disable newlines in Ui:C:textInput

### DIFF
--- a/lib/view/widget/as_ui_widget.dart
+++ b/lib/view/widget/as_ui_widget.dart
@@ -420,6 +420,7 @@ class AsUiWidget extends ConsumerWidget {
           onChanged: onInput != null
               ? (value) => onInput.call(value: value)
               : null,
+          maxLines: 1,
         );
       case AsUiComponent_NumberInput(
         field0: AsUiNumberInput(


### PR DESCRIPTION
Fixed an issue where `Ui:C:textInput` allowed input containing newlines.