### PR TITLE
fix: avoid sending delete request to push endpoint on Android

### DIFF
--- a/lib/provider/push_subscription_notifier_provider.dart
+++ b/lib/provider/push_subscription_notifier_provider.dart
@@ -40,14 +40,13 @@ class PushSubscriptionNotifier extends _$PushSubscriptionNotifier {
   Future<void> unsubscribe() async {
     final endpoint = state;
     if (endpoint == null) return;
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      await UnifiedPush.unregister(account.toString());
-    }
     final isProxy = ref.read(sharedPreferencesProvider).getBool(_isProxyKey);
     final keySet = await ref.read(
       webPushKeySetNotifierProvider(account).future,
     );
-    if (isProxy ?? keySet == null) {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      await UnifiedPush.unregister(account.toString());
+    } else if (isProxy ?? keySet == null) {
       await ref.read(dioProvider).delete<void>(endpoint);
     }
     await ref

--- a/lib/provider/push_subscription_notifier_provider.g.dart
+++ b/lib/provider/push_subscription_notifier_provider.g.dart
@@ -60,7 +60,7 @@ final class PushSubscriptionNotifierProvider
 }
 
 String _$pushSubscriptionNotifierHash() =>
-    r'04966a4c91b04bfe8dcf8179e18654a482109fad';
+    r'c4670793788ead0847155771c07fb62a0e5197f5';
 
 final class PushSubscriptionNotifierFamily extends $Family
     with


### PR DESCRIPTION
Removed the delete request to the push endpoint from the unsubscribe method on Android.

This may cause the unsubscribe to be incomplete if the user has enabled push notifications during the beta releases of Aria 1.0.0 (after #406 but before #585) and has not disabled them since then.

Fix #1001