### PR TITLE
perf: index custom emojis by name

### DIFF
--- a/lib/provider/custom_emoji_index_provider.dart
+++ b/lib/provider/custom_emoji_index_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../extension/string_extension.dart';
@@ -10,19 +9,21 @@ part 'custom_emoji_index_provider.g.dart';
 
 final _separators = RegExp('[_+-]+');
 
-Map<String, Set<Emoji>> _buildCustomEmojiIndex(Iterable<Emoji> emojis) {
-  final index = <String, Set<Emoji>>{};
+Map<String, Set<String>> _buildCustomEmojiIndex(
+  Iterable<({String name, List<String> aliases})> emojis,
+) {
+  final index = <String, Set<String>>{};
   for (final emoji in emojis) {
     final name = emoji.name.toLowerCase();
-    index.putIfAbsent(name, () => {}).add(emoji);
+    index.putIfAbsent(name, () => {}).add(emoji.name);
     final kanaName = safeToKatakana(name).replaceAll(_separators, '');
-    index.putIfAbsent(kanaName, () => {}).add(emoji);
+    index.putIfAbsent(kanaName, () => {}).add(emoji.name);
     for (final alias in emoji.aliases) {
       if (alias.isNotEmpty) {
         final hankakuAlias = alias.toHankaku().toLowerCase();
-        index.putIfAbsent(hankakuAlias, () => {}).add(emoji);
+        index.putIfAbsent(hankakuAlias, () => {}).add(emoji.name);
         final kanaAlias = safeToKatakana(hankakuAlias);
-        index.putIfAbsent(kanaAlias, () => {}).add(emoji);
+        index.putIfAbsent(kanaAlias, () => {}).add(emoji.name);
       }
     }
   }
@@ -30,8 +31,10 @@ Map<String, Set<Emoji>> _buildCustomEmojiIndex(Iterable<Emoji> emojis) {
 }
 
 @Riverpod(keepAlive: true)
-Future<Map<String, Set<Emoji>>> customEmojiIndex(Ref ref, String host) async {
+Future<Map<String, Set<String>>> customEmojiIndex(Ref ref, String host) async {
   final emojis = await ref.watch(emojisNotifierProvider(host).future);
-  final index = await compute(_buildCustomEmojiIndex, emojis.values);
-  return index;
+  return compute(
+    _buildCustomEmojiIndex,
+    emojis.values.map((emoji) => (name: emoji.name, aliases: emoji.aliases)),
+  );
 }

--- a/lib/provider/custom_emoji_index_provider.g.dart
+++ b/lib/provider/custom_emoji_index_provider.g.dart
@@ -15,13 +15,13 @@ final customEmojiIndexProvider = CustomEmojiIndexFamily._();
 final class CustomEmojiIndexProvider
     extends
         $FunctionalProvider<
-          AsyncValue<Map<String, Set<Emoji>>>,
-          Map<String, Set<Emoji>>,
-          FutureOr<Map<String, Set<Emoji>>>
+          AsyncValue<Map<String, Set<String>>>,
+          Map<String, Set<String>>,
+          FutureOr<Map<String, Set<String>>>
         >
     with
-        $FutureModifier<Map<String, Set<Emoji>>>,
-        $FutureProvider<Map<String, Set<Emoji>>> {
+        $FutureModifier<Map<String, Set<String>>>,
+        $FutureProvider<Map<String, Set<String>>> {
   CustomEmojiIndexProvider._({
     required CustomEmojiIndexFamily super.from,
     required String super.argument,
@@ -45,12 +45,12 @@ final class CustomEmojiIndexProvider
 
   @$internal
   @override
-  $FutureProviderElement<Map<String, Set<Emoji>>> $createElement(
+  $FutureProviderElement<Map<String, Set<String>>> $createElement(
     $ProviderPointer pointer,
   ) => $FutureProviderElement(pointer);
 
   @override
-  FutureOr<Map<String, Set<Emoji>>> create(Ref ref) {
+  FutureOr<Map<String, Set<String>>> create(Ref ref) {
     final argument = this.argument as String;
     return customEmojiIndex(ref, argument);
   }
@@ -66,10 +66,10 @@ final class CustomEmojiIndexProvider
   }
 }
 
-String _$customEmojiIndexHash() => r'b0b4f5411d2ea2ac82b7d5d09dc3b422937e6a82';
+String _$customEmojiIndexHash() => r'f63dbcb72b97f5ed8152746f4d88e60d9c2dfb1a';
 
 final class CustomEmojiIndexFamily extends $Family
-    with $FunctionalFamilyOverride<FutureOr<Map<String, Set<Emoji>>>, String> {
+    with $FunctionalFamilyOverride<FutureOr<Map<String, Set<String>>>, String> {
   CustomEmojiIndexFamily._()
     : super(
         retry: null,

--- a/lib/provider/search_custom_emojis_provider.dart
+++ b/lib/provider/search_custom_emojis_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:misskey_dart/misskey_dart.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../extension/string_extension.dart';
@@ -10,7 +9,7 @@ import 'custom_emoji_index_provider.dart';
 part 'search_custom_emojis_provider.g.dart';
 
 @riverpod
-Set<Emoji> searchCustomEmojis(Ref ref, String host, String query) {
+Set<String> searchCustomEmojis(Ref ref, String host, String query) {
   final link = ref.keepAlive();
   Timer? timer;
   ref.onCancel(() => timer = Timer(const Duration(minutes: 1), link.close));

--- a/lib/provider/search_custom_emojis_provider.g.dart
+++ b/lib/provider/search_custom_emojis_provider.g.dart
@@ -13,8 +13,8 @@ part of 'search_custom_emojis_provider.dart';
 final searchCustomEmojisProvider = SearchCustomEmojisFamily._();
 
 final class SearchCustomEmojisProvider
-    extends $FunctionalProvider<Set<Emoji>, Set<Emoji>, Set<Emoji>>
-    with $Provider<Set<Emoji>> {
+    extends $FunctionalProvider<Set<String>, Set<String>, Set<String>>
+    with $Provider<Set<String>> {
   SearchCustomEmojisProvider._({
     required SearchCustomEmojisFamily super.from,
     required (String, String) super.argument,
@@ -38,20 +38,20 @@ final class SearchCustomEmojisProvider
 
   @$internal
   @override
-  $ProviderElement<Set<Emoji>> $createElement($ProviderPointer pointer) =>
+  $ProviderElement<Set<String>> $createElement($ProviderPointer pointer) =>
       $ProviderElement(pointer);
 
   @override
-  Set<Emoji> create(Ref ref) {
+  Set<String> create(Ref ref) {
     final argument = this.argument as (String, String);
     return searchCustomEmojis(ref, argument.$1, argument.$2);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Set<Emoji> value) {
+  Override overrideWithValue(Set<String> value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<Set<Emoji>>(value),
+      providerOverride: $SyncValueProvider<Set<String>>(value),
     );
   }
 
@@ -67,10 +67,10 @@ final class SearchCustomEmojisProvider
 }
 
 String _$searchCustomEmojisHash() =>
-    r'0c1f681dbd87f74d2f5f91454a8f7cd0333abe76';
+    r'376bebf51f341a1390358b5edc75dad424094b75';
 
 final class SearchCustomEmojisFamily extends $Family
-    with $FunctionalFamilyOverride<Set<Emoji>, (String, String)> {
+    with $FunctionalFamilyOverride<Set<String>, (String, String)> {
   SearchCustomEmojisFamily._()
     : super(
         retry: null,

--- a/lib/view/page/server/server_emojis.dart
+++ b/lib/view/page/server/server_emojis.dart
@@ -71,10 +71,9 @@ class const ServerEmojis({super.key, required final String host})
                                 ...customEmojis.map(
                                   (emoji) => CustomEmoji(
                                     account: Account(host: host),
-                                    emoji: emoji.emoji,
-                                    onTap: () => context.push(
-                                      '/$host/emojis/${emoji.name}',
-                                    ),
+                                    emoji: ':$emoji@.:',
+                                    onTap: () =>
+                                        context.push('/$host/emojis/$emoji'),
                                     height: style.lineHeight * 2.0,
                                     fallbackTextStyle: style.apply(
                                       fontSizeFactor: 2.0,

--- a/lib/view/widget/custom_emoji.dart
+++ b/lib/view/widget/custom_emoji.dart
@@ -28,6 +28,7 @@ class const CustomEmoji({
   final bool fallbackToImage = true,
   final bool? enableFadeIn,
   final Widget Function(BuildContext context)? placeholderBuilder,
+  final int? cacheHeight,
 }) extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -136,10 +137,12 @@ class const CustomEmoji({
                       ),
                 enableFadeIn: enableFadeIn,
                 disableAnimations: disableShowingAnimatedImages,
+                cacheHeight: cacheHeight,
               ),
               semanticLabel: emoji,
               enableFadeIn: enableFadeIn,
               disableAnimations: disableShowingAnimatedImages,
+              cacheHeight: cacheHeight,
             ),
           ),
         ),

--- a/lib/view/widget/emoji_picker.dart
+++ b/lib/view/widget/emoji_picker.dart
@@ -170,6 +170,7 @@ class const EmojiPicker({
       };
     }, []);
     final theme = Theme.of(context);
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
 
     return ListView(
       controller: scrollController,
@@ -232,6 +233,8 @@ class const EmojiPicker({
                     fallbackTextStyle: style.apply(
                       fontSizeFactor: fontScaleFactor,
                     ),
+                    placeholderColor: theme.colorScheme.surfaceContainerHigh,
+                    devicePixelRatio: devicePixelRatio,
                   );
                 }),
                 ...unicodeEmojis.map(
@@ -297,6 +300,8 @@ class const EmojiPicker({
                     fallbackTextStyle: style.apply(
                       fontSizeFactor: fontScaleFactor,
                     ),
+                    placeholderColor: theme.colorScheme.surfaceContainerHigh,
+                    devicePixelRatio: devicePixelRatio,
                   );
                 } else {
                   return UnicodeEmoji(
@@ -377,6 +382,8 @@ class const EmojiPicker({
                     fallbackTextStyle: style.apply(
                       fontSizeFactor: fontScaleFactor,
                     ),
+                    placeholderColor: theme.colorScheme.surfaceContainerHigh,
+                    devicePixelRatio: devicePixelRatio,
                   );
                 } else {
                   return UnicodeEmoji(
@@ -456,6 +463,9 @@ class const EmojiPicker({
                           fallbackTextStyle: style.apply(
                             fontSizeFactor: fontScaleFactor,
                           ),
+                          placeholderColor:
+                              theme.colorScheme.surfaceContainerHigh,
+                          devicePixelRatio: devicePixelRatio,
                         );
                       }).toList(),
                     ),
@@ -512,11 +522,11 @@ class const _CustomEmoji({
   required final double height,
   final double opacity = 1.0,
   required final TextStyle fallbackTextStyle,
+  required final Color placeholderColor,
+  required final double devicePixelRatio,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return CustomEmoji(
       account: account,
       emoji: emoji,
@@ -529,11 +539,12 @@ class const _CustomEmoji({
         dimension: height,
         child: DecoratedBox(
           decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceContainerHigh,
+            color: placeholderColor,
             borderRadius: BorderRadius.circular(8.0),
           ),
         ),
       ),
+      cacheHeight: (height * devicePixelRatio).ceil(),
     );
   }
 }

--- a/lib/view/widget/emoji_picker.dart
+++ b/lib/view/widget/emoji_picker.dart
@@ -15,6 +15,7 @@ import '../../provider/api/i_notifier_provider.dart';
 import '../../provider/categorized_emojis_provider.dart';
 import '../../provider/custom_emoji_index_provider.dart';
 import '../../provider/emoji_provider.dart';
+import '../../provider/emojis_notifier_provider.dart';
 import '../../provider/general_settings_notifier_provider.dart';
 import '../../provider/pinned_emojis_notifier_provider.dart';
 import '../../provider/recently_used_emojis_notifier_provider.dart';
@@ -131,6 +132,7 @@ class const EmojiPicker({
     final emojiPickerAutofocus = generalSettings.emojiPickerAutofocus;
     final emojiPickerScale = generalSettings.emojiPickerScale;
     final fontScaleFactor = 2.0 * emojiPickerScale;
+    final emojis = ref.watch(emojisNotifierProvider(account.host)).value;
     final customEmojis = ref.watch(
       searchCustomEmojisProvider(account.host, query.value),
     );
@@ -212,21 +214,26 @@ class const EmojiPicker({
               spacing: 4.0,
               runSpacing: 4.0,
               children: [
-                ...customEmojis.map((emoji) {
-                  final enabled =
-                      targetNote == null ||
-                      checkReactionPermissions(i, targetNote!, emoji);
+                ...customEmojis.map((name) {
+                  final emoji = ':$name@.:';
+                  final enabled = switch (targetNote) {
+                    final note? => switch (emojis?[name]) {
+                      final emoji? => checkReactionPermissions(i, note, emoji),
+                      _ => true,
+                    },
+                    _ => true,
+                  };
 
                   return _CustomEmoji(
                     account: account,
-                    emoji: emoji.emoji,
+                    emoji: emoji,
                     onTap: enabled
-                        ? () => onTapEmoji(ref, emoji.emoji, keepOpen)
+                        ? () => onTapEmoji(ref, emoji, keepOpen)
                         : null,
                     onLongPress: () => showModalBottomSheet<void>(
                       context: context,
                       builder: (context) =>
-                          EmojiSheet(account: account, emoji: emoji.emoji),
+                          EmojiSheet(account: account, emoji: emoji),
                     ),
                     height: style.lineHeight * fontScaleFactor,
                     opacity: enabled ? 1.0 : 0.1,

--- a/lib/view/widget/image_widget.dart
+++ b/lib/view/widget/image_widget.dart
@@ -25,6 +25,8 @@ class const ImageWidget({
   final String? semanticLabel,
   final bool enableFadeIn = true,
   final bool disableAnimations = false,
+  final int? cacheWidth,
+  final int? cacheHeight,
 }) extends ConsumerWidget {
   Widget _buildPlaceholder(BuildContext context) {
     if (placeholderBuilder case final placeholderBuilder?) {
@@ -87,10 +89,14 @@ class const ImageWidget({
     }
     if (enableFadeIn) {
       return _FadeImageWidget(
-        image: CachedNetworkImageProvider(
-          url,
-          headers: {'User-Agent': ?userAgent},
-          cacheManager: cacheManager,
+        image: ResizeImage.resizeIfNeeded(
+          cacheWidth,
+          cacheHeight,
+          CachedNetworkImageProvider(
+            url,
+            headers: {'User-Agent': ?userAgent},
+            cacheManager: cacheManager,
+          ),
         ),
         width: width,
         height: height,
@@ -105,10 +111,14 @@ class const ImageWidget({
       );
     } else {
       return AnimatedImage(
-        image: CachedNetworkImageProvider(
-          url,
-          headers: {'User-Agent': ?userAgent},
-          cacheManager: cacheManager,
+        image: ResizeImage.resizeIfNeeded(
+          cacheWidth,
+          cacheHeight,
+          CachedNetworkImageProvider(
+            url,
+            headers: {'User-Agent': ?userAgent},
+            cacheManager: cacheManager,
+          ),
         ),
         width: width,
         height: height,
@@ -169,7 +179,7 @@ class const _FadeImageWidget({
         if (wasSynchronouslyLoaded) {
           return child;
         }
-        if (frame != null) {
+        if (frame != null && !isLoaded.value) {
           Future(() => isLoaded.value = true);
         }
         return _FadeStack(

--- a/lib/view/widget/mfm_keyboard.dart
+++ b/lib/view/widget/mfm_keyboard.dart
@@ -252,7 +252,7 @@ class const MfmEmojiKeyboard({
         else ...[
           ...ref
               .watch(searchCustomEmojisProvider(account.host, query.value))
-              .map((emoji) => ':${emoji.name}:'),
+              .map((emoji) => ':$emoji:'),
           ...ref.watch(searchUnicodeEmojisProvider(query.value)),
         ],
       ];


### PR DESCRIPTION
Changed the value of the custom emoji index to the name of the emoji instead of the emoji object.

The return type of `customEmojiIndex` has been changed from `Map<String, Set<Emoji>>` to `Map<String, Set<String>>` to reduce memory usage.

Also added the `cacheHeight` property to the `CustomEmoji` widget to resize the emojis in the emoji picker.