### PR TITLE
fix: ignore horizontal swipe for timeline header resizing

### DIFF
--- a/lib/view/widget/timeline_widget.dart
+++ b/lib/view/widget/timeline_widget.dart
@@ -369,7 +369,9 @@ class TimelineWidget extends HookConsumerWidget {
             Expanded(
               child: NotificationListener<ScrollNotification>(
                 onNotification: (notification) {
-                  if (alwaysShowHeader || isMenuExpanded.value) {
+                  if (alwaysShowHeader ||
+                      isMenuExpanded.value ||
+                      notification.metrics.axis == Axis.horizontal) {
                     return false;
                   }
                   switch (notification) {


### PR DESCRIPTION
Fixed an issue where the timeline header size changes when swiping a code block horizontally.